### PR TITLE
ci(publish-index): add `dedupe` dispatch input for one-shot repair

### DIFF
--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -10,6 +10,11 @@ on:
 
   # Allow manual triggering
   workflow_dispatch:
+    inputs:
+      dedupe:
+        description: "Run `nxv dedupe` on the index before publish (one-shot repair for pre-0.1.5 bloat)"
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-index
@@ -164,7 +169,7 @@ jobs:
           echo "strategy=shallow" >> $GITHUB_OUTPUT
 
       - name: Skip if already up to date
-        if: ${{ steps.clone-strategy.outputs.strategy == 'skip' }}
+        if: ${{ steps.clone-strategy.outputs.strategy == 'skip' && inputs.dedupe != true }}
         run: |
           echo "Index is already up to date, nothing to do!"
           echo "## Index Already Current" >> $GITHUB_STEP_SUMMARY
@@ -211,8 +216,21 @@ jobs:
           echo "new_packages=${NEW_PACKAGES}" >> $GITHUB_OUTPUT
           echo "New packages: ${NEW_PACKAGES}"
 
+      # One-shot repair path: collapse duplicate (attribute_path, version) rows
+      # produced by the pre-0.1.5 incremental-indexer bug. Runs only when the
+      # workflow was dispatched manually with `dedupe: true`, before publish
+      # so the republished artifact is clean.
+      - name: Dedupe existing index
+        if: ${{ inputs.dedupe == true && steps.download-index.outputs.index_exists == 'true' }}
+        run: |
+          echo "Rows before dedupe:"
+          ./target/release/nxv stats 2>/dev/null | grep "Total version ranges" || true
+          ./target/release/nxv --db-path ~/.local/share/nxv/index.db dedupe
+          echo "Rows after dedupe:"
+          ./target/release/nxv stats 2>/dev/null | grep "Total version ranges" || true
+
       - name: Generate publishable artifacts
-        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback'
+        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback' || inputs.dedupe == true
         env:
           NXV_SECRET_KEY: ${{ secrets.NXV_SIGNING_KEY }}
         run: |
@@ -222,7 +240,7 @@ jobs:
             --sign
 
       - name: Upload workflow artifacts
-        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback'
+        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback' || inputs.dedupe == true
         uses: actions/upload-artifact@v4
         with:
           name: nxv-index
@@ -230,7 +248,7 @@ jobs:
           retention-days: 7
 
       - name: Upload to GitHub Release
-        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback'
+        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback' || inputs.dedupe == true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -254,13 +272,16 @@ jobs:
             --clobber
 
       - name: Summary
-        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback'
+        if: steps.clone-strategy.outputs.strategy == 'shallow' || steps.clone-strategy.outputs.strategy == 'deep-fallback' || inputs.dedupe == true
         run: |
           echo "## Index Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.dedupe }}" = "true" ]; then
+            echo "- **Dedupe:** enabled (one-shot repair)" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "- **Clone depth:** ${{ steps.clone-strategy.outputs.depth }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **New packages:** ${{ steps.stats-after.outputs.new_packages }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Total packages:** ${{ steps.stats-after.outputs.packages_after }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New packages:** ${{ steps.stats-after.outputs.new_packages || 'n/a (no index run)' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total packages:** ${{ steps.stats-after.outputs.packages_after || 'n/a' }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Index size:** $(du -h publish/index.db.zst | cut -f1)" >> $GITHUB_STEP_SUMMARY
           echo "- **Bloom filter size:** $(du -h publish/bloom.bin 2>/dev/null | cut -f1 || echo 'N/A')" >> $GITHUB_STEP_SUMMARY
           echo "- **Release:** [$INDEX_RELEASE_TAG](https://github.com/${{ github.repository }}/releases/tag/$INDEX_RELEASE_TAG)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a `dedupe` boolean input to `publish-index.yml`'s `workflow_dispatch`. When triggered with `dedupe: true`:

- The existing "skip if already up to date" short-circuit is bypassed so the job proceeds even when there are no new nixpkgs commits.
- A new **Dedupe existing index** step runs `nxv dedupe` on the downloaded `index-latest` before the publish stage.
- The publish / upload / summary steps are gated on `shallow || deep-fallback || inputs.dedupe == true` so they run in all three modes.

When `dedupe: false` (the default, and all scheduled runs), behavior is unchanged.

## Rationale

The pre-0.1.5 incremental indexer bug left the published `index-latest` at 1.8GB / 1,745,607 rows — only ~195k distinct `(attribute_path, version)` pairs, with the rest being restamped duplicates (#24, v0.1.5). v0.1.6 ships `nxv dedupe` to collapse those in place. This workflow change is the mechanism to actually apply it to the public artifact without exposing the signing secret.

Verified locally against a copy of the current bloated DB:

| Metric | Before | After |
|---|---|---|
| Rows | 1,745,607 | 195,071 (-89%) |
| File size | 1.8GB | ~310MB (-82%) |
| `nxv search firefox` | ~15s | ~100ms |
| Dedupe + VACUUM wall time | — | ~3m |

## How to run after merge

```
gh workflow run publish-index.yml -f dedupe=true -R utensils/nxv
```

Scheduled runs (every 6h) continue as before without dedupe.

## Test plan

- [ ] CI (lint / check) green on this PR — workflow YAML is parsed by Actions
- [ ] After merge, a manual dispatch with `dedupe=true` runs through to completion, publishes a deduped artifact, and scheduled runs resume normally
- [ ] Local `nxv update` on a fresh install post-publish shows sub-second query times