### PR TITLE
fix(indexer): prevent duplicate-row bloat + modernize flake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ cargo test <test_name>           # Run a single test by name
 cargo test db::                  # Run tests in a specific module
 cargo clippy -- -D warnings      # Lint with errors on warnings
 cargo fmt                        # Format code
+cargo bench                      # Run benchmarks (bloom, search, indexer)
 nix flake check                  # Run all Nix checks (build, clippy, fmt, tests)
 ```
 
@@ -50,18 +51,22 @@ nix run .#nxv-indexer            # Run with indexer feature
 2. **Search** (`db/queries.rs`): Queries go through bloom filter first (fast negative lookup), then SQLite with FTS5
 3. **Output** (`output/`): Results formatted as table (default), JSON, or plain text
 
+### Backend Abstraction (`backend.rs`, `client.rs`)
+
+The CLI transparently runs against either a local index or a remote `nxv serve` instance. `main.rs` branches on `NXV_API_URL` — if set, `ApiClient` (HTTP) is used; otherwise the local SQLite/bloom backend is used. Both implement the same backend trait, so command handlers are backend-agnostic.
+
 ### API Server (`server/`)
 
 The `nxv serve` command runs an HTTP API server with:
 
 - REST API at `/api/v1/*` (search, package info, version history, stats)
-- Web frontend at `/` (embedded HTML/JS)
-- OpenAPI documentation at `/docs`
+- Web frontend at `/` served from `frontend/` (static HTML/CSS/JS, embedded at build time)
+- OpenAPI documentation at `/docs` (generated in `server/openapi.rs`)
 - Configurable CORS support
 
-### Indexer (feature-gated)
+### Indexer (`src/index/`, feature-gated)
 
-The `indexer` feature enables building indexes from a local nixpkgs clone:
+Note the directory is `src/index/` even though the Cargo feature is named `indexer`. The `indexer` feature enables building indexes from a local nixpkgs clone:
 
 - `git.rs`: Walks nixpkgs git history (commits from 2017+)
 - `extractor.rs`: Runs `nix eval` to extract package metadata per commit
@@ -90,6 +95,19 @@ The `indexer` feature enables building indexes from a local nixpkgs clone:
 ```bash
 cargo search <crate>           # Find latest version
 ```
+
+## Environment Variables
+
+Most are also exposed as CLI flags (see `src/cli.rs`); env vars are useful for tests and deployment.
+
+- `NXV_API_URL` — point the CLI at a remote `nxv serve` instead of the local DB
+- `NXV_API_TIMEOUT` — HTTP client timeout in seconds (default 30)
+- `NXV_DB_PATH` — override local SQLite path
+- `NXV_MANIFEST_URL` — override the manifest URL for `nxv update`
+- `NXV_SKIP_VERIFY` — skip minisign verification of the manifest
+- `NXV_PUBLIC_KEY` — override the embedded minisign public key
+- `NXV_HOST`, `NXV_PORT`, `NXV_RATE_LIMIT` — `nxv serve` bind/host/rate-limit
+- `NXV_GIT_REV` — set by the Nix flake build to embed the git rev in `--version`
 
 ## Data Paths
 

--- a/flake.lock
+++ b/flake.lock
@@ -15,46 +15,83 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "devshell": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "repo": "flake-utils",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766902085,
-        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "rust-overlay": {
@@ -77,18 +114,23 @@
         "type": "github"
       }
     },
-    "systems": {
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,16 @@
   description = "nxv - Nix Version Index";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -11,379 +19,579 @@
     crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
-    {
-      # Overlay for use in NixOS/home-manager configs
-      overlays.default = final: prev: {
-        nxv = self.packages.${prev.system}.nxv;
-        nxv-indexer = self.packages.${prev.system}.nxv-indexer;
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        inputs.devshell.flakeModule
+        inputs.treefmt-nix.flakeModule
+      ];
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      flake = {
+        # Overlay for use in NixOS/home-manager configs
+        overlays.default = final: prev: {
+          nxv = inputs.self.packages.${prev.system}.nxv;
+          nxv-indexer = inputs.self.packages.${prev.system}.nxv-indexer;
+        };
+
+        # NixOS module for running nxv as a service
+        nixosModules.default = import ./nix/module.nix {
+          flakePackages = inputs.self.packages;
+        };
+        nixosModules.nxv = inputs.self.nixosModules.default;
       };
 
-      # NixOS module for running nxv as a service
-      # The module is passed the flake's packages so it works without the overlay
-      nixosModules.default = import ./nix/module.nix { flakePackages = self.packages; };
-      nixosModules.nxv = self.nixosModules.default;
-    } // flake-utils.lib.eachDefaultSystem (system:
-      let
-        overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs { inherit system overlays; };
-
-        # Derive Docker timestamp from git commit (format: 20260108123456 -> 2026-01-08T12:34:56Z)
-        lastModified = self.lastModifiedDate;
-        dockerTimestamp = "${builtins.substring 0 4 lastModified}-${builtins.substring 4 2 lastModified}-${builtins.substring 6 2 lastModified}T${builtins.substring 8 2 lastModified}:${builtins.substring 10 2 lastModified}:${builtins.substring 12 2 lastModified}Z";
-
-        # Use stable Rust toolchain
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" "rust-analyzer" ];
-        };
-
-        # Create crane lib with our toolchain
-        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
-
-        # Common source filtering - include frontend and keys directories for embedded assets
-        src = pkgs.lib.cleanSourceWith {
-          src = ./.;
-          filter = path: type:
-            (craneLib.filterCargoSources path type) ||
-            (builtins.match ".*frontend.*" path != null) ||
-            (builtins.match ".*keys/.*\\.pub$" path != null);
-        };
-
-        # Read crate metadata from Cargo.toml
-        crateInfo = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
-
-        # Git revision for version string (available when flake is in a git repo)
-        gitRev = self.shortRev or self.dirtyShortRev or "";
-
-        # Common build arguments
-        commonArgs = {
-          inherit src;
-          inherit (crateInfo) pname version;
-          strictDeps = true;
-
-          # Pass git revision to Rust build for version string
-          NXV_GIT_REV = gitRev;
-
-          buildInputs = [
-            pkgs.openssl
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            pkgs.libiconv
-            pkgs.darwin.libiconv
-          ];
-
-          nativeBuildInputs = [
-            pkgs.pkg-config
-            pkgs.installShellFiles
-          ];
-        };
-
-        # Build dependencies only (for caching)
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-        # Shell completions install script
-        installCompletions = ''
-          installShellCompletion --cmd nxv \
-            --bash <($out/bin/nxv completions bash) \
-            --zsh <($out/bin/nxv completions zsh) \
-            --fish <($out/bin/nxv completions fish)
-        '';
-
-        # Build the main nxv package
-        nxv = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-
-          postInstall = installCompletions;
-
-          meta = {
-            description = "Nix Version Index";
-            homepage = "https://github.com/utensils/nxv";
-            license = pkgs.lib.licenses.mit;
-            maintainers = [ ];
-            mainProgram = "nxv";
-          };
-        });
-
-        # Build nxv with indexer feature enabled
-        nxv-indexer = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-          cargoExtraArgs = "--features indexer";
-          pname = "nxv-indexer";
-
-          buildInputs = commonArgs.buildInputs ++ [
-            pkgs.libgit2
-          ];
-
-          nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
-            pkgs.cmake
-            pkgs.git
-          ];
-
-          postInstall = installCompletions;
-
-          meta = {
-            description = "Nix Version Index (with indexer feature)";
-            homepage = "https://github.com/utensils/nxv";
-            license = pkgs.lib.licenses.mit;
-            maintainers = [ ];
-            mainProgram = "nxv";
-          };
-        });
-
-        # Static musl build (Linux only)
-        # Uses cross-compilation approach to avoid build script crashes
-        nxv-static = let
-          # Only build static on Linux
-          isLinux = pkgs.stdenv.isLinux;
-          target = if system == "aarch64-linux"
-                   then "aarch64-unknown-linux-musl"
-                   else "x86_64-unknown-linux-musl";
-
-          # musl cross-compilation pkgs
-          pkgsMusl = if system == "aarch64-linux"
-                     then pkgs.pkgsCross.aarch64-multiplatform-musl
-                     else pkgs.pkgsCross.musl64;
-
-          # Get the musl C compiler
-          muslCC = "${pkgsMusl.stdenv.cc}/bin/${pkgsMusl.stdenv.cc.targetPrefix}cc";
-
-          # Toolchain with musl target added
-          rustToolchainMusl = pkgs.rust-bin.stable.latest.default.override {
-            targets = [ target ];
+      perSystem =
+        {
+          system,
+          lib,
+          ...
+        }:
+        let
+          pkgs = import inputs.nixpkgs {
+            localSystem = system;
+            overlays = [ inputs.rust-overlay.overlays.default ];
           };
 
-          # Crane lib with musl toolchain
-          craneLibMusl = (crane.mkLib pkgs).overrideToolchain rustToolchainMusl;
+          # Derive a stable Docker image timestamp from the flake's lastModifiedDate.
+          # Format: 20260108123456 -> 2026-01-08T12:34:56Z
+          lastModified = toString (inputs.self.lastModifiedDate or "19700101000000");
+          dockerTimestamp =
+            "${builtins.substring 0 4 lastModified}-${builtins.substring 4 2 lastModified}-${
+              builtins.substring 6 2 lastModified
+            }"
+            + "T${builtins.substring 8 2 lastModified}:${builtins.substring 10 2 lastModified}:${
+              builtins.substring 12 2 lastModified
+            }Z";
 
-          # Common musl build args
-          muslBuildArgs = {
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
+              "rustfmt"
+              "clippy"
+            ];
+          };
+
+          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          # Source filter: include Cargo sources plus the embedded `frontend/`
+          # and the minisign public key under `keys/`.
+          src = lib.cleanSourceWith {
+            src = ./.;
+            filter =
+              path: type:
+              (craneLib.filterCargoSources path type)
+              || (builtins.match ".*frontend.*" path != null)
+              || (builtins.match ".*keys/.*\\.pub$" path != null);
+          };
+
+          crateInfo = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
+
+          # Git revision for version string (available when flake is in a git repo)
+          gitRev = inputs.self.shortRev or inputs.self.dirtyShortRev or "";
+
+          commonArgs = {
             inherit src;
             inherit (crateInfo) pname version;
             strictDeps = true;
 
-            # Pass git revision to Rust build for version string
             NXV_GIT_REV = gitRev;
 
-            CARGO_BUILD_TARGET = target;
-            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C linker=${muslCC}";
-
-            # C compiler configuration for musl
-            # HOST_CC is for build scripts that run on the build machine
-            # TARGET_CC/CC_x86_64_unknown_linux_musl is for code that runs on target
-            HOST_CC = "${pkgs.stdenv.cc}/bin/cc";
-            TARGET_CC = muslCC;
-            CC_x86_64_unknown_linux_musl = muslCC;
-            CC_aarch64_unknown_linux_musl = muslCC;
-
-            # Disable glibc-specific hardening that breaks musl
-            hardeningDisable = [ "fortify" ];
+            buildInputs = [
+              pkgs.openssl
+            ]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+            ];
 
             nativeBuildInputs = [
               pkgs.pkg-config
-              pkgsMusl.stdenv.cc  # musl cross-compiler
+              pkgs.installShellFiles
             ];
-
-            # Add musl libc for static linking
-            buildInputs = [ ];
+          }
+          // lib.optionalAttrs pkgs.stdenv.isDarwin {
+            # Xcode clang needs an explicit path to Nix-provided libiconv;
+            # build scripts and the final link both look it up via -liconv.
+            LIBRARY_PATH = "${pkgs.libiconv}/lib";
+            NIX_LDFLAGS = "-L${pkgs.libiconv}/lib";
           };
 
-          cargoArtifactsMusl = craneLibMusl.buildDepsOnly muslBuildArgs;
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
-        in if isLinux then craneLibMusl.buildPackage (muslBuildArgs // {
-          pname = "nxv-static";
-          cargoArtifacts = cargoArtifactsMusl;
+          installCompletions = ''
+            installShellCompletion --cmd nxv \
+              --bash <($out/bin/nxv completions bash) \
+              --zsh <($out/bin/nxv completions zsh) \
+              --fish <($out/bin/nxv completions fish)
+          '';
 
-          nativeBuildInputs = muslBuildArgs.nativeBuildInputs ++ [
-            pkgs.installShellFiles
-          ];
+          nxv = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
 
-          # Shell completions still work - binary runs on host during build
-          postInstall = installCompletions;
+              postInstall = installCompletions;
 
-          meta = {
-            description = "Nix Version Index (static musl binary)";
-            homepage = "https://github.com/utensils/nxv";
-            license = pkgs.lib.licenses.mit;
-            maintainers = [ ];
-            mainProgram = "nxv";
-            platforms = [ "x86_64-linux" "aarch64-linux" ];
+              meta = {
+                description = "Nix Version Index";
+                homepage = "https://github.com/utensils/nxv";
+                license = lib.licenses.mit;
+                maintainers = [ ];
+                mainProgram = "nxv";
+              };
+            }
+          );
+
+          nxv-indexer = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoExtraArgs = "--features indexer";
+              pname = "nxv-indexer";
+
+              buildInputs = commonArgs.buildInputs ++ [ pkgs.libgit2 ];
+
+              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+                pkgs.cmake
+                pkgs.git
+              ];
+
+              postInstall = installCompletions;
+
+              meta = {
+                description = "Nix Version Index (with indexer feature)";
+                homepage = "https://github.com/utensils/nxv";
+                license = lib.licenses.mit;
+                maintainers = [ ];
+                mainProgram = "nxv";
+              };
+            }
+          );
+
+          # Static musl build (Linux only). Uses cross-compilation so build
+          # scripts don't crash inside the sandbox.
+          nxv-static =
+            let
+              isLinux = pkgs.stdenv.isLinux;
+              target =
+                if system == "aarch64-linux" then "aarch64-unknown-linux-musl" else "x86_64-unknown-linux-musl";
+              pkgsMusl =
+                if system == "aarch64-linux" then
+                  pkgs.pkgsCross.aarch64-multiplatform-musl
+                else
+                  pkgs.pkgsCross.musl64;
+              muslCC = "${pkgsMusl.stdenv.cc}/bin/${pkgsMusl.stdenv.cc.targetPrefix}cc";
+              rustToolchainMusl = pkgs.rust-bin.stable.latest.default.override {
+                targets = [ target ];
+              };
+              craneLibMusl = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchainMusl;
+
+              muslBuildArgs = {
+                inherit src;
+                inherit (crateInfo) pname version;
+                strictDeps = true;
+
+                NXV_GIT_REV = gitRev;
+
+                CARGO_BUILD_TARGET = target;
+                CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C linker=${muslCC}";
+
+                HOST_CC = "${pkgs.stdenv.cc}/bin/cc";
+                TARGET_CC = muslCC;
+                CC_x86_64_unknown_linux_musl = muslCC;
+                CC_aarch64_unknown_linux_musl = muslCC;
+
+                hardeningDisable = [ "fortify" ];
+
+                nativeBuildInputs = [
+                  pkgs.pkg-config
+                  pkgsMusl.stdenv.cc
+                ];
+
+                buildInputs = [ ];
+              };
+
+              cargoArtifactsMusl = craneLibMusl.buildDepsOnly muslBuildArgs;
+            in
+            if isLinux then
+              craneLibMusl.buildPackage (
+                muslBuildArgs
+                // {
+                  pname = "nxv-static";
+                  cargoArtifacts = cargoArtifactsMusl;
+
+                  nativeBuildInputs = muslBuildArgs.nativeBuildInputs ++ [ pkgs.installShellFiles ];
+
+                  postInstall = installCompletions;
+
+                  meta = {
+                    description = "Nix Version Index (static musl binary)";
+                    homepage = "https://github.com/utensils/nxv";
+                    license = lib.licenses.mit;
+                    maintainers = [ ];
+                    mainProgram = "nxv";
+                    platforms = [
+                      "x86_64-linux"
+                      "aarch64-linux"
+                    ];
+                  };
+                }
+              )
+            else
+              pkgs.runCommand "nxv-static-unavailable" { } ''
+                echo "nxv-static is only available on Linux" >&2
+                exit 1
+              '';
+
+          # Cross-compile nxv to aarch64-linux-musl from x86_64-linux.
+          nxv-static-aarch64 =
+            let
+              isLinuxX86 = pkgs.stdenv.isLinux && system == "x86_64-linux";
+              target = "aarch64-unknown-linux-musl";
+              pkgsMusl = pkgs.pkgsCross.aarch64-multiplatform-musl;
+              muslCC = "${pkgsMusl.stdenv.cc}/bin/${pkgsMusl.stdenv.cc.targetPrefix}cc";
+              rustToolchainMusl = pkgs.rust-bin.stable.latest.default.override {
+                targets = [ target ];
+              };
+              craneLibMusl = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchainMusl;
+
+              muslBuildArgs = {
+                inherit src;
+                inherit (crateInfo) pname version;
+                strictDeps = true;
+
+                NXV_GIT_REV = gitRev;
+
+                CARGO_BUILD_TARGET = target;
+                CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C linker=${muslCC}";
+
+                HOST_CC = "${pkgs.stdenv.cc}/bin/cc";
+                TARGET_CC = muslCC;
+                CC_aarch64_unknown_linux_musl = muslCC;
+
+                hardeningDisable = [ "fortify" ];
+
+                nativeBuildInputs = [
+                  pkgs.pkg-config
+                  pkgsMusl.stdenv.cc
+                ];
+
+                buildInputs = [ ];
+              };
+
+              cargoArtifactsMusl = craneLibMusl.buildDepsOnly muslBuildArgs;
+            in
+            if isLinuxX86 then
+              craneLibMusl.buildPackage (
+                muslBuildArgs
+                // {
+                  pname = "nxv-static-aarch64";
+                  cargoArtifacts = cargoArtifactsMusl;
+
+                  # Skip tests — can't run aarch64 binary on x86_64 without QEMU.
+                  doCheck = false;
+
+                  nativeBuildInputs = muslBuildArgs.nativeBuildInputs ++ [ pkgs.installShellFiles ];
+
+                  # Skip shell completions — can't run aarch64 binary on x86_64.
+                  postInstall = "";
+
+                  meta = {
+                    description = "Nix Version Index (static aarch64 musl binary)";
+                    homepage = "https://github.com/utensils/nxv";
+                    license = lib.licenses.mit;
+                    maintainers = [ ];
+                    mainProgram = "nxv";
+                    platforms = [ "x86_64-linux" ];
+                  };
+                }
+              )
+            else
+              pkgs.runCommand "nxv-static-aarch64-unavailable" { } ''
+                echo "nxv-static-aarch64 cross-compilation is only available on x86_64-linux" >&2
+                exit 1
+              '';
+
+          nxv-docker =
+            if pkgs.stdenv.isLinux then
+              pkgs.dockerTools.buildLayeredImage {
+                name = "nxv";
+                tag = crateInfo.version;
+                created = dockerTimestamp;
+
+                contents = [
+                  nxv-indexer
+                  pkgs.cacert
+                  pkgs.tzdata
+                  pkgs.git
+                ];
+
+                config = {
+                  Entrypoint = [ "${nxv-indexer}/bin/nxv" ];
+                  Cmd = [ "serve" ];
+                  ExposedPorts = {
+                    "8080/tcp" = { };
+                  };
+                  Env = [
+                    "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                    "TZ=UTC"
+                  ];
+                  Labels = {
+                    "org.opencontainers.image.title" = "nxv";
+                    "org.opencontainers.image.description" = "Nix Version Index - search nixpkgs package history";
+                    "org.opencontainers.image.source" = "https://github.com/utensils/nxv";
+                    "org.opencontainers.image.version" = crateInfo.version;
+                  };
+                };
+              }
+            else
+              pkgs.runCommand "nxv-docker-unavailable" { } ''
+                echo "Docker images are only available on Linux" >&2
+                exit 1
+              '';
+        in
+        {
+          _module.args.pkgs = pkgs;
+
+          packages = {
+            inherit
+              nxv
+              nxv-indexer
+              nxv-static
+              nxv-static-aarch64
+              nxv-docker
+              ;
+            default = nxv;
           };
-        }) else pkgs.runCommand "nxv-static-unavailable" {} ''
-          echo "nxv-static is only available on Linux" >&2
-          exit 1
-        '';
 
-        # Cross-compile to aarch64-linux-musl from x86_64-linux
-        # This allows building ARM64 Linux binaries on x86_64 without QEMU
-        nxv-static-aarch64 = let
-          isLinuxX86 = pkgs.stdenv.isLinux && system == "x86_64-linux";
-          target = "aarch64-unknown-linux-musl";
-
-          # aarch64 musl cross-compilation pkgs
-          pkgsMusl = pkgs.pkgsCross.aarch64-multiplatform-musl;
-
-          # Get the musl C compiler for aarch64
-          muslCC = "${pkgsMusl.stdenv.cc}/bin/${pkgsMusl.stdenv.cc.targetPrefix}cc";
-
-          # Toolchain with aarch64-musl target added
-          rustToolchainMusl = pkgs.rust-bin.stable.latest.default.override {
-            targets = [ target ];
-          };
-
-          # Crane lib with musl toolchain
-          craneLibMusl = (crane.mkLib pkgs).overrideToolchain rustToolchainMusl;
-
-          # Cross-compilation build args
-          muslBuildArgs = {
-            inherit src;
-            inherit (crateInfo) pname version;
-            strictDeps = true;
-
-            # Pass git revision to Rust build for version string
-            NXV_GIT_REV = gitRev;
-
-            CARGO_BUILD_TARGET = target;
-            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C linker=${muslCC}";
-
-            HOST_CC = "${pkgs.stdenv.cc}/bin/cc";
-            TARGET_CC = muslCC;
-            CC_aarch64_unknown_linux_musl = muslCC;
-
-            hardeningDisable = [ "fortify" ];
-
-            nativeBuildInputs = [
-              pkgs.pkg-config
-              pkgsMusl.stdenv.cc
-            ];
-
-            buildInputs = [ ];
-          };
-
-          cargoArtifactsMusl = craneLibMusl.buildDepsOnly muslBuildArgs;
-
-        in if isLinuxX86 then craneLibMusl.buildPackage (muslBuildArgs // {
-          pname = "nxv-static-aarch64";
-          cargoArtifacts = cargoArtifactsMusl;
-
-          # Skip tests - can't run aarch64 binary on x86_64 without QEMU
-          doCheck = false;
-
-          nativeBuildInputs = muslBuildArgs.nativeBuildInputs ++ [
-            pkgs.installShellFiles
-          ];
-
-          # Skip shell completions - can't run aarch64 binary on x86_64
-          postInstall = "";
-
-          meta = {
-            description = "Nix Version Index (static aarch64 musl binary)";
-            homepage = "https://github.com/utensils/nxv";
-            license = pkgs.lib.licenses.mit;
-            maintainers = [ ];
-            mainProgram = "nxv";
-            platforms = [ "x86_64-linux" ];
-          };
-        }) else pkgs.runCommand "nxv-static-aarch64-unavailable" {} ''
-          echo "nxv-static-aarch64 cross-compilation is only available on x86_64-linux" >&2
-          exit 1
-        '';
-
-        # Docker image for nxv-indexer (Linux only)
-        nxv-docker = if pkgs.stdenv.isLinux then pkgs.dockerTools.buildLayeredImage {
-          name = "nxv";
-          tag = crateInfo.version;
-          created = dockerTimestamp;
-
-          contents = [
-            nxv-indexer
-            pkgs.cacert        # CA certificates for HTTPS
-            pkgs.tzdata        # Timezone data
-            pkgs.git           # Required for indexing nixpkgs
-          ];
-
-          config = {
-            Entrypoint = [ "${nxv-indexer}/bin/nxv" ];
-            Cmd = [ "serve" ];
-            ExposedPorts = {
-              "8080/tcp" = {};
+          apps = {
+            default = {
+              type = "app";
+              program = "${nxv}/bin/nxv";
+              meta = nxv.meta;
             };
-            Env = [
-              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-              "TZ=UTC"
-            ];
-            Labels = {
-              "org.opencontainers.image.title" = "nxv";
-              "org.opencontainers.image.description" = "Nix Version Index - search nixpkgs package history";
-              "org.opencontainers.image.source" = "https://github.com/utensils/nxv";
-              "org.opencontainers.image.version" = crateInfo.version;
+            nxv = {
+              type = "app";
+              program = "${nxv}/bin/nxv";
+              meta = nxv.meta;
+            };
+            nxv-indexer = {
+              type = "app";
+              program = "${nxv-indexer}/bin/nxv";
+              meta = nxv-indexer.meta;
             };
           };
-        } else pkgs.runCommand "nxv-docker-unavailable" {} ''
-          echo "Docker images are only available on Linux" >&2
-          exit 1
-        '';
 
-      in
-      {
-        # Packages
-        packages = {
-          inherit nxv nxv-indexer nxv-static nxv-static-aarch64 nxv-docker;
-          default = nxv;
-        };
+          checks = {
+            inherit nxv;
 
-        # Development shell
-        devShells.default = craneLib.devShell {
-          inputsFrom = [ nxv ];
+            nxv-clippy = craneLib.cargoClippy (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+              }
+            );
 
-          packages = [
-            pkgs.bashInteractive  # Use interactive bash (stdenv bash lacks readline/progcomp)
-            pkgs.rust-analyzer
-            pkgs.cargo-watch
-            pkgs.cargo-edit
-            pkgs.miniserve  # Simple HTTP server for frontend dev
-            pkgs.nodePackages.prettier  # HTML/JS/CSS formatter
-            pkgs.markdownlint-cli  # Markdown linter
-            pkgs.k6  # Load testing tool
-          ];
+            nxv-test = craneLib.cargoTest (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+              }
+            );
 
-          RUST_BACKTRACE = "1";
-        };
+            nxv-fmt = craneLib.cargoFmt { inherit src; };
+          };
 
-        # Checks (run with `nix flake check`)
-        checks = {
-          inherit nxv;
+          devshells.default = {
+            motd = ''
+              {202}nxv{reset} — Nix Version Index ({bold}${system}{reset})
+              $(type menu &>/dev/null && menu)
+            '';
 
-          nxv-clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
+            packagesFrom = [ nxv ];
 
-          nxv-test = craneLib.cargoTest (commonArgs // {
-            inherit cargoArtifacts;
-          });
+            packages = [
+              rustToolchain
+              pkgs.cargo-watch
+              pkgs.cargo-edit
+              pkgs.cargo-outdated
+              pkgs.cargo-audit
+              pkgs.cargo-llvm-cov
+              pkgs.git
+              pkgs.gh
+              pkgs.jq
+              pkgs.miniserve # Simple HTTP server for frontend dev
+              pkgs.prettier # HTML/JS/CSS formatter
+              pkgs.markdownlint-cli # Markdown linter
+              pkgs.k6 # Load testing tool
+            ];
 
-          nxv-fmt = craneLib.cargoFmt {
-            inherit src;
+            env = [
+              {
+                name = "RUST_BACKTRACE";
+                value = "1";
+              }
+            ]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              {
+                name = "LIBRARY_PATH";
+                value = "${pkgs.libiconv}/lib";
+              }
+              {
+                name = "NIX_LDFLAGS";
+                value = "-L${pkgs.libiconv}/lib";
+              }
+            ];
+
+            commands = [
+              {
+                category = "build";
+                name = "build";
+                help = "cargo build (debug)";
+                command = "cargo build \"$@\"";
+              }
+              {
+                category = "build";
+                name = "build-indexer";
+                help = "cargo build with indexer feature";
+                command = "cargo build --features indexer \"$@\"";
+              }
+              {
+                category = "build";
+                name = "build-release";
+                help = "cargo build --release";
+                command = "cargo build --release \"$@\"";
+              }
+              {
+                category = "check";
+                name = "check";
+                help = "cargo check --features indexer";
+                command = "cargo check --features indexer \"$@\"";
+              }
+              {
+                category = "check";
+                name = "clippy";
+                help = "cargo clippy --features indexer -- -D warnings (matches CI)";
+                command = "cargo clippy --features indexer \"$@\" -- -D warnings";
+              }
+              {
+                category = "check";
+                name = "fmt";
+                help = "cargo fmt";
+                command = "cargo fmt \"$@\"";
+              }
+              {
+                category = "check";
+                name = "fmt-check";
+                help = "cargo fmt --check (matches CI)";
+                command = "cargo fmt --check \"$@\"";
+              }
+              {
+                category = "check";
+                name = "run-tests";
+                help = "cargo test --features indexer (matches CI)";
+                command = "cargo test --features indexer \"$@\"";
+              }
+              {
+                category = "check";
+                name = "ci-local";
+                help = "run the same sequence CI runs: fmt-check, clippy, test";
+                command = ''
+                  set -euo pipefail
+                  cargo fmt --all -- --check
+                  cargo clippy --features indexer --all-targets -- -D warnings
+                  cargo test --features indexer
+                '';
+              }
+              {
+                category = "check";
+                name = "flake-check";
+                help = "nix flake check (full Nix CI checks)";
+                command = "nix flake check \"$@\"";
+              }
+              {
+                category = "check";
+                name = "coverage";
+                help = "test coverage summary (pass --html for a browsable report)";
+                command = ''
+                  set -euo pipefail
+                  LLVM_COV="$(find /nix/store -maxdepth 3 -name llvm-cov 2>/dev/null | head -1)"
+                  LLVM_PROFDATA="$(find /nix/store -maxdepth 3 -name llvm-profdata 2>/dev/null | head -1)"
+                  export LLVM_COV LLVM_PROFDATA
+                  if [ "''${1:-}" = "--html" ]; then
+                    cargo llvm-cov --features indexer --html --output-dir target/coverage
+                    echo "Report: target/coverage/html/index.html"
+                  else
+                    cargo llvm-cov --features indexer --summary-only
+                  fi
+                '';
+              }
+              {
+                category = "run";
+                name = "nxv";
+                help = "run nxv";
+                command = "cargo run -- \"$@\"";
+              }
+              {
+                category = "run";
+                name = "nxv-indexer";
+                help = "run nxv with the indexer feature";
+                command = "cargo run --features indexer -- \"$@\"";
+              }
+              {
+                category = "run";
+                name = "serve";
+                help = "start the nxv API server";
+                command = "cargo run -- serve \"$@\"";
+              }
+              {
+                category = "run";
+                name = "frontend-dev";
+                help = "serve the static frontend from ./frontend on :3030";
+                command = "miniserve --index index.html ./frontend \"$@\"";
+              }
+              {
+                category = "deps";
+                name = "deps-outdated";
+                help = "list outdated crates";
+                command = "cargo outdated \"$@\"";
+              }
+              {
+                category = "deps";
+                name = "deps-audit";
+                help = "run cargo audit";
+                command = "cargo audit \"$@\"";
+              }
+              {
+                category = "deps";
+                name = "deps-update";
+                help = "cargo update + nix flake update";
+                command = ''
+                  set -euo pipefail
+                  cargo update
+                  nix flake update
+                '';
+              }
+            ];
+          };
+
+          treefmt = {
+            projectRootFile = "flake.nix";
+            programs.nixfmt.enable = true;
+            programs.rustfmt = {
+              enable = true;
+              edition = "2024";
+            };
           };
         };
-
-        # Apps (run with `nix run`)
-        apps = {
-          default = {
-            type = "app";
-            program = "${nxv}/bin/nxv";
-            meta = nxv.meta;
-          };
-          nxv = {
-            type = "app";
-            program = "${nxv}/bin/nxv";
-            meta = nxv.meta;
-          };
-          nxv-indexer = {
-            type = "app";
-            program = "${nxv-indexer}/bin/nxv";
-            meta = nxv-indexer.meta;
-          };
-        };
-      }
-    );
+    };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -35,19 +35,33 @@
 # The module takes an optional flakePackages argument that is passed from
 # the flake. This is a function from system to package, allowing the module
 # to work without requiring the overlay.
-{ flakePackages ? null }:
+{
+  flakePackages ? null,
+}:
 
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.services.nxv;
-  inherit (lib) mkEnableOption mkOption mkIf types;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    ;
 
   # Use the package from the flake if provided, otherwise fall back to pkgs.nxv
   defaultPkg =
-    if flakePackages != null && flakePackages ? ${pkgs.system}
-    then flakePackages.${pkgs.system}.nxv
-    else pkgs.nxv or (throw "nxv package not found. Either use the nxv overlay or set services.nxv.package.");
+    if flakePackages != null && flakePackages ? ${pkgs.system} then
+      flakePackages.${pkgs.system}.nxv
+    else
+      pkgs.nxv
+        or (throw "nxv package not found. Either use the nxv overlay or set services.nxv.package.");
 in
 {
   options.services.nxv = {
@@ -90,7 +104,10 @@ in
       origins = mkOption {
         type = types.nullOr (types.listOf types.str);
         default = null;
-        example = [ "https://example.com" "https://app.example.com" ];
+        example = [
+          "https://example.com"
+          "https://app.example.com"
+        ];
         description = ''
           Specific CORS origins to allow. If set, only these origins
           will be permitted. If null and cors.enable is true, all
@@ -176,7 +193,10 @@ in
       };
 
       format = mkOption {
-        type = types.enum [ "text" "json" ];
+        type = types.enum [
+          "text"
+          "json"
+        ];
         default = "text";
         description = ''
           Log output format.
@@ -259,74 +279,83 @@ in
         RUST_LOG = cfg.logging.level;
         NXV_MAX_DB_CONNECTIONS = toString cfg.database.maxConnections;
         NXV_DB_TIMEOUT_SECS = toString cfg.database.timeoutSeconds;
-      } // lib.optionalAttrs (cfg.logging.format == "json") {
+      }
+      // lib.optionalAttrs (cfg.logging.format == "json") {
         NXV_LOG_FORMAT = "json";
-      } // lib.optionalAttrs cfg.rateLimit.enable {
+      }
+      // lib.optionalAttrs cfg.rateLimit.enable {
         NXV_RATE_LIMIT = toString cfg.rateLimit.requestsPerSecond;
-      } // lib.optionalAttrs (cfg.rateLimit.enable && cfg.rateLimit.burst != null) {
+      }
+      // lib.optionalAttrs (cfg.rateLimit.enable && cfg.rateLimit.burst != null) {
         NXV_RATE_LIMIT_BURST = toString cfg.rateLimit.burst;
       };
 
-      serviceConfig = let
-        manifestArgs = lib.optionalString (cfg.manifestUrl != null)
-          "--manifest-url ${cfg.manifestUrl}";
-        publicKeyArgs = lib.optionalString (cfg.publicKey != null)
-          "--public-key ${toString cfg.publicKey}";
-        skipVerifyArgs = lib.optionalString cfg.skipVerify
-          "--skip-verify";
-        updateArgs = lib.concatStringsSep " " (lib.filter (s: s != "") [
-          manifestArgs publicKeyArgs skipVerifyArgs
-        ]);
-        corsArgs =
-          if cfg.cors.origins != null then
-            "--cors-origins ${lib.concatStringsSep "," cfg.cors.origins}"
-          else if cfg.cors.enable then
-            "--cors"
-          else
-            "";
-      in {
-        Type = "simple";
-        User = cfg.user;
-        Group = cfg.group;
-        ExecStartPre = pkgs.writeShellScript "nxv-bootstrap" ''
-          if [ ! -f "${cfg.dataDir}/index.db" ]; then
-            echo "Database not found, downloading index..."
-            ${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db update ${updateArgs}
-          fi
-        '';
-        ExecStart = ''
-          ${cfg.package}/bin/nxv \
-            --db-path ${cfg.dataDir}/index.db \
-            serve \
-            --host ${cfg.host} \
-            --port ${toString cfg.port} \
-            ${corsArgs}
-        '';
-        Restart = "on-failure";
-        RestartSec = "5s";
+      serviceConfig =
+        let
+          manifestArgs = lib.optionalString (cfg.manifestUrl != null) "--manifest-url ${cfg.manifestUrl}";
+          publicKeyArgs = lib.optionalString (cfg.publicKey != null) "--public-key ${toString cfg.publicKey}";
+          skipVerifyArgs = lib.optionalString cfg.skipVerify "--skip-verify";
+          updateArgs = lib.concatStringsSep " " (
+            lib.filter (s: s != "") [
+              manifestArgs
+              publicKeyArgs
+              skipVerifyArgs
+            ]
+          );
+          corsArgs =
+            if cfg.cors.origins != null then
+              "--cors-origins ${lib.concatStringsSep "," cfg.cors.origins}"
+            else if cfg.cors.enable then
+              "--cors"
+            else
+              "";
+        in
+        {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStartPre = pkgs.writeShellScript "nxv-bootstrap" ''
+            if [ ! -f "${cfg.dataDir}/index.db" ]; then
+              echo "Database not found, downloading index..."
+              ${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db update ${updateArgs}
+            fi
+          '';
+          ExecStart = ''
+            ${cfg.package}/bin/nxv \
+              --db-path ${cfg.dataDir}/index.db \
+              serve \
+              --host ${cfg.host} \
+              --port ${toString cfg.port} \
+              ${corsArgs}
+          '';
+          Restart = "on-failure";
+          RestartSec = "5s";
 
-        # Resource limits
-        LimitNOFILE = 65536;  # Increase file descriptor limit for high concurrency
+          # Resource limits
+          LimitNOFILE = 65536; # Increase file descriptor limit for high concurrency
 
-        # Hardening options
-        NoNewPrivileges = true;
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectControlGroups = true;
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        MemoryDenyWriteExecute = true;
-        LockPersonality = true;
-        ReadWritePaths = [ cfg.dataDir ];
-        CapabilityBoundingSet = "";
-        SystemCallFilter = [ "@system-service" "~@privileged" ];
-        SystemCallArchitectures = "native";
-      };
+          # Hardening options
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          MemoryDenyWriteExecute = true;
+          LockPersonality = true;
+          ReadWritePaths = [ cfg.dataDir ];
+          CapabilityBoundingSet = "";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+          ];
+          SystemCallArchitectures = "native";
+        };
     };
 
     # Automatic update service and timer
@@ -335,30 +364,33 @@ in
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
 
-      serviceConfig = let
-        manifestArgs = lib.optionalString (cfg.manifestUrl != null)
-          "--manifest-url ${cfg.manifestUrl}";
-        publicKeyArgs = lib.optionalString (cfg.publicKey != null)
-          "--public-key ${toString cfg.publicKey}";
-        skipVerifyArgs = lib.optionalString cfg.skipVerify
-          "--skip-verify";
-        updateArgs = lib.concatStringsSep " " (lib.filter (s: s != "") [
-          manifestArgs publicKeyArgs skipVerifyArgs
-        ]);
-      in {
-        Type = "oneshot";
-        User = cfg.user;
-        Group = cfg.group;
-        ExecStart = "${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db update ${updateArgs}";
+      serviceConfig =
+        let
+          manifestArgs = lib.optionalString (cfg.manifestUrl != null) "--manifest-url ${cfg.manifestUrl}";
+          publicKeyArgs = lib.optionalString (cfg.publicKey != null) "--public-key ${toString cfg.publicKey}";
+          skipVerifyArgs = lib.optionalString cfg.skipVerify "--skip-verify";
+          updateArgs = lib.concatStringsSep " " (
+            lib.filter (s: s != "") [
+              manifestArgs
+              publicKeyArgs
+              skipVerifyArgs
+            ]
+          );
+        in
+        {
+          Type = "oneshot";
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStart = "${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db update ${updateArgs}";
 
-        # Hardening options
-        NoNewPrivileges = true;
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        ReadWritePaths = [ cfg.dataDir ];
-      };
+          # Hardening options
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ReadWritePaths = [ cfg.dataDir ];
+        };
     };
 
     systemd.timers.nxv-update = mkIf cfg.autoUpdate.enable {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -175,6 +175,9 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_packages_attr ON package_versions(attribute_path);
             CREATE INDEX IF NOT EXISTS idx_packages_first_date ON package_versions(first_commit_date DESC);
             CREATE INDEX IF NOT EXISTS idx_packages_last_date ON package_versions(last_commit_date DESC);
+            -- Used by the incremental indexer's resume path (load_open_ranges_at_commit)
+            -- to avoid a full table scan at the start of every run on large DBs.
+            CREATE INDEX IF NOT EXISTS idx_packages_last_commit_hash ON package_versions(last_commit_hash);
             "#,
         )?;
 
@@ -425,10 +428,11 @@ impl Database {
     /// indexing run so that subsequent commits *extend* existing rows instead of
     /// creating duplicates stamped with a new `first_commit_hash`.
     ///
-    /// Already-bloated databases can hold several rows with the same unique key
-    /// but different `first_commit_hash` — this function picks the row with the
-    /// smallest `id` per key via `GROUP BY` so seeding is deterministic. A full
-    /// rebuild is still required to actually remove the duplicate rows.
+    /// Already-bloated databases can hold several rows for the same
+    /// `(attribute_path, version)` pair but different `first_commit_hash` values
+    /// — this function picks the row with the smallest `id` per pair via
+    /// `GROUP BY` so seeding is deterministic. A full rebuild is still required
+    /// to actually remove the duplicate rows.
     #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
     pub fn load_open_ranges_at_commit(&self, commit_hash: &str) -> Result<Vec<PackageVersion>> {
         let mut stmt = self.conn.prepare(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -339,14 +339,18 @@ impl Database {
         &self.conn
     }
 
-    /// Inserts multiple package version records in a single transaction.
+    /// Upserts multiple package version records in a single transaction.
     ///
-    /// Uses a transaction for performance and atomicity. Duplicate entries (same
-    /// `attribute_path`, `version`, and `first_commit_hash`) are ignored.
+    /// On conflict against UNIQUE(attribute_path, version, first_commit_hash) the
+    /// existing row is extended: `last_commit_hash` / `last_commit_date` and most
+    /// metadata fields are overwritten with the incoming values, while `source_path`
+    /// is preserved if the DB already has one (mirrors `OpenRange::update_metadata`).
     ///
     /// # Returns
     ///
-    /// The number of rows that were actually inserted.
+    /// The number of rows written (inserts *and* conflict-driven updates). SQLite
+    /// reports `1` for both paths, so the returned count is the total number of
+    /// successful row operations, not strictly new rows.
     ///
     /// # Examples
     ///
@@ -354,24 +358,38 @@ impl Database {
     /// # use crate::db::Database;
     /// # use crate::db::queries::PackageVersion;
     /// # fn example(mut db: Database, packages: Vec<PackageVersion>) {
-    /// let inserted = db.insert_package_ranges_batch(&packages).unwrap();
-    /// assert!(inserted <= packages.len());
+    /// let written = db.insert_package_ranges_batch(&packages).unwrap();
+    /// assert!(written <= packages.len());
     /// # }
     /// ```
     #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
     pub fn insert_package_ranges_batch(&mut self, packages: &[PackageVersion]) -> Result<usize> {
         let tx = self.conn.transaction()?;
-        let mut inserted = 0;
+        let mut written = 0;
 
         {
+            // Upsert keyed on the UNIQUE(attribute_path, version, first_commit_hash)
+            // constraint. On conflict we extend the existing range (last_commit_hash /
+            // last_commit_date) and refresh metadata. source_path is sticky: once a
+            // row has one, we never overwrite it with NULL, matching OpenRange::update_metadata.
             let mut stmt = tx.prepare_cached(
                 r#"
-                INSERT OR IGNORE INTO package_versions
+                INSERT INTO package_versions
                     (name, version, first_commit_hash, first_commit_date,
                      last_commit_hash, last_commit_date, attribute_path,
                      description, license, homepage, maintainers, platforms, source_path,
                      known_vulnerabilities)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(attribute_path, version, first_commit_hash) DO UPDATE SET
+                    last_commit_hash = excluded.last_commit_hash,
+                    last_commit_date = excluded.last_commit_date,
+                    description = excluded.description,
+                    license = excluded.license,
+                    homepage = excluded.homepage,
+                    maintainers = excluded.maintainers,
+                    platforms = excluded.platforms,
+                    source_path = COALESCE(source_path, excluded.source_path),
+                    known_vulnerabilities = excluded.known_vulnerabilities
                 "#,
             )?;
 
@@ -392,12 +410,48 @@ impl Database {
                     pkg.source_path,
                     pkg.known_vulnerabilities,
                 ])?;
-                inserted += changes;
+                written += changes;
             }
         }
 
         tx.commit()?;
-        Ok(inserted)
+        Ok(written)
+    }
+
+    /// Load the "open" ranges at a given checkpoint commit — one row per
+    /// (attribute_path, version) still present in nixpkgs as of `commit_hash`.
+    ///
+    /// Used to seed the in-memory `open_ranges` map at the start of an incremental
+    /// indexing run so that subsequent commits *extend* existing rows instead of
+    /// creating duplicates stamped with a new `first_commit_hash`.
+    ///
+    /// Already-bloated databases can hold several rows with the same unique key
+    /// but different `first_commit_hash` — this function picks the row with the
+    /// smallest `id` per key via `GROUP BY` so seeding is deterministic. A full
+    /// rebuild is still required to actually remove the duplicate rows.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn load_open_ranges_at_commit(&self, commit_hash: &str) -> Result<Vec<PackageVersion>> {
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, name, version, first_commit_hash, first_commit_date,
+                   last_commit_hash, last_commit_date, attribute_path,
+                   description, license, homepage, maintainers, platforms,
+                   source_path, known_vulnerabilities
+              FROM package_versions
+             WHERE last_commit_hash = ?1
+               AND id IN (
+                   SELECT MIN(id) FROM package_versions
+                    WHERE last_commit_hash = ?1
+                    GROUP BY attribute_path, version
+               )
+            "#,
+        )?;
+        let rows = stmt.query_map([commit_hash], PackageVersion::from_row)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
     }
 
     /// Update the last_commit fields for an existing package version range.
@@ -561,24 +615,101 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_insert_duplicate_handling() {
+    fn test_batch_insert_extends_existing_range() {
         use chrono::Utc;
 
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("test.db");
         let mut db = Database::open(&db_path).unwrap();
 
-        let now = Utc::now();
-        let pkg = PackageVersion {
+        let t0 = Utc::now();
+        let mut pkg = PackageVersion {
             id: 0,
             name: "python".to_string(),
             version: "3.11.0".to_string(),
-            first_commit_hash: "abc1234567890".to_string(),
-            first_commit_date: now,
-            last_commit_hash: "def1234567890".to_string(),
-            last_commit_date: now,
+            first_commit_hash: "first_commit".to_string(),
+            first_commit_date: t0,
+            last_commit_hash: "last_commit_a".to_string(),
+            last_commit_date: t0,
             attribute_path: "python311".to_string(),
             description: Some("Python interpreter".to_string()),
+            license: None,
+            homepage: None,
+            maintainers: None,
+            platforms: None,
+            source_path: Some("pkgs/development/interpreters/python".to_string()),
+            known_vulnerabilities: None,
+        };
+
+        let written1 = db
+            .insert_package_ranges_batch(std::slice::from_ref(&pkg))
+            .unwrap();
+        assert_eq!(written1, 1);
+
+        // Second write with same unique key but extended last_commit_hash should
+        // update the existing row, not create a duplicate.
+        let t1 = t0 + chrono::Duration::days(30);
+        pkg.last_commit_hash = "last_commit_b".to_string();
+        pkg.last_commit_date = t1;
+        pkg.description = Some("Python 3.11 interpreter".to_string());
+        // source_path arriving as None must not clobber the existing value.
+        pkg.source_path = None;
+
+        let written2 = db
+            .insert_package_ranges_batch(std::slice::from_ref(&pkg))
+            .unwrap();
+        assert_eq!(written2, 1);
+
+        let count: i32 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM package_versions", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 1, "upsert must not create a duplicate row");
+
+        let (last_hash, last_ts, description, source_path): (
+            String,
+            i64,
+            Option<String>,
+            Option<String>,
+        ) = db
+            .conn
+            .query_row(
+                "SELECT last_commit_hash, last_commit_date, description, source_path FROM package_versions",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(last_hash, "last_commit_b");
+        assert_eq!(last_ts, t1.timestamp());
+        assert_eq!(description.as_deref(), Some("Python 3.11 interpreter"));
+        assert_eq!(
+            source_path.as_deref(),
+            Some("pkgs/development/interpreters/python"),
+            "source_path must be sticky (preserved when new value is NULL)"
+        );
+    }
+
+    #[test]
+    fn test_load_open_ranges_at_commit() {
+        use chrono::Utc;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mut db = Database::open(&db_path).unwrap();
+
+        let t0 = Utc::now();
+        let make = |name: &str, version: &str, first: &str, last: &str| PackageVersion {
+            id: 0,
+            name: name.to_string(),
+            version: version.to_string(),
+            first_commit_hash: first.to_string(),
+            first_commit_date: t0,
+            last_commit_hash: last.to_string(),
+            last_commit_date: t0,
+            attribute_path: name.to_string(),
+            description: None,
             license: None,
             homepage: None,
             maintainers: None,
@@ -587,26 +718,35 @@ mod tests {
             known_vulnerabilities: None,
         };
 
-        // First insert should succeed
-        let inserted1 = db
-            .insert_package_ranges_batch(std::slice::from_ref(&pkg))
-            .unwrap();
-        assert_eq!(inserted1, 1);
+        let pkgs = vec![
+            make("firefox", "100.0", "c1", "checkpoint"),
+            make("firefox", "99.0", "c0", "checkpoint"),
+            make("chromium", "90.0", "c1", "older"),
+            // Simulate a bloated DB: same (attribute_path, version) with
+            // different first_commit_hash values — the previous indexer bug.
+            make("firefox", "100.0", "c2", "checkpoint"),
+            make("firefox", "100.0", "c3", "checkpoint"),
+        ];
+        db.insert_package_ranges_batch(&pkgs).unwrap();
 
-        // Second insert of same package should be ignored (no error)
-        let inserted2 = db
-            .insert_package_ranges_batch(std::slice::from_ref(&pkg))
-            .unwrap();
-        assert_eq!(inserted2, 0);
+        let open = db.load_open_ranges_at_commit("checkpoint").unwrap();
+        assert_eq!(
+            open.len(),
+            2,
+            "must collapse duplicate (attribute_path, version) tuples"
+        );
+        assert!(open.iter().all(|p| p.last_commit_hash == "checkpoint"));
 
-        // Verify only one row exists
-        let count: i32 = db
-            .conn
-            .query_row("SELECT COUNT(*) FROM package_versions", [], |row| {
-                row.get(0)
-            })
+        // Deterministic: the row with the smallest id per key should win
+        // (i.e. the first inserted, which has first_commit_hash = "c1").
+        let firefox_100 = open
+            .iter()
+            .find(|p| p.attribute_path == "firefox" && p.version == "100.0")
             .unwrap();
-        assert_eq!(count, 1);
+        assert_eq!(firefox_100.first_commit_hash, "c1");
+
+        let none = db.load_open_ranges_at_commit("does_not_exist").unwrap();
+        assert!(none.is_empty());
     }
 
     #[test]

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -712,7 +712,7 @@ impl Indexer {
                             return Ok(IndexResult {
                                 commits_processed: 0,
                                 packages_found: 0,
-                                ranges_created: 0,
+                                ranges_written: 0,
                                 unique_names: 0,
                                 was_interrupted: false,
                             });
@@ -817,10 +817,38 @@ impl Indexer {
         // Track unique package names for bloom filter
         let mut unique_names: HashSet<String> = HashSet::new();
 
+        // Pre-populate open_ranges from the last checkpoint. Without this, incremental
+        // runs create a new row per (attribute_path, version, new first_commit_hash)
+        // tuple — the UNIQUE constraint doesn't fire because first_commit_hash differs,
+        // and each run adds a duplicate for every package that's still present.
+        if let Some(resume_hash) = resume_from {
+            for pv in db.load_open_ranges_at_commit(resume_hash)? {
+                let key = format!("{}::{}", pv.attribute_path, pv.version);
+                unique_names.insert(pv.name.clone());
+                open_ranges.insert(
+                    key,
+                    OpenRange {
+                        name: pv.name,
+                        version: pv.version,
+                        first_commit_hash: pv.first_commit_hash,
+                        first_commit_date: pv.first_commit_date,
+                        attribute_path: pv.attribute_path,
+                        description: pv.description,
+                        license: pv.license,
+                        homepage: pv.homepage,
+                        maintainers: pv.maintainers,
+                        platforms: pv.platforms,
+                        source_path: pv.source_path,
+                        known_vulnerabilities: pv.known_vulnerabilities,
+                    },
+                );
+            }
+        }
+
         let mut result = IndexResult {
             commits_processed: 0,
             packages_found: 0,
-            ranges_created: 0,
+            ranges_written: 0,
             unique_names: 0,
             was_interrupted: false,
         };
@@ -872,7 +900,7 @@ impl Indexer {
 
                 // Insert pending ranges
                 if !pending_inserts.is_empty() {
-                    result.ranges_created +=
+                    result.ranges_written +=
                         db.insert_package_ranges_batch(&pending_inserts)? as u64;
                 }
 
@@ -894,7 +922,7 @@ impl Indexer {
                     &commit.short_hash,
                     commit.date.format("%Y-%m-%d"),
                     result.packages_found,
-                    result.ranges_created
+                    result.ranges_written
                 ));
             }
 
@@ -1093,12 +1121,24 @@ impl Indexer {
             // Record commit processing time for ETA calculation
             eta_tracker.finish_commit();
 
-            // Checkpoint if needed
+            // Checkpoint if needed.
+            // At each checkpoint we must flush the *current* state of every open range
+            // (not only ranges that have disappeared) so that a hard kill between
+            // periodic checkpoints and the final loop exit can still resume correctly:
+            // after the kill, load_open_ranges_at_commit(last_indexed_commit) will find
+            // these rows and re-seed them. Re-flushing the same range on the next
+            // checkpoint is safe because insert_package_ranges_batch is an upsert.
             if (commit_idx + 1).is_multiple_of(self.config.checkpoint_interval)
                 || commit_idx + 1 == commits.len()
             {
+                if let (Some(prev_hash), Some(prev_date)) = (&prev_commit_hash, prev_commit_date) {
+                    for range in open_ranges.values() {
+                        pending_inserts.push(range.to_package_version(prev_hash, prev_date));
+                    }
+                }
+
                 if !pending_inserts.is_empty() {
-                    result.ranges_created +=
+                    result.ranges_written +=
                         db.insert_package_ranges_batch(&pending_inserts)? as u64;
                     pending_inserts.clear();
                 }
@@ -1122,7 +1162,7 @@ impl Indexer {
             }
 
             if !pending_inserts.is_empty() {
-                result.ranges_created += db.insert_package_ranges_batch(&pending_inserts)? as u64;
+                result.ranges_written += db.insert_package_ranges_batch(&pending_inserts)? as u64;
             }
 
             if let Some(ref last_hash) = prev_commit_hash {
@@ -1138,7 +1178,7 @@ impl Indexer {
         if let Some(ref pb) = progress_bar {
             pb.finish_with_message(format!(
                 "done | {} commits | {} pkgs | {} ranges",
-                result.commits_processed, result.packages_found, result.ranges_created
+                result.commits_processed, result.packages_found, result.ranges_written
             ));
         }
 
@@ -1217,8 +1257,8 @@ pub struct IndexResult {
     pub commits_processed: u64,
     /// Total number of package extractions (may count same package multiple times).
     pub packages_found: u64,
-    /// Number of version ranges created in the database.
-    pub ranges_created: u64,
+    /// Number of rows written to the database (inserts + upsert updates).
+    pub ranges_written: u64,
     /// Number of unique package names found.
     pub unique_names: u64,
     /// Whether the indexing was interrupted (e.g., by Ctrl+C).
@@ -1465,7 +1505,7 @@ mod tests {
         let result = IndexResult {
             commits_processed: 0,
             packages_found: 0,
-            ranges_created: 0,
+            ranges_written: 0,
             unique_names: 0,
             was_interrupted: false,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1145,7 +1145,7 @@ fn cmd_index(cli: &Cli, args: &cli::IndexArgs) -> Result<()> {
     eprintln!("Indexing complete!");
     eprintln!("  Commits processed: {}", result.commits_processed);
     eprintln!("  Total packages found: {}", result.packages_found);
-    eprintln!("  Version ranges created: {}", result.ranges_created);
+    eprintln!("  Range rows written:     {}", result.ranges_written);
     eprintln!("  Unique package names: {}", result.unique_names);
 
     // Build and save bloom filter from current database state


### PR DESCRIPTION
## Summary

Two independent changes on `misc-fixes`:

### 1. Indexer: prevent unbounded duplicate-row growth

The published package index had grown to **1.8GB / 1,745,607 rows** against only **~120k distinct `(attribute_path, version)` pairs** (some pairs duplicated 290×, matching ~480 CI runs over 120 days). Queries that used to be sub-second took ~15s.

**Root cause:** `process_commits` started each incremental run with an empty `open_ranges` map, so at the first processed commit it re-stamped every still-present package with a new `first_commit_hash`. `INSERT OR IGNORE` didn't catch the collision because `UNIQUE(attribute_path, version, first_commit_hash)` includes `first_commit_hash`.

**Fix:**
- `Database::load_open_ranges_at_commit` seeds `open_ranges` from rows where `last_commit_hash = resume_hash`. Deduped via `MIN(id) GROUP BY attribute_path, version` so bloated DBs still seed deterministically.
- `insert_package_ranges_batch` switched from `INSERT OR IGNORE` to `INSERT ... ON CONFLICT DO UPDATE`. `source_path` is kept sticky via `COALESCE(source_path, excluded.source_path)` to mirror in-memory `OpenRange::update_metadata`.
- `process_commits` prepopulates `open_ranges` when `resume_from` is `Some` and now flushes **all** `open_ranges` at every periodic checkpoint (not just disappeared ranges) — a hard kill between checkpoints still resumes correctly because upsert makes re-flushing safe.
- `IndexResult::ranges_created` → `ranges_written` (the count now includes conflict updates).

**Note:** existing bloated DBs still need a full rebuild to actually remove the duplicate rows; once this ships CI needs to run a full rebuild + republish.

### 2. Flake modernization

- Migrate from `flake-utils` → `flake-parts`.
- Add `numtide/devshell` with categorized commands (build / check / run / deps) and an motd.
- Add `treefmt-nix` (nixfmt + rustfmt).
- Bump all flake inputs; refresh Rust toolchain to `stable.latest` with `rust-src` / `rust-analyzer` / `rustfmt` / `clippy`.
- Add `cargo-outdated`, `cargo-audit`, `cargo-llvm-cov` to the devshell.
- Fix Darwin `libiconv` linking (`LIBRARY_PATH` + `NIX_LDFLAGS` in `commonArgs` and the devshell env).
- Replace `pkgs.nodePackages.prettier` → `pkgs.prettier` (nodePackages removed upstream).
- Preserve every existing output: `overlays.default`, `nixosModules.default`/`nxv`, `packages.{nxv, nxv-indexer, nxv-static, nxv-static-aarch64, nxv-docker}`, `apps`, `checks`.
- `nix/module.nix` auto-reformatted by `nixfmt`; no semantic changes.
- CLAUDE.md updated: backend abstraction, env vars, `src/index/` vs `indexer` feature name, `cargo bench`.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --features indexer --all-targets -- -D warnings`
- [x] `cargo test --features indexer` (73 DB tests, 64 integration)
- [x] New unit tests: `test_batch_insert_extends_existing_range`, `test_load_open_ranges_at_commit` (covers dedupe seeding against bloated state)
- [x] `nix flake check` passes on aarch64-darwin
- [x] Codex peer review — findings addressed (periodic-checkpoint flush; bloated-DB dedupe seeding; ranges_written rename; docstring drift)
- [ ] CI Linux build + static musl cross-build
- [ ] CI `nix flake check` across all systems