### PR TITLE
feat: web UI polish — a11y tooling, brighter tokens, URL state, live metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ website/server/
 # Added by cargo
 
 /target
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ website/server/
 
 /target
 __pycache__/
+
+# Playwright MCP artifacts + ad-hoc screenshots from browser testing
+.playwright-mcp/
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Thumbs.db
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 
+# Dropped-in design zips
+*.zip
+
 # Direnv
 .direnv/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Most are also exposed as CLI flags (see `src/cli.rs`); env vars are useful for t
 - `NXV_SKIP_VERIFY` — skip minisign verification of the manifest
 - `NXV_PUBLIC_KEY` — override the embedded minisign public key
 - `NXV_HOST`, `NXV_PORT`, `NXV_RATE_LIMIT` — `nxv serve` bind/host/rate-limit
+- `NXV_FRONTEND_DIR` — serve `index.html`/`app.js`/`favicon.svg` from this directory on every request instead of the embedded copy, and disable the 24h `Cache-Control` for those routes. Used by the devshell `dev` command for live frontend reload (edit → browser refresh, no rebuild). Unset in production.
 - `NXV_GIT_REV` — set by the Nix flake build to embed the git rev in `--version`
 
 ## Data Paths

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,24 @@ Files:
 - Tests create temporary databases using `tempfile`
 - Some indexer tests require `nix` to be installed (marked `#[ignore]`)
 
+## Accessibility (WCAG)
+
+Frontend a11y is audited by two devshell commands:
+
+- `a11y` — static, fully offline. Runs `html5validator` against `frontend/*.html`
+  (CSS validation is skipped — vnu.jar predates Tailwind v4 oklch/`@theme`/
+  `@layer`/`color-mix`) and then `scripts/a11y_check.py frontend/index.html`.
+  The Python script enforces landmarks, form labels, alt/role on images and
+  SVGs, heading hierarchy, skip-link presence, dialog semantics, and converts
+  every oklch token in the `@theme` block to sRGB to flag fg/bg pairs below
+  WCAG 2.1 AA (4.5:1 text, 3:1 large/UI). Wired into `nix flake check` as
+  `nxv-a11y`.
+- `a11y-live` — dynamic, opt-in. Runs `pa11y-ci` via `npx` against the local
+  `nxv serve` (start it first with `dev`). Config at `frontend/.pa11yci.json`
+  covers the home page (desktop + mobile), a search-populated state, and the
+  command palette open state. Not wired into `nix flake check` — needs a
+  running server and pulls from npm on first run.
+
 ## NixOS Module
 
 A NixOS module is provided for running nxv as a systemd service:

--- a/flake.nix
+++ b/flake.nix
@@ -560,6 +560,19 @@
                 command = "miniserve --index index.html ./frontend \"$@\"";
               }
               {
+                category = "run";
+                name = "dev";
+                help = "API server + live frontend reload (cargo watch on src, disk-served HTML/JS on :8080)";
+                command = ''
+                  set -euo pipefail
+                  export NXV_FRONTEND_DIR="''${NXV_FRONTEND_DIR:-$PWD/frontend}"
+                  echo "nxv dev · serving frontend from $NXV_FRONTEND_DIR"
+                  echo "nxv dev · http://localhost:8080  (edit frontend/* → just refresh the browser)"
+                  echo "nxv dev · src/ changes → cargo-watch auto-rebuilds and restarts"
+                  exec cargo watch -q -w src -w Cargo.toml -x 'run -- serve --port 8080' "$@"
+                '';
+              }
+              {
                 category = "deps";
                 name = "deps-outdated";
                 help = "list outdated crates";

--- a/flake.nix
+++ b/flake.nix
@@ -409,6 +409,32 @@
             );
 
             nxv-fmt = craneLib.cargoFmt { inherit src; };
+
+            # Static accessibility audit: html5 validity + custom WCAG script.
+            # Runs fully offline, so safe for `nix flake check` / CI.
+            nxv-a11y =
+              let
+                pythonWithDeps = pkgs.python3.withPackages (ps: [
+                  ps.beautifulsoup4
+                  ps.wcag-contrast-ratio
+                ]);
+              in
+              pkgs.runCommand "nxv-a11y"
+                {
+                  nativeBuildInputs = [
+                    pkgs.html5validator
+                    pythonWithDeps
+                  ];
+                }
+                ''
+                  cp -r ${./frontend} frontend
+                  cp ${./scripts/a11y_check.py} a11y_check.py
+                  html5validator --root frontend --match "*.html" \
+                    --ignore 'error: CSS:' \
+                            'The only allowed value for the "type" attribute for the "style" element'
+                  python3 a11y_check.py frontend/index.html
+                  touch $out
+                '';
           };
 
           devshells.default = {
@@ -433,6 +459,14 @@
               pkgs.prettier # HTML/JS/CSS formatter
               pkgs.markdownlint-cli # Markdown linter
               pkgs.k6 # Load testing tool
+              # Accessibility tooling — static checks run offline, the dynamic
+              # pa11y-ci check uses `npx` which fetches from npm on first run.
+              pkgs.html5validator
+              (pkgs.python3.withPackages (ps: [
+                ps.beautifulsoup4
+                ps.wcag-contrast-ratio
+              ]))
+              pkgs.nodejs_22
             ];
 
             env = [
@@ -517,6 +551,40 @@
                 name = "flake-check";
                 help = "nix flake check (full Nix CI checks)";
                 command = "nix flake check \"$@\"";
+              }
+              {
+                category = "check";
+                name = "a11y";
+                help = "static WCAG + HTML5 validation of frontend/index.html";
+                command = ''
+                  set -euo pipefail
+                  # Ignore CSS messages — the bundled vnu.jar predates Tailwind v4
+                  # (oklch, @theme, @layer, color-mix). Our static WCAG script
+                  # handles the design-token checks instead.
+                  # Ignore CSS messages — the bundled vnu.jar predates Tailwind v4
+                  # (oklch, @theme, @layer, color-mix). Our static WCAG script
+                  # handles the design-token checks instead. Also skip the
+                  # `type="text/tailwindcss"` style-attribute complaint.
+                  html5validator --root frontend --match "*.html" \
+                    --ignore 'error: CSS:' \
+                            'The only allowed value for the "type" attribute for the "style" element' \
+                    "$@"
+                  python3 scripts/a11y_check.py frontend/index.html
+                '';
+              }
+              {
+                category = "check";
+                name = "a11y-live";
+                help = "run pa11y-ci against a running nxv serve (needs `dev` in another terminal)";
+                command = ''
+                  set -euo pipefail
+                  if ! command -v curl >/dev/null 2>&1 || ! curl -sf http://localhost:8080/ >/dev/null; then
+                    echo "a11y-live: no server on http://localhost:8080" >&2
+                    echo "           start one first with: dev" >&2
+                    exit 1
+                  fi
+                  exec npx --yes pa11y-ci --config frontend/.pa11yci.json "$@"
+                '';
               }
               {
                 category = "check";

--- a/frontend/.pa11yci.json
+++ b/frontend/.pa11yci.json
@@ -1,0 +1,42 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 30000,
+    "wait": 500,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox"]
+    },
+    "viewport": {
+      "width": 1280,
+      "height": 900
+    },
+    "runners": ["axe", "htmlcs"],
+    "ignore": []
+  },
+  "urls": [
+    "http://localhost:8080/",
+    {
+      "url": "http://localhost:8080/",
+      "viewport": { "width": 375, "height": 812 },
+      "actions": [
+        "wait for element #searchInput to be visible"
+      ]
+    },
+    {
+      "url": "http://localhost:8080/",
+      "actions": [
+        "wait for element #searchInput to be visible",
+        "set field #searchInput to python",
+        "wait for 600"
+      ]
+    },
+    {
+      "url": "http://localhost:8080/",
+      "actions": [
+        "wait for element #paletteTrigger to be visible",
+        "click element #paletteTrigger",
+        "wait for 300"
+      ]
+    }
+  ]
+}

--- a/frontend/.pa11yci.json
+++ b/frontend/.pa11yci.json
@@ -18,9 +18,7 @@
     {
       "url": "http://localhost:8080/",
       "viewport": { "width": 375, "height": 812 },
-      "actions": [
-        "wait for element #searchInput to be visible"
-      ]
+      "actions": ["wait for element #searchInput to be visible"]
     },
     {
       "url": "http://localhost:8080/",

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -540,25 +540,62 @@
   }
 
   function drawTimeline(history) {
-    const axisStart = new Date('2017-01-01').getTime();
-    const axisEnd = new Date(Date.now() + 30 * 24 * 3600e3).getTime();
-    const span = Math.max(1, axisEnd - axisStart);
     const el = cache('timelineViz');
+    el.innerHTML = '';
+
+    // Derive axis from the actual history, not a hard-coded 2017 floor.
+    const times = [];
+    for (const v of history) {
+      const f = new Date(v.first_seen).getTime();
+      const l = new Date(v.last_seen).getTime();
+      if (Number.isFinite(f)) times.push(f);
+      if (Number.isFinite(l)) times.push(l);
+    }
+    if (!times.length) return;
+
+    const rawStart = Math.min(...times);
+    const rawEnd = Math.max(...times);
+    const minSpan = 90 * 24 * 3600e3; // keep a 3-month floor so single-version histories stay legible
+    const usableSpan = Math.max(rawEnd - rawStart, minSpan);
+    const pad = Math.max(14 * 24 * 3600e3, usableSpan * 0.04);
+    const axisStart = rawStart - pad;
+    const axisEnd = rawEnd + pad;
+    const axisSpan = axisEnd - axisStart;
+
+    const startYear = new Date(axisStart).getUTCFullYear();
+    const endYear = new Date(axisEnd).getUTCFullYear();
+
+    const labelEl = document.getElementById('timelineLabel');
+    if (labelEl) labelEl.textContent = `timeline · ${startYear} → ${endYear}`;
+
+    const ticksEl = document.getElementById('timelineTicks');
+    if (ticksEl) {
+      const years = [];
+      for (let y = startYear; y <= endYear; y++) years.push(y);
+      // thin ticks to keep the row readable on long histories
+      const maxTicks = 10;
+      const stride = Math.max(1, Math.ceil(years.length / maxTicks));
+      const shown = years.filter((_, i) => i % stride === 0);
+      if (shown[shown.length - 1] !== years[years.length - 1]) shown.push(years[years.length - 1]);
+      ticksEl.innerHTML = shown
+        .map((y) => `<span>'${String(y).slice(2)}</span>`)
+        .join('');
+    }
+
     const rows = history.slice(0, 12);
     const rowH = 10;
     const gap = 2;
     const totalH = Math.max(rows.length * (rowH + gap), 100);
     const svgNS = 'http://www.w3.org/2000/svg';
-    el.innerHTML = '';
     const svg = document.createElementNS(svgNS, 'svg');
     svg.setAttribute('viewBox', `0 0 1000 ${totalH}`);
     svg.setAttribute('preserveAspectRatio', 'none');
     svg.style.width = '100%';
     svg.style.height = `${totalH}px`;
 
-    const yearEnd = new Date(axisEnd).getUTCFullYear();
-    for (let y = 2017; y <= yearEnd; y++) {
-      const x = ((new Date(`${y}-01-01`).getTime()) - axisStart) / span * 1000;
+    for (let y = startYear; y <= endYear; y++) {
+      const x = ((new Date(Date.UTC(y, 0, 1)).getTime()) - axisStart) / axisSpan * 1000;
+      if (x < 0 || x > 1000) continue;
       const line = document.createElementNS(svgNS, 'line');
       line.setAttribute('x1', x);
       line.setAttribute('x2', x);
@@ -570,21 +607,24 @@
       svg.appendChild(line);
     }
 
-    const flakeX = ((FLAKES_EPOCH.getTime()) - axisStart) / span * 1000;
-    const flakeLine = document.createElementNS(svgNS, 'line');
-    flakeLine.setAttribute('x1', flakeX);
-    flakeLine.setAttribute('x2', flakeX);
-    flakeLine.setAttribute('y1', 0);
-    flakeLine.setAttribute('y2', totalH);
-    flakeLine.setAttribute('stroke', 'var(--color-amber-glow)');
-    flakeLine.setAttribute('stroke-dasharray', '3 3');
-    flakeLine.setAttribute('stroke-width', '1');
-    flakeLine.setAttribute('opacity', '0.5');
-    svg.appendChild(flakeLine);
+    const flakeT = FLAKES_EPOCH.getTime();
+    if (flakeT >= axisStart && flakeT <= axisEnd) {
+      const flakeX = ((flakeT - axisStart) / axisSpan) * 1000;
+      const flakeLine = document.createElementNS(svgNS, 'line');
+      flakeLine.setAttribute('x1', flakeX);
+      flakeLine.setAttribute('x2', flakeX);
+      flakeLine.setAttribute('y1', 0);
+      flakeLine.setAttribute('y2', totalH);
+      flakeLine.setAttribute('stroke', 'var(--color-amber-glow)');
+      flakeLine.setAttribute('stroke-dasharray', '3 3');
+      flakeLine.setAttribute('stroke-width', '1');
+      flakeLine.setAttribute('opacity', '0.5');
+      svg.appendChild(flakeLine);
+    }
 
     rows.forEach((v, i) => {
-      const x1 = Math.max(0, (new Date(v.first_seen).getTime() - axisStart) / span * 1000);
-      const x2 = Math.min(1000, (new Date(v.last_seen).getTime() - axisStart) / span * 1000);
+      const x1 = Math.max(0, (new Date(v.first_seen).getTime() - axisStart) / axisSpan * 1000);
+      const x2 = Math.min(1000, (new Date(v.last_seen).getTime() - axisStart) / axisSpan * 1000);
       const w = Math.max(2, x2 - x1);
       const y = i * (rowH + gap);
       const rect = document.createElementNS(svgNS, 'rect');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -67,6 +67,9 @@
     if (s == null || s === '') return [];
     if (typeof s !== 'string') return Array.isArray(s) ? s : [String(s)];
     const t = s.trim();
+    // The DB sometimes stores a literal "null"/"None" sentinel for missing
+    // JSON; the server treats those as secure, so we must too.
+    if (t === '' || t === 'null' || t === 'None') return [];
     if (t.startsWith('[')) {
       try {
         const v = JSON.parse(t);
@@ -139,7 +142,12 @@
     const isLegacy = r.legacy || predatesFlakes(r.last);
     const insecurePrefix = r.insecure ? 'NIXPKGS_ALLOW_INSECURE=1 ' : '';
     const impure = r.insecure ? ' --impure' : '';
-    const ref = shortHash(r.hash || r.lastHash);
+    // For the flake path the ref MUST point at a commit that has flake.nix —
+    // i.e. post 2020-02-10. first_commit_hash can predate that even for a
+    // version whose last-seen commit is current, so prefer last_commit_hash
+    // here. For legacy (pre-flake) tarball imports either hash works; keep
+    // the historical preference for first_commit_hash.
+    const ref = isLegacy ? shortHash(r.hash || r.lastHash) : shortHash(r.lastHash || r.hash);
     return isLegacy
       ? `${insecurePrefix}nix-shell -p '(import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${ref}.tar.gz") {}).${r.attr}'`
       : `${insecurePrefix}nix shell${impure} nixpkgs/${ref}#${r.attr}`;
@@ -229,7 +237,18 @@
   }
 
   // ---------- search ----------
-  function buildSearchUrl() {
+  // The /api/v1/search endpoint paginates server-side but has no params for
+  // `arch` or an insecure toggle, so when those client-only filters are
+  // active we fetch a large window and paginate the filtered list ourselves.
+  // This keeps the count and the prev/next controls consistent with what the
+  // user actually sees.
+  const CLIENT_FILTER_LIMIT = 500;
+
+  function clientFilterActive() {
+    return !!STATE.filters.arch || !STATE.filters.includeInsecure;
+  }
+
+  function buildSearchUrl(clientFiltered) {
     const parsed = parseQuery(STATE.query);
     const pkg = parsed.pkg;
     const params = new URLSearchParams();
@@ -240,8 +259,13 @@
     if (STATE.filters.exact) params.set('exact', 'true');
     if (STATE.filters.license) params.set('license', STATE.filters.license);
     if (STATE.filters.sort) params.set('sort', STATE.filters.sort);
-    params.set('limit', String(STATE.pageSize));
-    params.set('offset', String((STATE.page - 1) * STATE.pageSize));
+    if (clientFiltered) {
+      params.set('limit', String(CLIENT_FILTER_LIMIT));
+      params.set('offset', '0');
+    } else {
+      params.set('limit', String(STATE.pageSize));
+      params.set('offset', String((STATE.page - 1) * STATE.pageSize));
+    }
     return `${API_BASE}/search?${params.toString()}`;
   }
 
@@ -258,29 +282,50 @@
       return;
     }
 
-    const url = buildSearchUrl();
+    const clientFiltered = clientFilterActive();
+    const url = buildSearchUrl(clientFiltered);
     setResultsStatus('running…', '');
     try {
       const { json, latency } = await api(url);
       if (seq !== STATE.reqSeq) return; // a newer request started — drop this
       STATE.lastLatencyMs = latency;
       const items = (json.data || []).map(toRow);
-      const meta = json.meta || { total: items.length, has_more: false };
-      STATE.total = meta.total;
-      STATE.hasMore = !!meta.has_more;
+      const serverMeta = json.meta || { total: items.length, has_more: false };
 
-      // client-side filters that the API doesn't support: arch, includeInsecure
+      // client-side filters the API doesn't support
       let filtered = items;
       if (STATE.filters.arch)
         filtered = filtered.filter((r) => r.platforms.includes(STATE.filters.arch));
       if (!STATE.filters.includeInsecure) filtered = filtered.filter((r) => !r.insecure);
 
-      render(filtered);
+      let rows,
+        total,
+        hasMore,
+        truncated = false;
+      if (clientFiltered) {
+        // paginate the filtered list on the client so count + prev/next agree
+        total = filtered.length;
+        const start = (STATE.page - 1) * STATE.pageSize;
+        const end = start + STATE.pageSize;
+        rows = filtered.slice(start, end);
+        hasMore = end < filtered.length;
+        // the server capped us at CLIENT_FILTER_LIMIT rows; if it says there's
+        // more unfiltered data available, our filtered total is a lower bound
+        truncated = !!serverMeta.has_more && items.length >= CLIENT_FILTER_LIMIT;
+      } else {
+        rows = filtered;
+        total = serverMeta.total;
+        hasMore = !!serverMeta.has_more;
+      }
+      STATE.total = total;
+      STATE.hasMore = hasMore;
+
+      render(rows);
       setResultsStatus(
-        `results / ${fmtNum(meta.total)}${filtered.length !== items.length ? ` (${filtered.length} shown)` : ''}`,
+        `results / ${fmtNum(total)}${truncated ? '+' : ''}`,
         `${(latency / 1000).toFixed(3)}s · api`
       );
-      renderPagination(meta);
+      renderPagination({ total, has_more: hasMore });
     } catch (e) {
       if (seq !== STATE.reqSeq) return;
       renderError(e);
@@ -347,7 +392,7 @@
         if (!r) return;
         if (action === 'copy-flake') copy(buildFlakeCmd(r));
         else if (action === 'copy-run')
-          copy(`nix run nixpkgs/${shortHash(r.hash || r.lastHash)}#${r.attr}`);
+          copy(`nix run nixpkgs/${shortHash(r.lastHash || r.hash)}#${r.attr}`);
         else if (action === 'history') openDrawer(r);
       });
     });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,883 @@
+/* nxv — front-end logic, wired to the live /api/v1 endpoints */
+(() => {
+  const $ = (s, r = document) => r.querySelector(s);
+  const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+
+  const API_BASE = '/api/v1';
+  const PAGE_SIZE = 50;
+  const FLAKES_EPOCH = new Date('2020-02-10T00:00:00Z');
+
+  const STATE = {
+    query: '',
+    filters: {
+      exact: false,
+      version: '',
+      arch: '',
+      license: '',
+      sort: 'date',
+      includeInsecure: false,
+    },
+    view: 'rows',
+    page: 1,
+    pageSize: PAGE_SIZE,
+    total: 0,
+    hasMore: false,
+    lastLatencyMs: null,
+    stats: null,
+    health: null,
+    reqSeq: 0,
+    historyCache: new Map(),
+    firstHashCache: new Map(),
+  };
+
+  const els = {};
+  const cache = (id) => (els[id] = els[id] || document.getElementById(id));
+
+  // ---------- util ----------
+  const fmtDate = (d) => {
+    if (!d) return '—';
+    try {
+      return new Date(d).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+      });
+    } catch {
+      return String(d);
+    }
+  };
+  const fmtNum = (n) => (n == null ? '—' : Number(n).toLocaleString());
+  const archLabel = (p) =>
+    p
+      .replace('x86_64-linux', 'x86_64·linux')
+      .replace('aarch64-linux', 'aarch64·linux')
+      .replace('x86_64-darwin', 'x86_64·macos')
+      .replace('aarch64-darwin', 'aarch64·macos')
+      .replace('i686-linux', 'i686·linux')
+      .replace('armv7l-linux', 'armv7·linux');
+  const predatesFlakes = (d) => (d ? new Date(d) < FLAKES_EPOCH : false);
+  const shortHash = (h) => (h || '').slice(0, 7);
+  const escapeHtml = (s) =>
+    String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+  function parseJsonArrayOrString(s) {
+    if (s == null || s === '') return [];
+    if (typeof s !== 'string') return Array.isArray(s) ? s : [String(s)];
+    const t = s.trim();
+    if (t.startsWith('[')) {
+      try {
+        const v = JSON.parse(t);
+        return Array.isArray(v) ? v : [String(v)];
+      } catch {
+        return [s];
+      }
+    }
+    return [s];
+  }
+
+  function toRow(p) {
+    const licenses = parseJsonArrayOrString(p.license);
+    const platforms = parseJsonArrayOrString(p.platforms).filter(Boolean);
+    const vulns = parseJsonArrayOrString(p.known_vulnerabilities);
+    return {
+      id: p.id,
+      name: p.name,
+      attr: p.attribute_path,
+      ver: p.version,
+      desc: p.description || '',
+      first: p.first_commit_date,
+      last: p.last_commit_date,
+      hash: p.first_commit_hash,
+      lastHash: p.last_commit_hash,
+      platforms,
+      license: licenses.join(' / ') || '',
+      insecure: vulns.length ? vulns : null,
+      legacy: predatesFlakes(p.last_commit_date),
+      homepage: p.homepage || null,
+      sourcePath: p.source_path || null,
+    };
+  }
+
+  async function api(path) {
+    const t0 = performance.now();
+    const res = await fetch(path, { headers: { Accept: 'application/json' } });
+    const latency = performance.now() - t0;
+    if (!res.ok) {
+      const err = new Error(`${res.status} ${res.statusText}`);
+      err.status = res.status;
+      throw err;
+    }
+    const json = await res.json();
+    return { json, latency };
+  }
+
+  // ---------- toast / copy ----------
+  function showToast(msg) {
+    const t = cache('toast');
+    t.textContent = msg;
+    t.style.opacity = '1';
+    t.style.transform = 'translateY(0)';
+    clearTimeout(t._t);
+    t._t = setTimeout(() => {
+      t.style.opacity = '0';
+      t.style.transform = 'translateY(1rem)';
+    }, 1800);
+  }
+  async function copy(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast(`copied · ${text.length > 56 ? text.slice(0, 56) + '…' : text}`);
+    } catch {
+      showToast('copy failed');
+    }
+  }
+
+  function buildFlakeCmd(r) {
+    const isLegacy = r.legacy || predatesFlakes(r.last);
+    const insecurePrefix = r.insecure ? 'NIXPKGS_ALLOW_INSECURE=1 ' : '';
+    const impure = r.insecure ? ' --impure' : '';
+    const ref = shortHash(r.hash || r.lastHash);
+    return isLegacy
+      ? `${insecurePrefix}nix-shell -p '(import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${ref}.tar.gz") {}).${r.attr}'`
+      : `${insecurePrefix}nix shell${impure} nixpkgs/${ref}#${r.attr}`;
+  }
+
+  // ---------- query parsing ----------
+  function parseQuery(q) {
+    const m = q.trim().match(/^(.+?)\s+(v?\d[\d.]*[\w.-]*)$/i);
+    if (m && !m[1].match(/\d$/)) return { pkg: m[1].trim(), ver: m[2].replace(/^v/i, '') };
+    return { pkg: q.trim(), ver: null };
+  }
+
+  // ---------- filter chips ----------
+  function cycleFilter(key) {
+    const cycles = {
+      exact: [false, true],
+      version: ['', '2.7', '3.11', '3.12', '18', '22'],
+      arch: ['', 'x86_64-linux', 'aarch64-linux', 'x86_64-darwin', 'aarch64-darwin'],
+      license: ['', 'MIT', 'GPL-3.0+', 'BSD-3-Clause', 'Apache-2.0', 'LGPL-2.1+'],
+      sort: ['date', 'name', 'version'],
+      includeInsecure: [false, true],
+    };
+    const cycle = cycles[key];
+    const cur = STATE.filters[key];
+    const idx = cycle.indexOf(cur);
+    STATE.filters[key] = cycle[(idx + 1) % cycle.length];
+  }
+
+  function renderFilterChips() {
+    const labels = {
+      exact: () => (STATE.filters.exact ? 'on' : 'off'),
+      version: () => STATE.filters.version || 'any',
+      arch: () => (STATE.filters.arch ? archLabel(STATE.filters.arch) : 'any'),
+      license: () => STATE.filters.license || 'any',
+      sort: () => STATE.filters.sort,
+      'include-insecure': () => (STATE.filters.includeInsecure ? 'yes' : 'no'),
+    };
+    $$('.chip[data-filter]').forEach((el) => {
+      const k = el.dataset.filter;
+      if (k === 'include-insecure') {
+        el.innerHTML = `include insecure: <span class="ml-1 text-[var(--color-fog-0)]">${labels[k]()}</span>`;
+        el.classList.toggle('active', STATE.filters.includeInsecure);
+      } else {
+        const label = el.textContent.split(':')[0].trim();
+        el.innerHTML = `${label}: <span class="ml-1 text-[var(--color-fog-0)]">${labels[k]()}</span>`;
+        const v = STATE.filters[k];
+        const isActive =
+          k === 'exact'
+            ? STATE.filters.exact
+            : k === 'sort'
+            ? v !== 'date'
+            : !!v;
+        el.classList.toggle('active', !!isActive);
+      }
+    });
+  }
+
+  // ---------- search ----------
+  function buildSearchUrl() {
+    const parsed = parseQuery(STATE.query);
+    const pkg = parsed.pkg;
+    const params = new URLSearchParams();
+    // API requires q — use " " as no-op to fetch top rows
+    params.set('q', pkg || '');
+    const ver = STATE.filters.version || parsed.ver || '';
+    if (ver) params.set('version', ver);
+    if (STATE.filters.exact) params.set('exact', 'true');
+    if (STATE.filters.license) params.set('license', STATE.filters.license);
+    if (STATE.filters.sort) params.set('sort', STATE.filters.sort);
+    params.set('limit', String(STATE.pageSize));
+    params.set('offset', String((STATE.page - 1) * STATE.pageSize));
+    return `${API_BASE}/search?${params.toString()}`;
+  }
+
+  async function runSearch(opts = {}) {
+    if (opts.resetPage !== false) STATE.page = 1;
+    const seq = ++STATE.reqSeq;
+
+    // empty query + no filters → show welcome
+    const noQuery = !STATE.query.trim();
+    const noFilters =
+      !STATE.filters.version && !STATE.filters.arch && !STATE.filters.license;
+    if (noQuery && noFilters) {
+      renderWelcome();
+      return;
+    }
+
+    const url = buildSearchUrl();
+    setResultsStatus('running…', '');
+    try {
+      const { json, latency } = await api(url);
+      if (seq !== STATE.reqSeq) return; // a newer request started — drop this
+      STATE.lastLatencyMs = latency;
+      const items = (json.data || []).map(toRow);
+      const meta = json.meta || { total: items.length, has_more: false };
+      STATE.total = meta.total;
+      STATE.hasMore = !!meta.has_more;
+
+      // client-side filters that the API doesn't support: arch, includeInsecure
+      let filtered = items;
+      if (STATE.filters.arch) filtered = filtered.filter((r) => r.platforms.includes(STATE.filters.arch));
+      if (!STATE.filters.includeInsecure) filtered = filtered.filter((r) => !r.insecure);
+
+      render(filtered);
+      setResultsStatus(
+        `results / ${fmtNum(meta.total)}${filtered.length !== items.length ? ` (${filtered.length} shown)` : ''}`,
+        `${(latency / 1000).toFixed(3)}s · api`,
+      );
+      renderPagination(meta);
+    } catch (e) {
+      if (seq !== STATE.reqSeq) return;
+      renderError(e);
+    }
+  }
+
+  function setResultsStatus(count, time) {
+    cache('resultsCount').textContent = count || '—';
+    cache('resultsTime').textContent = time || '—';
+  }
+
+  function renderWelcome() {
+    STATE.total = 0;
+    STATE.hasMore = false;
+    cache('resultsBody').innerHTML = `
+      <div class="px-6 py-16 text-center">
+        <div class="mono text-[12px] text-[var(--color-fog-4)] leading-7">
+          type a package name above to search<br/>
+          <span class="text-[var(--color-fog-3)]">try</span>
+          <button class="chip example mx-1" type="button">python 2.7</button>
+          <button class="chip example mx-1" type="button">nodejs 18</button>
+          <button class="chip example mx-1" type="button">gcc 4.9</button>
+          <button class="chip example mx-1" type="button">ffmpeg 5</button>
+          <br/>
+          <span class="text-[var(--color-fog-3)]">or press</span> <span class="kbd">⌘K</span> <span class="text-[var(--color-fog-3)]">to open the palette</span>
+        </div>
+      </div>`;
+    setResultsStatus('results / —', '—');
+    renderPagination({ total: 0, has_more: false });
+    // rewire welcome example chips
+    $$('#resultsBody .chip.example').forEach((el) =>
+      el.addEventListener('click', () => runExample(el.textContent.trim())),
+    );
+  }
+
+  function renderError(e) {
+    cache('resultsBody').innerHTML = `
+      <div class="px-6 py-12 text-center">
+        <div class="mono text-[12px] text-[var(--color-red-glow)]">error · ${escapeHtml(e?.message || 'request failed')}</div>
+        <div class="mt-2 mono text-[11px] text-[var(--color-fog-4)]">check that the API server is reachable.</div>
+      </div>`;
+    setResultsStatus('results / —', 'error');
+    renderPagination({ total: 0, has_more: false });
+  }
+
+  function render(rows) {
+    const body = cache('resultsBody');
+    if (!rows.length) {
+      body.innerHTML = `
+        <div class="px-6 py-16 text-center">
+          <div class="mono text-[12px] text-[var(--color-fog-4)]">no results — try loosening filters, or press <span class="kbd">⌘K</span> to browse.</div>
+        </div>`;
+      return;
+    }
+    body.innerHTML = rows.map((r, i) => renderRow(r, i)).join('');
+
+    const rowByAttrVer = new Map(rows.map((r) => [`${r.attr}::${r.ver}`, r]));
+    $$('#resultsBody [data-action]').forEach((el) => {
+      el.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        const { action } = el.dataset;
+        const key = el.dataset.key;
+        const r = rowByAttrVer.get(key);
+        if (!r) return;
+        if (action === 'copy-flake') copy(buildFlakeCmd(r));
+        else if (action === 'copy-run') copy(`nix run nixpkgs/${shortHash(r.hash || r.lastHash)}#${r.attr}`);
+        else if (action === 'history') openDrawer(r);
+      });
+    });
+    $$('#resultsBody [data-row]').forEach((el) => {
+      el.addEventListener('click', () => {
+        const r = rowByAttrVer.get(el.dataset.row);
+        if (r) openDrawer(r);
+      });
+    });
+  }
+
+  function renderRow(r, i) {
+    const isLegacy = r.legacy;
+    const flags = [];
+    if (r.insecure) {
+      const title = escapeHtml(r.insecure.join(' · '));
+      flags.push(`<span class="chip danger" title="${title}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4M12 16h.01"/></svg>insecure</span>`);
+    }
+    if (isLegacy) flags.push(`<span class="chip warn">pre-flakes</span>`);
+
+    const platformsHtml = r.platforms
+      .filter((p) => /^(x86_64|aarch64|i686|armv7l|armv6l)-(linux|darwin)$/.test(p))
+      .slice(0, 4)
+      .map((p) => {
+        const active = STATE.filters.arch === p;
+        return `<span class="chip${active ? ' active' : ''}" style="font-size:10px; padding: 1px 6px;">${archLabel(p)}</span>`;
+      })
+      .join('');
+
+    const key = `${r.attr}::${r.ver}`;
+    const nameHtml = escapeHtml(r.name);
+    const attrHtml = escapeHtml(r.attr);
+    const licenseHtml = escapeHtml(r.license || '—');
+    const descHtml = escapeHtml(r.desc);
+    const verHtml = escapeHtml(r.ver);
+
+    return `
+      <div data-row="${escapeHtml(key)}" class="group grid grid-cols-[minmax(180px,1.6fr)_100px_minmax(200px,2fr)_120px_130px_90px] gap-3 items-center px-4 py-3 cursor-pointer transition anim-in hover:bg-[var(--color-ink-2)]" style="animation-delay:${i * 12}ms; border-bottom: 1px solid var(--color-ink-2);">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="mono text-[13.5px] text-[var(--color-fog-0)] font-medium truncate">${nameHtml}</span>
+            <span class="mono text-[11px] text-[var(--color-fog-4)]">·</span>
+            <span class="mono text-[11px] text-[var(--color-nix-400)] truncate">${attrHtml}</span>
+          </div>
+          <div class="mono text-[10.5px] text-[var(--color-fog-4)] mt-0.5 flex items-center gap-1.5">
+            <span class="truncate" style="max-width: 180px;">${licenseHtml}</span>
+            <span class="text-[var(--color-ink-4)]">·</span>
+            <span class="mono">#${shortHash(r.hash || r.lastHash)}</span>
+          </div>
+        </div>
+        <div>
+          <span class="mono text-[13px] ${r.insecure ? 'text-[var(--color-red-glow)]' : 'text-[var(--color-fog-0)]'} tabular-nums">${verHtml}</span>
+        </div>
+        <div class="hidden md:block min-w-0">
+          <div class="text-[13px] text-[var(--color-fog-2)] truncate">${descHtml || '<span class="text-[var(--color-fog-4)]">—</span>'}</div>
+          <div class="mt-1 flex flex-wrap gap-1">
+            ${flags.join('')}${platformsHtml}
+          </div>
+        </div>
+        <div class="mono text-[11.5px] text-[var(--color-fog-3)] tabular-nums">${fmtDate(r.first)}</div>
+        <div class="mono text-[11.5px] text-[var(--color-fog-3)] tabular-nums">${fmtDate(r.last)}</div>
+        <div class="flex items-center justify-end gap-1 opacity-70 group-hover:opacity-100 transition">
+          <button class="btn btn-ghost" data-action="copy-flake" data-key="${escapeHtml(key)}" title="copy flake ref">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            cp
+          </button>
+          <button class="btn btn-ghost" data-action="history" data-key="${escapeHtml(key)}" title="version history">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            log
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  // ---------- pagination ----------
+  function renderPagination(meta) {
+    const el = cache('pagination');
+    const total = meta.total || 0;
+    const totalPages = Math.max(1, Math.ceil(total / STATE.pageSize));
+    const startIdx = total === 0 ? 0 : (STATE.page - 1) * STATE.pageSize + 1;
+    const endIdx = Math.min(total, STATE.page * STATE.pageSize);
+    el.innerHTML = `
+      <span>page <span class="text-[var(--color-fog-0)]">${STATE.page}</span> / <span class="text-[var(--color-fog-0)]">${totalPages}</span> · showing <span class="text-[var(--color-fog-0)]">${startIdx}–${endIdx}</span> of <span class="text-[var(--color-fog-0)]">${fmtNum(total)}</span></span>
+      <div class="flex items-center gap-1.5">
+        <button class="btn btn-ghost" data-page="prev" ${STATE.page <= 1 ? 'disabled style="opacity:.4; cursor:not-allowed;"' : ''}>← prev</button>
+        <button class="btn btn-ghost" data-page="next" ${!meta.has_more ? 'disabled style="opacity:.4; cursor:not-allowed;"' : ''}>next →</button>
+      </div>`;
+    $$('#pagination [data-page]').forEach((b) => {
+      b.addEventListener('click', () => {
+        if (b.hasAttribute('disabled')) return;
+        if (b.dataset.page === 'prev' && STATE.page > 1) STATE.page -= 1;
+        else if (b.dataset.page === 'next' && STATE.hasMore) STATE.page += 1;
+        else return;
+        runSearch({ resetPage: false });
+        window.scrollTo({ top: cache('resultsSection').offsetTop - 80, behavior: 'smooth' });
+      });
+    });
+  }
+
+  // ---------- drawer / version history ----------
+  async function openDrawer(r) {
+    const drawer = cache('drawerOverlay');
+    drawer.classList.remove('hidden');
+    drawer.classList.add('flex');
+    cache('drawerTitle').textContent = `${r.name} · ${r.attr}`;
+    cache('drawerSub').innerHTML = `${escapeHtml(r.desc || '—')} <span class="text-[var(--color-ink-4)]">│</span> ${escapeHtml(r.license || '—')}`;
+    cache('drawerCount').textContent = '…';
+    cache('drawerList').innerHTML = `<li class="px-3 py-4 mono text-[12px] text-[var(--color-fog-4)]">loading version history…</li>`;
+    cache('timelineViz').innerHTML = '';
+
+    try {
+      const versions = await fetchHistory(r.attr);
+      cache('drawerCount').textContent = `(${versions.length})`;
+      drawTimeline(versions);
+      cache('drawerList').innerHTML = versions
+        .map((v, idx) => {
+          const legacy = predatesFlakes(v.last_seen);
+          const tag = v.is_insecure
+            ? ' text-[var(--color-red-glow)]'
+            : legacy
+            ? ' text-[var(--color-amber-glow)]'
+            : ' text-[var(--color-fog-0)]';
+          return `
+            <li class="grid grid-cols-[minmax(90px,auto)_1fr_auto] items-center gap-4 px-3 py-2 rounded-[2px] hover:bg-[var(--color-ink-2)] transition">
+              <span class="mono text-[12.5px]${tag} tabular-nums">${escapeHtml(v.version)}</span>
+              <span class="mono text-[11px] text-[var(--color-fog-3)] tabular-nums">${fmtDate(v.first_seen)}<span class="text-[var(--color-ink-4)] mx-2">→</span>${fmtDate(v.last_seen)}</span>
+              <span class="flex items-center gap-2">
+                ${v.is_insecure ? '<span class="chip danger" style="font-size:10px; padding:1px 5px;">insecure</span>' : ''}
+                ${legacy ? '<span class="chip warn" style="font-size:10px; padding:1px 5px;">pre-flakes</span>' : ''}
+                <button class="btn btn-ghost" data-history-copy="${idx}" title="copy flake ref">cp</button>
+              </span>
+            </li>`;
+        })
+        .join('');
+
+      $$('#drawerList [data-history-copy]').forEach((b) => {
+        b.addEventListener('click', async () => {
+          const v = versions[parseInt(b.dataset.historyCopy, 10)];
+          if (!v) return;
+          b.textContent = '…';
+          try {
+            const hash = await fetchFirstHash(r.attr, v.version);
+            const synth = {
+              attr: r.attr,
+              hash,
+              last: v.last_seen,
+              insecure: v.is_insecure ? ['insecure'] : null,
+              legacy: predatesFlakes(v.last_seen),
+            };
+            copy(buildFlakeCmd(synth));
+          } catch (e) {
+            showToast(`error · ${e.message}`);
+          } finally {
+            b.textContent = 'cp';
+          }
+        });
+      });
+    } catch (e) {
+      cache('drawerCount').textContent = '';
+      cache('drawerList').innerHTML = `
+        <li class="px-3 py-4 mono text-[12px] text-[var(--color-red-glow)]">error · ${escapeHtml(e.message)}</li>`;
+    }
+  }
+
+  function closeDrawer() {
+    const drawer = cache('drawerOverlay');
+    drawer.classList.add('hidden');
+    drawer.classList.remove('flex');
+  }
+
+  async function fetchHistory(attr) {
+    if (STATE.historyCache.has(attr)) return STATE.historyCache.get(attr);
+    const { json } = await api(`${API_BASE}/packages/${encodeURIComponent(attr)}/history?limit=100`);
+    const versions = (json.data || []).slice();
+    STATE.historyCache.set(attr, versions);
+    return versions;
+  }
+
+  async function fetchFirstHash(attr, version) {
+    const key = `${attr}::${version}`;
+    if (STATE.firstHashCache.has(key)) return STATE.firstHashCache.get(key);
+    const { json } = await api(
+      `${API_BASE}/packages/${encodeURIComponent(attr)}/versions/${encodeURIComponent(version)}/first`,
+    );
+    const hash = json?.data?.first_commit_hash || '';
+    STATE.firstHashCache.set(key, hash);
+    return hash;
+  }
+
+  function drawTimeline(history) {
+    const axisStart = new Date('2017-01-01').getTime();
+    const axisEnd = new Date(Date.now() + 30 * 24 * 3600e3).getTime();
+    const span = Math.max(1, axisEnd - axisStart);
+    const el = cache('timelineViz');
+    const rows = history.slice(0, 12);
+    const rowH = 10;
+    const gap = 2;
+    const totalH = Math.max(rows.length * (rowH + gap), 100);
+    const svgNS = 'http://www.w3.org/2000/svg';
+    el.innerHTML = '';
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', `0 0 1000 ${totalH}`);
+    svg.setAttribute('preserveAspectRatio', 'none');
+    svg.style.width = '100%';
+    svg.style.height = `${totalH}px`;
+
+    const yearEnd = new Date(axisEnd).getUTCFullYear();
+    for (let y = 2017; y <= yearEnd; y++) {
+      const x = ((new Date(`${y}-01-01`).getTime()) - axisStart) / span * 1000;
+      const line = document.createElementNS(svgNS, 'line');
+      line.setAttribute('x1', x);
+      line.setAttribute('x2', x);
+      line.setAttribute('y1', 0);
+      line.setAttribute('y2', totalH);
+      line.setAttribute('stroke', 'var(--color-ink-3)');
+      line.setAttribute('stroke-dasharray', '2 4');
+      line.setAttribute('stroke-width', '1');
+      svg.appendChild(line);
+    }
+
+    const flakeX = ((FLAKES_EPOCH.getTime()) - axisStart) / span * 1000;
+    const flakeLine = document.createElementNS(svgNS, 'line');
+    flakeLine.setAttribute('x1', flakeX);
+    flakeLine.setAttribute('x2', flakeX);
+    flakeLine.setAttribute('y1', 0);
+    flakeLine.setAttribute('y2', totalH);
+    flakeLine.setAttribute('stroke', 'var(--color-amber-glow)');
+    flakeLine.setAttribute('stroke-dasharray', '3 3');
+    flakeLine.setAttribute('stroke-width', '1');
+    flakeLine.setAttribute('opacity', '0.5');
+    svg.appendChild(flakeLine);
+
+    rows.forEach((v, i) => {
+      const x1 = Math.max(0, (new Date(v.first_seen).getTime() - axisStart) / span * 1000);
+      const x2 = Math.min(1000, (new Date(v.last_seen).getTime() - axisStart) / span * 1000);
+      const w = Math.max(2, x2 - x1);
+      const y = i * (rowH + gap);
+      const rect = document.createElementNS(svgNS, 'rect');
+      rect.setAttribute('x', x1);
+      rect.setAttribute('y', y);
+      rect.setAttribute('width', w);
+      rect.setAttribute('height', rowH);
+      rect.setAttribute('rx', '1');
+      rect.setAttribute('fill', v.is_insecure ? 'var(--color-red-glow)' : 'var(--color-nix-500)');
+      rect.setAttribute('opacity', v.is_insecure ? '0.75' : '0.85');
+      svg.appendChild(rect);
+      if (w > 30) {
+        const label = document.createElementNS(svgNS, 'text');
+        label.setAttribute('x', Math.min(980, x2 + 4));
+        label.setAttribute('y', y + rowH - 1.5);
+        label.setAttribute('font-family', 'JetBrains Mono');
+        label.setAttribute('font-size', '8.5');
+        label.setAttribute('fill', 'var(--color-fog-3)');
+        label.textContent = v.version;
+        svg.appendChild(label);
+      }
+    });
+
+    el.appendChild(svg);
+  }
+
+  // ---------- stats / header populate ----------
+  async function loadBoot() {
+    // fetch health + stats in parallel
+    const samples = [];
+    const tHealth = performance.now();
+    const healthP = api(`${API_BASE}/health`)
+      .then(({ json, latency }) => {
+        samples.push(latency);
+        STATE.health = json;
+      })
+      .catch(() => {});
+    const statsP = api(`${API_BASE}/stats`)
+      .then(({ json, latency }) => {
+        samples.push(latency);
+        STATE.stats = json.data || json;
+      })
+      .catch(() => {});
+    await Promise.all([healthP, statsP]);
+
+    // one more health ping to stabilize a small latency sample
+    try {
+      const { latency } = await api(`${API_BASE}/health`);
+      samples.push(latency);
+    } catch {}
+
+    renderHeaderStrip(samples);
+    renderHeroStats();
+    renderLatencyCard(samples);
+    renderUptimeCard();
+    renderSelfhostCard();
+  }
+
+  function renderHeaderStrip(samples) {
+    const stats = STATE.stats;
+    const health = STATE.health;
+    const strip = document.querySelector('header .h-6');
+    if (!strip) return;
+
+    const p50 = samples.length ? Math.round(samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]) : null;
+    const operational = !!health;
+    const dot = operational
+      ? '<span class="inline-block w-1.5 h-1.5 rounded-full" style="background: var(--color-green-glow); box-shadow: 0 0 6px oklch(0.74 0.15 150 / 0.6);"></span>'
+      : '<span class="inline-block w-1.5 h-1.5 rounded-full" style="background: var(--color-red-glow); box-shadow: 0 0 6px oklch(0.66 0.19 25 / 0.6);"></span>';
+    const opTxt = operational ? 'api operational' : 'api unreachable';
+
+    const lastDate = stats?.last_indexed_date ? fmtDate(stats.last_indexed_date) : '—';
+    const commit = health?.index_commit || stats?.last_indexed_commit || '';
+    const oldest = stats?.oldest_commit_date ? new Date(stats.oldest_commit_date).toISOString().slice(0, 7) : '—';
+    const newest = stats?.newest_commit_date ? new Date(stats.newest_commit_date).toISOString().slice(0, 7) : '—';
+
+    strip.innerHTML = `
+      <span class="flex items-center gap-1.5">
+        ${dot}
+        ${opTxt}${p50 != null ? ` · p50 ${p50}ms` : ''}
+      </span>
+      <span class="text-[var(--color-ink-4)]">│</span>
+      <span>index · <span class="text-[var(--color-fog-2)]">${lastDate}</span>${commit ? ` · commit <span class="text-[var(--color-fog-2)]">${shortHash(commit)}</span>` : ''}</span>
+      <span class="text-[var(--color-ink-4)]">│</span>
+      <span>nixpkgs · <span class="text-[var(--color-fog-2)]">${oldest} → ${newest}</span></span>
+      <span class="flex-1"></span>
+      <span class="hidden md:inline">press <span class="kbd">/</span> to focus</span>`;
+
+    // version tag in hero line — find by its original text
+    const heroVer = [...document.querySelectorAll('main .mono')].find((el) =>
+      el.textContent.includes('NIX VERSION INDEX'),
+    );
+    if (heroVer && health?.version) {
+      heroVer.innerHTML = `// NIX VERSION INDEX &nbsp;·&nbsp; v${escapeHtml(health.version)}`;
+    }
+  }
+
+  function renderHeroStats() {
+    const s = STATE.stats;
+    const aside = document.querySelector('aside.mono.select-none');
+    if (!aside || !s) return;
+    const oldest = s.oldest_commit_date ? new Date(s.oldest_commit_date) : null;
+    const newest = s.newest_commit_date ? new Date(s.newest_commit_date) : null;
+    const years = oldest && newest
+      ? Math.max(1, Math.round((newest - oldest) / (365.25 * 24 * 3600e3)))
+      : null;
+    const histTxt = years != null ? `${years}+ yrs` : '—';
+    aside.innerHTML = `
+      <div class="ascii-rule text-[10px] leading-none mb-2">┌─ INDEX STATS ──────────────────────┐</div>
+      <div class="grid grid-cols-2 gap-x-6 gap-y-1 px-3">
+        <span>packages</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">${fmtNum(s.unique_names)}</span>
+        <span>versions</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">${fmtNum(s.unique_versions)}</span>
+        <span>records</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">${fmtNum(s.total_ranges)}</span>
+        <span>latest</span><span class="text-right text-[var(--color-fog-0)] tabular-nums mono">${s.last_indexed_commit ? '#' + shortHash(s.last_indexed_commit) : '—'}</span>
+        <span>history</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">${histTxt}</span>
+      </div>
+      <div class="ascii-rule text-[10px] leading-none mt-2">└────────────────────────────────────┘</div>`;
+  }
+
+  function renderLatencyCard(samples) {
+    const panel = document.querySelectorAll('#stats .panel')[1];
+    if (!panel) return;
+    // Find the big latency readout by its distinctive tabular-nums class;
+    // there is only one such element inside the latency panel.
+    const main = [...panel.querySelectorAll('.tabular-nums')][0];
+    if (samples.length < 1) {
+      if (main) main.textContent = '—';
+      return;
+    }
+    const sorted = [...samples].sort((a, b) => a - b);
+    const p = (q) => Math.round(sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))] || 0);
+    const p50 = p(0.5);
+    const p95 = p(0.95);
+    const p99 = p(0.99);
+    if (main) {
+      main.innerHTML = `
+        ${p50}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+        <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
+        ${p95}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+        <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
+        ${p99}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>`;
+    }
+    const sub = panel.querySelector('.mt-5');
+    if (sub) {
+      const s = STATE.stats;
+      sub.innerHTML = `
+        records indexed · <span class="text-[var(--color-fog-0)]">${fmtNum(s?.total_ranges)}</span><br/>
+        packages · <span class="text-[var(--color-fog-0)]">${fmtNum(s?.unique_names)}</span>`;
+    }
+  }
+
+  function renderUptimeCard() {
+    // no historical metric available; show a stable synthesized 30-bar sparkline
+    // seeded on the commit hash so it is stable per-index
+    const seed = (STATE.stats?.last_indexed_commit || 'nxv').split('').reduce((a, c) => (a * 31 + c.charCodeAt(0)) >>> 0, 7);
+    let s = seed;
+    const rand = () => {
+      s = (s * 1103515245 + 12345) & 0x7fffffff;
+      return s / 0x7fffffff;
+    };
+    const bars = Array.from({ length: 30 }).map(() => {
+      const ok = rand() > 0.02;
+      const h = ok ? 28 + rand() * 26 : 8 + rand() * 12;
+      return `<span class="inline-block rounded-[1px] transition" style="width:6px; height:${h.toFixed(1)}px; background:${ok ? 'var(--color-green-glow)' : 'var(--color-amber-glow)'}; opacity:${ok ? (0.55 + (h / 54) * 0.4).toFixed(2) : 0.9};"></span>`;
+    }).join('');
+    cache('uptimeBars').innerHTML = bars;
+  }
+
+  function renderSelfhostCard() {
+    const panel = document.querySelectorAll('#stats .panel')[2];
+    if (!panel) return;
+    const link = panel.querySelector('a.btn');
+    if (link) {
+      link.href = 'https://github.com/utensils/nxv#readme';
+      link.target = '_blank';
+      link.rel = 'noopener';
+    }
+  }
+
+  // ---------- command palette ----------
+  const PALETTE_ITEMS = [
+    { cat: 'jump', label: 'python',     hint: 'popular package', action: () => runExample('python') },
+    { cat: 'jump', label: 'nodejs',     hint: 'popular package', action: () => runExample('nodejs') },
+    { cat: 'jump', label: 'ruby',       hint: 'popular package', action: () => runExample('ruby') },
+    { cat: 'jump', label: 'gcc',        hint: 'toolchain',        action: () => runExample('gcc') },
+    { cat: 'jump', label: 'postgresql', hint: 'databases',        action: () => runExample('postgresql') },
+    { cat: 'jump', label: 'ffmpeg',     hint: 'media',            action: () => runExample('ffmpeg') },
+    { cat: 'cmd',  label: 'toggle exact match',        hint: 'filter', action: () => { cycleFilter('exact'); renderFilterChips(); runSearch(); } },
+    { cat: 'cmd',  label: 'include insecure packages', hint: 'filter', action: () => { cycleFilter('includeInsecure'); renderFilterChips(); runSearch(); } },
+    { cat: 'cmd',  label: 'sort by name',  hint: 'sort', action: () => { STATE.filters.sort = 'name'; renderFilterChips(); runSearch(); } },
+    { cat: 'cmd',  label: 'sort by date',  hint: 'sort', action: () => { STATE.filters.sort = 'date'; renderFilterChips(); runSearch(); } },
+    { cat: 'cmd',  label: 'sort by version', hint: 'sort', action: () => { STATE.filters.sort = 'version'; renderFilterChips(); runSearch(); } },
+    { cat: 'cmd',  label: 'clear filters', hint: 'reset', action: () => { STATE.filters = { exact: false, version: '', arch: '', license: '', sort: 'date', includeInsecure: false }; renderFilterChips(); runSearch(); } },
+    { cat: 'go',   label: 'open api docs',   hint: '/docs',         action: () => { window.location.href = '/docs'; } },
+    { cat: 'go',   label: 'openapi spec',    hint: '/openapi.json', action: () => { window.open('/openapi.json', '_blank'); } },
+    { cat: 'go',   label: 'github',          hint: 'source',        action: () => window.open('https://github.com/utensils/nxv', '_blank') },
+    { cat: 'go',   label: 'install guide',   hint: 'readme',        action: () => window.open('https://github.com/utensils/nxv#readme', '_blank') },
+  ];
+  let paletteIndex = 0;
+  let paletteItems = [];
+
+  function openPalette() {
+    const p = cache('palette');
+    p.classList.remove('hidden');
+    p.classList.add('flex');
+    const input = cache('paletteInput');
+    input.value = '';
+    input.focus();
+    renderPalette('');
+  }
+  function closePalette() {
+    const p = cache('palette');
+    p.classList.add('hidden');
+    p.classList.remove('flex');
+  }
+  function renderPalette(q) {
+    q = q.trim().toLowerCase();
+    paletteItems = PALETTE_ITEMS.filter((it) => !q || it.label.toLowerCase().includes(q) || it.cat.includes(q));
+    // add ad-hoc "search for q" entry if user typed something
+    if (q) {
+      paletteItems.unshift({
+        cat: 'run',
+        label: `search: ${q}`,
+        hint: '/api/v1/search',
+        action: () => {
+          STATE.query = q;
+          cache('searchInput').value = q;
+          runSearch();
+        },
+      });
+    }
+    paletteIndex = 0;
+    cache('paletteList').innerHTML = paletteItems
+      .map((it, i) => `
+        <li data-idx="${i}" class="palette-item px-4 py-2 flex items-center gap-3 cursor-pointer mono text-[12.5px] ${i === 0 ? 'bg-[var(--color-ink-2)]' : ''}">
+          <span class="chip" style="min-width: 36px; justify-content: center;">${escapeHtml(it.cat)}</span>
+          <span class="text-[var(--color-fog-0)]">${escapeHtml(it.label)}</span>
+          <span class="text-[var(--color-fog-4)]">${escapeHtml(it.hint)}</span>
+          <span class="flex-1"></span>
+          ${i === 0 ? '<span class="mono text-[10px] text-[var(--color-fog-4)]">↵ select</span>' : ''}
+        </li>
+      `)
+      .join('');
+    $$('#paletteList .palette-item').forEach((el, i) => {
+      el.addEventListener('click', () => { paletteItems[i].action(); closePalette(); });
+      el.addEventListener('mouseenter', () => { paletteIndex = i; highlightPalette(); });
+    });
+  }
+  function highlightPalette() {
+    $$('#paletteList .palette-item').forEach((el, i) => {
+      el.classList.toggle('bg-[var(--color-ink-2)]', i === paletteIndex);
+    });
+  }
+
+  // ---------- wiring ----------
+  function runExample(q) {
+    STATE.query = q;
+    cache('searchInput').value = q;
+    runSearch();
+    window.scrollTo({ top: cache('resultsSection').offsetTop - 80, behavior: 'smooth' });
+  }
+
+  function wire() {
+    let t;
+    cache('searchInput').addEventListener('input', (e) => {
+      clearTimeout(t);
+      STATE.query = e.target.value;
+      t = setTimeout(() => runSearch(), 220);
+    });
+    cache('searchInput').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { clearTimeout(t); runSearch(); }
+    });
+
+    $$('.chip[data-filter]').forEach((el) => {
+      el.addEventListener('click', () => {
+        const k = el.dataset.filter;
+        cycleFilter(k === 'include-insecure' ? 'includeInsecure' : k);
+        renderFilterChips();
+        runSearch();
+      });
+    });
+
+    $$('.chip.example').forEach((el) => {
+      el.addEventListener('click', () => runExample(el.textContent.trim()));
+    });
+
+    $$('[data-view]').forEach((el) => {
+      el.addEventListener('click', () => {
+        $$('[data-view]').forEach((o) => {
+          o.classList.remove('hairline');
+          o.classList.remove('text-[var(--color-fog-0)]');
+          o.classList.add('text-[var(--color-fog-4)]');
+        });
+        el.classList.add('hairline');
+        el.classList.add('text-[var(--color-fog-0)]');
+        el.classList.remove('text-[var(--color-fog-4)]');
+        STATE.view = el.dataset.view;
+      });
+    });
+
+    $$('[data-close]').forEach((el) => el.addEventListener('click', closeDrawer));
+
+    cache('paletteTrigger').addEventListener('click', openPalette);
+    $$('[data-palette-close]').forEach((el) => el.addEventListener('click', closePalette));
+    cache('paletteInput').addEventListener('input', (e) => renderPalette(e.target.value));
+    cache('paletteInput').addEventListener('keydown', (e) => {
+      const items = $$('#paletteList .palette-item');
+      if (e.key === 'ArrowDown') { e.preventDefault(); paletteIndex = Math.min(items.length - 1, paletteIndex + 1); highlightPalette(); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); paletteIndex = Math.max(0, paletteIndex - 1); highlightPalette(); }
+      else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (items[paletteIndex]) items[paletteIndex].click();
+      }
+    });
+
+    window.addEventListener('keydown', (e) => {
+      const inField = ['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName);
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault(); openPalette();
+      } else if (e.key === '/' && !inField) {
+        e.preventDefault(); cache('searchInput').focus();
+      } else if (e.key === 'Escape') {
+        closePalette(); closeDrawer();
+      }
+    });
+  }
+
+  // ---------- init ----------
+  wire();
+  renderFilterChips();
+  renderWelcome();
+  loadBoot();
+})();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -58,7 +58,10 @@
   const predatesFlakes = (d) => (d ? new Date(d) < FLAKES_EPOCH : false);
   const shortHash = (h) => (h || '').slice(0, 7);
   const escapeHtml = (s) =>
-    String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+    String(s ?? '').replace(
+      /[&<>"']/g,
+      (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+    );
 
   function parseJsonArrayOrString(s) {
     if (s == null || s === '') return [];
@@ -219,12 +222,7 @@
         const label = el.textContent.split(':')[0].trim();
         el.innerHTML = `${label}: <span class="ml-1 text-[var(--color-fog-0)]">${labels[k]()}</span>`;
         const v = STATE.filters[k];
-        const isActive =
-          k === 'exact'
-            ? STATE.filters.exact
-            : k === 'sort'
-            ? v !== 'date'
-            : !!v;
+        const isActive = k === 'exact' ? STATE.filters.exact : k === 'sort' ? v !== 'date' : !!v;
         el.classList.toggle('active', !!isActive);
       }
     });
@@ -254,8 +252,7 @@
 
     // empty query + no filters → show welcome
     const noQuery = !STATE.query.trim();
-    const noFilters =
-      !STATE.filters.version && !STATE.filters.arch && !STATE.filters.license;
+    const noFilters = !STATE.filters.version && !STATE.filters.arch && !STATE.filters.license;
     if (noQuery && noFilters) {
       renderWelcome();
       return;
@@ -274,13 +271,14 @@
 
       // client-side filters that the API doesn't support: arch, includeInsecure
       let filtered = items;
-      if (STATE.filters.arch) filtered = filtered.filter((r) => r.platforms.includes(STATE.filters.arch));
+      if (STATE.filters.arch)
+        filtered = filtered.filter((r) => r.platforms.includes(STATE.filters.arch));
       if (!STATE.filters.includeInsecure) filtered = filtered.filter((r) => !r.insecure);
 
       render(filtered);
       setResultsStatus(
         `results / ${fmtNum(meta.total)}${filtered.length !== items.length ? ` (${filtered.length} shown)` : ''}`,
-        `${(latency / 1000).toFixed(3)}s · api`,
+        `${(latency / 1000).toFixed(3)}s · api`
       );
       renderPagination(meta);
     } catch (e) {
@@ -314,7 +312,7 @@
     renderPagination({ total: 0, has_more: false });
     // rewire welcome example chips
     $$('#resultsBody .chip.example').forEach((el) =>
-      el.addEventListener('click', () => runExample(el.textContent.trim())),
+      el.addEventListener('click', () => runExample(el.textContent.trim()))
     );
   }
 
@@ -348,7 +346,8 @@
         const r = rowByAttrVer.get(key);
         if (!r) return;
         if (action === 'copy-flake') copy(buildFlakeCmd(r));
-        else if (action === 'copy-run') copy(`nix run nixpkgs/${shortHash(r.hash || r.lastHash)}#${r.attr}`);
+        else if (action === 'copy-run')
+          copy(`nix run nixpkgs/${shortHash(r.hash || r.lastHash)}#${r.attr}`);
         else if (action === 'history') openDrawer(r);
       });
     });
@@ -365,7 +364,9 @@
     const flags = [];
     if (r.insecure) {
       const title = escapeHtml(r.insecure.join(' · '));
-      flags.push(`<span class="chip danger" title="${title}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4M12 16h.01"/></svg>insecure</span>`);
+      flags.push(
+        `<span class="chip danger" title="${title}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M12 8v4M12 16h.01"/></svg>insecure</span>`
+      );
     }
     if (isLegacy) flags.push(`<span class="chip warn">pre-flakes</span>`);
 
@@ -455,9 +456,11 @@
     drawer.classList.remove('hidden');
     drawer.classList.add('flex');
     cache('drawerTitle').textContent = `${r.name} · ${r.attr}`;
-    cache('drawerSub').innerHTML = `${escapeHtml(r.desc || '—')} <span class="text-[var(--color-ink-4)]">│</span> ${escapeHtml(r.license || '—')}`;
+    cache('drawerSub').innerHTML =
+      `${escapeHtml(r.desc || '—')} <span class="text-[var(--color-ink-4)]">│</span> ${escapeHtml(r.license || '—')}`;
     cache('drawerCount').textContent = '…';
-    cache('drawerList').innerHTML = `<li class="px-3 py-4 mono text-[12px] text-[var(--color-fog-4)]">loading version history…</li>`;
+    cache('drawerList').innerHTML =
+      `<li class="px-3 py-4 mono text-[12px] text-[var(--color-fog-4)]">loading version history…</li>`;
     cache('timelineViz').innerHTML = '';
 
     try {
@@ -470,8 +473,8 @@
           const tag = v.is_insecure
             ? ' text-[var(--color-red-glow)]'
             : legacy
-            ? ' text-[var(--color-amber-glow)]'
-            : ' text-[var(--color-fog-0)]';
+              ? ' text-[var(--color-amber-glow)]'
+              : ' text-[var(--color-fog-0)]';
           return `
             <li class="grid grid-cols-[minmax(90px,auto)_1fr_auto] items-center gap-4 px-3 py-2 rounded-[2px] hover:bg-[var(--color-ink-2)] transition">
               <span class="mono text-[12.5px]${tag} tabular-nums">${escapeHtml(v.version)}</span>
@@ -522,7 +525,9 @@
 
   async function fetchHistory(attr) {
     if (STATE.historyCache.has(attr)) return STATE.historyCache.get(attr);
-    const { json } = await api(`${API_BASE}/packages/${encodeURIComponent(attr)}/history?limit=100`);
+    const { json } = await api(
+      `${API_BASE}/packages/${encodeURIComponent(attr)}/history?limit=100`
+    );
     const versions = (json.data || []).slice();
     STATE.historyCache.set(attr, versions);
     return versions;
@@ -532,7 +537,7 @@
     const key = `${attr}::${version}`;
     if (STATE.firstHashCache.has(key)) return STATE.firstHashCache.get(key);
     const { json } = await api(
-      `${API_BASE}/packages/${encodeURIComponent(attr)}/versions/${encodeURIComponent(version)}/first`,
+      `${API_BASE}/packages/${encodeURIComponent(attr)}/versions/${encodeURIComponent(version)}/first`
     );
     const hash = json?.data?.first_commit_hash || '';
     STATE.firstHashCache.set(key, hash);
@@ -577,9 +582,7 @@
       const stride = Math.max(1, Math.ceil(years.length / maxTicks));
       const shown = years.filter((_, i) => i % stride === 0);
       if (shown[shown.length - 1] !== years[years.length - 1]) shown.push(years[years.length - 1]);
-      ticksEl.innerHTML = shown
-        .map((y) => `<span>'${String(y).slice(2)}</span>`)
-        .join('');
+      ticksEl.innerHTML = shown.map((y) => `<span>'${String(y).slice(2)}</span>`).join('');
     }
 
     const rows = history.slice(0, 12);
@@ -594,7 +597,7 @@
     svg.style.height = `${totalH}px`;
 
     for (let y = startYear; y <= endYear; y++) {
-      const x = ((new Date(Date.UTC(y, 0, 1)).getTime()) - axisStart) / axisSpan * 1000;
+      const x = ((new Date(Date.UTC(y, 0, 1)).getTime() - axisStart) / axisSpan) * 1000;
       if (x < 0 || x > 1000) continue;
       const line = document.createElementNS(svgNS, 'line');
       line.setAttribute('x1', x);
@@ -623,8 +626,8 @@
     }
 
     rows.forEach((v, i) => {
-      const x1 = Math.max(0, (new Date(v.first_seen).getTime() - axisStart) / axisSpan * 1000);
-      const x2 = Math.min(1000, (new Date(v.last_seen).getTime() - axisStart) / axisSpan * 1000);
+      const x1 = Math.max(0, ((new Date(v.first_seen).getTime() - axisStart) / axisSpan) * 1000);
+      const x2 = Math.min(1000, ((new Date(v.last_seen).getTime() - axisStart) / axisSpan) * 1000);
       const w = Math.max(2, x2 - x1);
       const y = i * (rowH + gap);
       const rect = document.createElementNS(svgNS, 'rect');
@@ -700,8 +703,12 @@
 
     const lastDate = stats?.last_indexed_date ? fmtDate(stats.last_indexed_date) : '—';
     const commit = health?.index_commit || stats?.last_indexed_commit || '';
-    const oldest = stats?.oldest_commit_date ? new Date(stats.oldest_commit_date).toISOString().slice(0, 7) : '—';
-    const newest = stats?.newest_commit_date ? new Date(stats.newest_commit_date).toISOString().slice(0, 7) : '—';
+    const oldest = stats?.oldest_commit_date
+      ? new Date(stats.oldest_commit_date).toISOString().slice(0, 7)
+      : '—';
+    const newest = stats?.newest_commit_date
+      ? new Date(stats.newest_commit_date).toISOString().slice(0, 7)
+      : '—';
 
     strip.innerHTML = `
       <span id="headerStatus" class="flex items-center gap-1.5">
@@ -717,7 +724,7 @@
 
     // version tag in hero line — find by its original text
     const heroVer = [...document.querySelectorAll('main .mono')].find((el) =>
-      el.textContent.includes('NIX VERSION INDEX'),
+      el.textContent.includes('NIX VERSION INDEX')
     );
     if (heroVer && health?.version) {
       heroVer.innerHTML = `// NIX VERSION INDEX &nbsp;·&nbsp; v${escapeHtml(health.version)}`;
@@ -741,9 +748,8 @@
     if (!aside || !s) return;
     const oldest = s.oldest_commit_date ? new Date(s.oldest_commit_date) : null;
     const newest = s.newest_commit_date ? new Date(s.newest_commit_date) : null;
-    const years = oldest && newest
-      ? Math.max(1, Math.round((newest - oldest) / (365.25 * 24 * 3600e3)))
-      : null;
+    const years =
+      oldest && newest ? Math.max(1, Math.round((newest - oldest) / (365.25 * 24 * 3600e3))) : null;
     const histTxt = years != null ? `${years}+ yrs` : '—';
     aside.innerHTML = `
       <div class="ascii-rule text-[10px] leading-none mb-2">┌─ INDEX STATS ──────────────────────┐</div>
@@ -779,9 +785,10 @@
     const sub = panel.querySelector('.mt-5');
     if (sub) {
       const s = STATE.stats;
-      const sampleTxt = lat?.samples > 0
-        ? `from <span class="text-[var(--color-fog-0)]">${fmtNum(lat.samples)}</span> recent api requests`
-        : `awaiting traffic`;
+      const sampleTxt =
+        lat?.samples > 0
+          ? `from <span class="text-[var(--color-fog-0)]">${fmtNum(lat.samples)}</span> recent api requests`
+          : `awaiting traffic`;
       sub.innerHTML = `
         records indexed · <span class="text-[var(--color-fog-0)]">${fmtNum(s?.total_ranges)}</span><br/>
         ${sampleTxt}`;
@@ -834,22 +841,107 @@
 
   // ---------- command palette ----------
   const PALETTE_ITEMS = [
-    { cat: 'jump', label: 'python',     hint: 'popular package', action: () => runExample('python') },
-    { cat: 'jump', label: 'nodejs',     hint: 'popular package', action: () => runExample('nodejs') },
-    { cat: 'jump', label: 'ruby',       hint: 'popular package', action: () => runExample('ruby') },
-    { cat: 'jump', label: 'gcc',        hint: 'toolchain',        action: () => runExample('gcc') },
-    { cat: 'jump', label: 'postgresql', hint: 'databases',        action: () => runExample('postgresql') },
-    { cat: 'jump', label: 'ffmpeg',     hint: 'media',            action: () => runExample('ffmpeg') },
-    { cat: 'cmd',  label: 'toggle exact match',        hint: 'filter', action: () => { cycleFilter('exact'); renderFilterChips(); runSearch(); } },
-    { cat: 'cmd',  label: 'include insecure packages', hint: 'filter', action: () => { cycleFilter('includeInsecure'); renderFilterChips(); runSearch(); } },
-    { cat: 'cmd',  label: 'sort by name',  hint: 'sort', action: () => { STATE.filters.sort = 'name'; renderFilterChips(); runSearch(); } },
-    { cat: 'cmd',  label: 'sort by date',  hint: 'sort', action: () => { STATE.filters.sort = 'date'; renderFilterChips(); runSearch(); } },
-    { cat: 'cmd',  label: 'sort by version', hint: 'sort', action: () => { STATE.filters.sort = 'version'; renderFilterChips(); runSearch(); } },
-    { cat: 'cmd',  label: 'clear filters', hint: 'reset', action: () => { STATE.filters = { exact: false, version: '', arch: '', license: '', sort: 'date', includeInsecure: false }; renderFilterChips(); runSearch(); } },
-    { cat: 'go',   label: 'open api docs',   hint: '/docs',         action: () => { window.location.href = '/docs'; } },
-    { cat: 'go',   label: 'openapi spec',    hint: '/openapi.json', action: () => { window.open('/openapi.json', '_blank'); } },
-    { cat: 'go',   label: 'github',          hint: 'source',        action: () => window.open('https://github.com/utensils/nxv', '_blank') },
-    { cat: 'go',   label: 'install guide',   hint: 'docs',          action: () => window.open('https://utensils.io/nxv/', '_blank') },
+    { cat: 'jump', label: 'python', hint: 'popular package', action: () => runExample('python') },
+    { cat: 'jump', label: 'nodejs', hint: 'popular package', action: () => runExample('nodejs') },
+    { cat: 'jump', label: 'ruby', hint: 'popular package', action: () => runExample('ruby') },
+    { cat: 'jump', label: 'gcc', hint: 'toolchain', action: () => runExample('gcc') },
+    { cat: 'jump', label: 'postgresql', hint: 'databases', action: () => runExample('postgresql') },
+    { cat: 'jump', label: 'ffmpeg', hint: 'media', action: () => runExample('ffmpeg') },
+    {
+      cat: 'cmd',
+      label: 'toggle exact match',
+      hint: 'filter',
+      action: () => {
+        cycleFilter('exact');
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'cmd',
+      label: 'include insecure packages',
+      hint: 'filter',
+      action: () => {
+        cycleFilter('includeInsecure');
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'cmd',
+      label: 'sort by name',
+      hint: 'sort',
+      action: () => {
+        STATE.filters.sort = 'name';
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'cmd',
+      label: 'sort by date',
+      hint: 'sort',
+      action: () => {
+        STATE.filters.sort = 'date';
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'cmd',
+      label: 'sort by version',
+      hint: 'sort',
+      action: () => {
+        STATE.filters.sort = 'version';
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'cmd',
+      label: 'clear filters',
+      hint: 'reset',
+      action: () => {
+        STATE.filters = {
+          exact: false,
+          version: '',
+          arch: '',
+          license: '',
+          sort: 'date',
+          includeInsecure: false,
+        };
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'go',
+      label: 'open api docs',
+      hint: '/docs',
+      action: () => {
+        window.location.href = '/docs';
+      },
+    },
+    {
+      cat: 'go',
+      label: 'openapi spec',
+      hint: '/openapi.json',
+      action: () => {
+        window.open('/openapi.json', '_blank');
+      },
+    },
+    {
+      cat: 'go',
+      label: 'github',
+      hint: 'source',
+      action: () => window.open('https://github.com/utensils/nxv', '_blank'),
+    },
+    {
+      cat: 'go',
+      label: 'install guide',
+      hint: 'docs',
+      action: () => window.open('https://utensils.io/nxv/', '_blank'),
+    },
   ];
   let paletteIndex = 0;
   let paletteItems = [];
@@ -870,7 +962,9 @@
   }
   function renderPalette(q) {
     q = q.trim().toLowerCase();
-    paletteItems = PALETTE_ITEMS.filter((it) => !q || it.label.toLowerCase().includes(q) || it.cat.includes(q));
+    paletteItems = PALETTE_ITEMS.filter(
+      (it) => !q || it.label.toLowerCase().includes(q) || it.cat.includes(q)
+    );
     // add ad-hoc "search for q" entry if user typed something
     if (q) {
       paletteItems.unshift({
@@ -886,7 +980,8 @@
     }
     paletteIndex = 0;
     cache('paletteList').innerHTML = paletteItems
-      .map((it, i) => `
+      .map(
+        (it, i) => `
         <li data-idx="${i}" class="palette-item px-4 py-2 flex items-center gap-3 cursor-pointer mono text-[12.5px] ${i === 0 ? 'bg-[var(--color-ink-2)]' : ''}">
           <span class="chip" style="min-width: 36px; justify-content: center;">${escapeHtml(it.cat)}</span>
           <span class="text-[var(--color-fog-0)]">${escapeHtml(it.label)}</span>
@@ -894,11 +989,18 @@
           <span class="flex-1"></span>
           ${i === 0 ? '<span class="mono text-[10px] text-[var(--color-fog-4)]">↵ select</span>' : ''}
         </li>
-      `)
+      `
+      )
       .join('');
     $$('#paletteList .palette-item').forEach((el, i) => {
-      el.addEventListener('click', () => { paletteItems[i].action(); closePalette(); });
-      el.addEventListener('mouseenter', () => { paletteIndex = i; highlightPalette(); });
+      el.addEventListener('click', () => {
+        paletteItems[i].action();
+        closePalette();
+      });
+      el.addEventListener('mouseenter', () => {
+        paletteIndex = i;
+        highlightPalette();
+      });
     });
   }
   function highlightPalette() {
@@ -923,7 +1025,10 @@
       t = setTimeout(() => runSearch(), 220);
     });
     cache('searchInput').addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { clearTimeout(t); runSearch(); }
+      if (e.key === 'Enter') {
+        clearTimeout(t);
+        runSearch();
+      }
     });
 
     $$('.chip[data-filter]').forEach((el) => {
@@ -961,9 +1066,15 @@
     cache('paletteInput').addEventListener('input', (e) => renderPalette(e.target.value));
     cache('paletteInput').addEventListener('keydown', (e) => {
       const items = $$('#paletteList .palette-item');
-      if (e.key === 'ArrowDown') { e.preventDefault(); paletteIndex = Math.min(items.length - 1, paletteIndex + 1); highlightPalette(); }
-      else if (e.key === 'ArrowUp') { e.preventDefault(); paletteIndex = Math.max(0, paletteIndex - 1); highlightPalette(); }
-      else if (e.key === 'Enter') {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        paletteIndex = Math.min(items.length - 1, paletteIndex + 1);
+        highlightPalette();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        paletteIndex = Math.max(0, paletteIndex - 1);
+        highlightPalette();
+      } else if (e.key === 'Enter') {
         e.preventDefault();
         if (items[paletteIndex]) items[paletteIndex].click();
       }
@@ -972,11 +1083,14 @@
     window.addEventListener('keydown', (e) => {
       const inField = ['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName);
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-        e.preventDefault(); openPalette();
+        e.preventDefault();
+        openPalette();
       } else if (e.key === '/' && !inField) {
-        e.preventDefault(); cache('searchInput').focus();
+        e.preventDefault();
+        cache('searchInput').focus();
       } else if (e.key === 'Escape') {
-        closePalette(); closeDrawer();
+        closePalette();
+        closeDrawer();
       }
     });
   }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -576,43 +576,45 @@
 
   // ---------- stats / header populate ----------
   async function loadBoot() {
-    // fetch health + stats in parallel
-    const samples = [];
-    const tHealth = performance.now();
     const healthP = api(`${API_BASE}/health`)
-      .then(({ json, latency }) => {
-        samples.push(latency);
+      .then(({ json }) => {
         STATE.health = json;
       })
       .catch(() => {});
     const statsP = api(`${API_BASE}/stats`)
-      .then(({ json, latency }) => {
-        samples.push(latency);
+      .then(({ json }) => {
         STATE.stats = json.data || json;
       })
       .catch(() => {});
     await Promise.all([healthP, statsP]);
 
-    // one more health ping to stabilize a small latency sample
-    try {
-      const { latency } = await api(`${API_BASE}/health`);
-      samples.push(latency);
-    } catch {}
-
-    renderHeaderStrip(samples);
+    await refreshMetrics();
+    renderHeaderStrip();
     renderHeroStats();
-    renderLatencyCard(samples);
-    renderUptimeCard();
     renderSelfhostCard();
+
+    // keep metrics live — cheap in-memory query, no db work
+    setInterval(refreshMetrics, 30_000);
   }
 
-  function renderHeaderStrip(samples) {
+  async function refreshMetrics() {
+    try {
+      const { json } = await api(`${API_BASE}/metrics`);
+      STATE.metrics = json;
+      renderActivityCard(json);
+      renderLatencyCard(json);
+      refreshHeaderLatency(json);
+    } catch {
+      // leave previous values in place if a poll fails
+    }
+  }
+
+  function renderHeaderStrip() {
     const stats = STATE.stats;
     const health = STATE.health;
     const strip = document.querySelector('header .h-6');
     if (!strip) return;
 
-    const p50 = samples.length ? Math.round(samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]) : null;
     const operational = !!health;
     const dot = operational
       ? '<span class="inline-block w-1.5 h-1.5 rounded-full" style="background: var(--color-green-glow); box-shadow: 0 0 6px oklch(0.74 0.15 150 / 0.6);"></span>'
@@ -625,9 +627,9 @@
     const newest = stats?.newest_commit_date ? new Date(stats.newest_commit_date).toISOString().slice(0, 7) : '—';
 
     strip.innerHTML = `
-      <span class="flex items-center gap-1.5">
+      <span id="headerStatus" class="flex items-center gap-1.5">
         ${dot}
-        ${opTxt}${p50 != null ? ` · p50 ${p50}ms` : ''}
+        ${opTxt}
       </span>
       <span class="text-[var(--color-ink-4)]">│</span>
       <span>index · <span class="text-[var(--color-fog-2)]">${lastDate}</span>${commit ? ` · commit <span class="text-[var(--color-fog-2)]">${shortHash(commit)}</span>` : ''}</span>
@@ -643,6 +645,17 @@
     if (heroVer && health?.version) {
       heroVer.innerHTML = `// NIX VERSION INDEX &nbsp;·&nbsp; v${escapeHtml(health.version)}`;
     }
+  }
+
+  function refreshHeaderLatency(metrics) {
+    const el = document.getElementById('headerStatus');
+    const p50 = metrics?.latency?.p50_ms;
+    if (!el || p50 == null) return;
+    const dot = el.querySelector('span') || null;
+    const dotHtml = dot ? dot.outerHTML : '';
+    const operational = STATE.health ? 'api operational' : 'api unreachable';
+    const latencyTxt = metrics.latency.samples > 0 ? ` · p50 ${p50.toFixed(1)}ms` : '';
+    el.innerHTML = `${dotHtml} ${operational}${latencyTxt}`;
   }
 
   function renderHeroStats() {
@@ -667,53 +680,68 @@
       <div class="ascii-rule text-[10px] leading-none mt-2">└────────────────────────────────────┘</div>`;
   }
 
-  function renderLatencyCard(samples) {
+  function renderLatencyCard(metrics) {
     const panel = document.querySelectorAll('#stats .panel')[1];
     if (!panel) return;
-    // Find the big latency readout by its distinctive tabular-nums class;
-    // there is only one such element inside the latency panel.
+    // The big three-number readout is the first .tabular-nums inside the panel.
     const main = [...panel.querySelectorAll('.tabular-nums')][0];
-    if (samples.length < 1) {
-      if (main) main.textContent = '—';
-      return;
-    }
-    const sorted = [...samples].sort((a, b) => a - b);
-    const p = (q) => Math.round(sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))] || 0);
-    const p50 = p(0.5);
-    const p95 = p(0.95);
-    const p99 = p(0.99);
+    const lat = metrics?.latency;
     if (main) {
-      main.innerHTML = `
-        ${p50}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
-        <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
-        ${p95}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
-        <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
-        ${p99}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>`;
+      if (!lat || lat.samples === 0) {
+        main.innerHTML = `<span class="text-[var(--color-fog-4)] text-[18px]">waiting for samples…</span>`;
+      } else {
+        const fmt = (v) => (v < 10 ? v.toFixed(1) : Math.round(v));
+        main.innerHTML = `
+          ${fmt(lat.p50_ms)}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+          <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
+          ${fmt(lat.p95_ms)}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+          <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
+          ${fmt(lat.p99_ms)}<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>`;
+      }
     }
     const sub = panel.querySelector('.mt-5');
     if (sub) {
       const s = STATE.stats;
+      const sampleTxt = lat?.samples > 0
+        ? `from <span class="text-[var(--color-fog-0)]">${fmtNum(lat.samples)}</span> recent api requests`
+        : `awaiting traffic`;
       sub.innerHTML = `
         records indexed · <span class="text-[var(--color-fog-0)]">${fmtNum(s?.total_ranges)}</span><br/>
-        packages · <span class="text-[var(--color-fog-0)]">${fmtNum(s?.unique_names)}</span>`;
+        ${sampleTxt}`;
     }
   }
 
-  function renderUptimeCard() {
-    // no historical metric available; show a stable synthesized 30-bar sparkline
-    // seeded on the commit hash so it is stable per-index
-    const seed = (STATE.stats?.last_indexed_commit || 'nxv').split('').reduce((a, c) => (a * 31 + c.charCodeAt(0)) >>> 0, 7);
-    let s = seed;
-    const rand = () => {
-      s = (s * 1103515245 + 12345) & 0x7fffffff;
-      return s / 0x7fffffff;
-    };
-    const bars = Array.from({ length: 30 }).map(() => {
-      const ok = rand() > 0.02;
-      const h = ok ? 28 + rand() * 26 : 8 + rand() * 12;
-      return `<span class="inline-block rounded-[1px] transition" style="width:6px; height:${h.toFixed(1)}px; background:${ok ? 'var(--color-green-glow)' : 'var(--color-amber-glow)'}; opacity:${ok ? (0.55 + (h / 54) * 0.4).toFixed(2) : 0.9};"></span>`;
-    }).join('');
-    cache('uptimeBars').innerHTML = bars;
+  function renderActivityCard(metrics) {
+    const buckets = metrics?.activity || [];
+    const counts = buckets.map((b) => b.count || 0);
+    const max = Math.max(1, ...counts);
+    const bars = counts
+      .map((c) => {
+        const h = c === 0 ? 3 : 6 + (c / max) * 48;
+        const idle = c === 0;
+        return `<span class="inline-block rounded-[1px] transition" style="width:6px; height:${h.toFixed(1)}px; background:${idle ? 'var(--color-ink-4)' : 'var(--color-green-glow)'}; opacity:${idle ? 0.5 : (0.55 + (h / 54) * 0.4).toFixed(2)};" title="${c} req${c === 1 ? '' : 's'}"></span>`;
+      })
+      .join('');
+    cache('activityBars').innerHTML = bars;
+
+    const summary = document.getElementById('activitySummary');
+    if (summary) {
+      const total = metrics?.runtime?.total_requests ?? 0;
+      const uptime = fmtDuration(metrics?.runtime?.uptime_seconds ?? 0);
+      summary.innerHTML = `uptime <span class="text-[var(--color-fog-0)]">${uptime}</span> · <span class="text-[var(--color-fog-0)]">${fmtNum(total)}</span> req${total === 1 ? '' : 's'}`;
+    }
+  }
+
+  function fmtDuration(totalSeconds) {
+    if (!Number.isFinite(totalSeconds) || totalSeconds < 0) return '—';
+    const s = Math.floor(totalSeconds);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m ${s % 60}s`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ${m % 60}m`;
+    const d = Math.floor(h / 24);
+    return `${d}d ${h % 24}h`;
   }
 
   function renderSelfhostCard() {
@@ -721,7 +749,7 @@
     if (!panel) return;
     const link = panel.querySelector('a.btn');
     if (link) {
-      link.href = 'https://github.com/utensils/nxv#readme';
+      link.href = 'https://utensils.io/nxv/';
       link.target = '_blank';
       link.rel = 'noopener';
     }
@@ -744,7 +772,7 @@
     { cat: 'go',   label: 'open api docs',   hint: '/docs',         action: () => { window.location.href = '/docs'; } },
     { cat: 'go',   label: 'openapi spec',    hint: '/openapi.json', action: () => { window.open('/openapi.json', '_blank'); } },
     { cat: 'go',   label: 'github',          hint: 'source',        action: () => window.open('https://github.com/utensils/nxv', '_blank') },
-    { cat: 'go',   label: 'install guide',   hint: 'readme',        action: () => window.open('https://github.com/utensils/nxv#readme', '_blank') },
+    { cat: 'go',   label: 'install guide',   hint: 'docs',          action: () => window.open('https://utensils.io/nxv/', '_blank') },
   ];
   let paletteIndex = 0;
   let paletteItems = [];

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -142,6 +142,42 @@
       : `${insecurePrefix}nix shell${impure} nixpkgs/${ref}#${r.attr}`;
   }
 
+  // ---------- URL state (refresh-safe, shareable) ----------
+  function serializeState() {
+    const p = new URLSearchParams();
+    if (STATE.query) p.set('q', STATE.query);
+    if (STATE.filters.exact) p.set('exact', '1');
+    if (STATE.filters.version) p.set('version', STATE.filters.version);
+    if (STATE.filters.arch) p.set('arch', STATE.filters.arch);
+    if (STATE.filters.license) p.set('license', STATE.filters.license);
+    if (STATE.filters.sort && STATE.filters.sort !== 'date') p.set('sort', STATE.filters.sort);
+    if (STATE.filters.includeInsecure) p.set('insecure', '1');
+    if (STATE.view && STATE.view !== 'rows') p.set('view', STATE.view);
+    if (STATE.page > 1) p.set('page', String(STATE.page));
+    return p;
+  }
+
+  function syncUrl() {
+    const qs = serializeState().toString();
+    const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+    // replaceState so every keystroke doesn't bloat browser history
+    window.history.replaceState(null, '', url);
+  }
+
+  function hydrateFromUrl() {
+    const p = new URLSearchParams(window.location.search);
+    STATE.query = p.get('q') || '';
+    STATE.filters.exact = p.get('exact') === '1';
+    STATE.filters.version = p.get('version') || '';
+    STATE.filters.arch = p.get('arch') || '';
+    STATE.filters.license = p.get('license') || '';
+    STATE.filters.sort = p.get('sort') || 'date';
+    STATE.filters.includeInsecure = p.get('insecure') === '1';
+    STATE.view = p.get('view') || 'rows';
+    const pg = parseInt(p.get('page') || '1', 10);
+    STATE.page = Number.isFinite(pg) && pg > 0 ? pg : 1;
+  }
+
   // ---------- query parsing ----------
   function parseQuery(q) {
     const m = q.trim().match(/^(.+?)\s+(v?\d[\d.]*[\w.-]*)$/i);
@@ -213,6 +249,7 @@
 
   async function runSearch(opts = {}) {
     if (opts.resetPage !== false) STATE.page = 1;
+    syncUrl();
     const seq = ++STATE.reqSeq;
 
     // empty query + no filters → show welcome
@@ -873,6 +910,7 @@
         el.classList.add('text-[var(--color-fog-0)]');
         el.classList.remove('text-[var(--color-fog-4)]');
         STATE.view = el.dataset.view;
+        syncUrl();
       });
     });
 
@@ -903,9 +941,39 @@
     });
   }
 
+  function applyViewToggleStyles() {
+    $$('[data-view]').forEach((o) => {
+      const active = o.dataset.view === STATE.view;
+      o.classList.toggle('hairline', active);
+      o.classList.toggle('text-[var(--color-fog-0)]', active);
+      o.classList.toggle('text-[var(--color-fog-4)]', !active);
+    });
+  }
+
+  function hasActiveState() {
+    const f = STATE.filters;
+    return !!(
+      STATE.query ||
+      f.version ||
+      f.arch ||
+      f.license ||
+      (f.sort && f.sort !== 'date') ||
+      f.exact ||
+      f.includeInsecure ||
+      STATE.page > 1
+    );
+  }
+
   // ---------- init ----------
+  hydrateFromUrl();
   wire();
+  cache('searchInput').value = STATE.query;
   renderFilterChips();
-  renderWelcome();
+  applyViewToggleStyles();
+  if (hasActiveState()) {
+    runSearch({ resetPage: false });
+  } else {
+    renderWelcome();
+  }
   loadBoot();
 })();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -413,7 +413,7 @@
         <div class="flex items-center justify-end gap-1 opacity-70 group-hover:opacity-100 transition">
           <button class="btn btn-ghost" data-action="copy-flake" data-key="${escapeHtml(key)}" title="copy flake ref">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-            cp
+            copy
           </button>
           <button class="btn btn-ghost" data-action="history" data-key="${escapeHtml(key)}" title="version history">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -479,7 +479,7 @@
               <span class="flex items-center gap-2">
                 ${v.is_insecure ? '<span class="chip danger" style="font-size:10px; padding:1px 5px;">insecure</span>' : ''}
                 ${legacy ? '<span class="chip warn" style="font-size:10px; padding:1px 5px;">pre-flakes</span>' : ''}
-                <button class="btn btn-ghost" data-history-copy="${idx}" title="copy flake ref">cp</button>
+                <button class="btn btn-ghost" data-history-copy="${idx}" title="copy flake ref">copy</button>
               </span>
             </li>`;
         })
@@ -503,7 +503,7 @@
           } catch (e) {
             showToast(`error · ${e.message}`);
           } finally {
-            b.textContent = 'cp';
+            b.textContent = 'copy';
           }
         });
       });

--- a/frontend/favicon.svg
+++ b/frontend/favicon.svg
@@ -1,187 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg
-   width="535"
-   height="535"
-   viewBox="0 0 501.56251 501.56249"
-   id="svg2"
-   version="1.1"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   sodipodi:docname="nix-snowflake-colours.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <defs
-     id="defs4">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5562">
-      <stop
-         style="stop-color:#699ad7;stop-opacity:1"
-         offset="0"
-         id="stop5564" />
-      <stop
-         id="stop5566"
-         offset="0.24345198"
-         style="stop-color:#7eb1dd;stop-opacity:1" />
-      <stop
-         style="stop-color:#7ebae4;stop-opacity:1"
-         offset="1"
-         id="stop5568" />
+
+<svg width="535" height="535" viewBox="0 0 501.56251 501.56249" id="svg2" version="1.1" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)" xmlns:sodipodi-0.dtd="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" sodipodi-0.dtd:docname="nix-snowflake-colours.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs id="defs4">
+    <linearGradient inkscape:collect="always" id="linearGradient5562">
+      <stop style="stop-color:#699ad7;stop-opacity:1" offset="0" id="stop5564"></stop>
+      <stop id="stop5566" offset="0.24345198" style="stop-color:#7eb1dd;stop-opacity:1"></stop>
+      <stop style="stop-color:#7ebae4;stop-opacity:1" offset="1" id="stop5568"></stop>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5053">
-      <stop
-         style="stop-color:#415e9a;stop-opacity:1"
-         offset="0"
-         id="stop5055" />
-      <stop
-         id="stop5057"
-         offset="0.23168644"
-         style="stop-color:#4a6baf;stop-opacity:1" />
-      <stop
-         style="stop-color:#5277c3;stop-opacity:1"
-         offset="1"
-         id="stop5059" />
+    <linearGradient inkscape:collect="always" id="linearGradient5053">
+      <stop style="stop-color:#415e9a;stop-opacity:1" offset="0" id="stop5055"></stop>
+      <stop id="stop5057" offset="0.23168644" style="stop-color:#4a6baf;stop-opacity:1"></stop>
+      <stop style="stop-color:#5277c3;stop-opacity:1" offset="1" id="stop5059"></stop>
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5562"
-       id="linearGradient4328"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(70.650339,-1055.1511)"
-       x1="200.59668"
-       y1="351.41116"
-       x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5053"
-       id="linearGradient4330"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(864.69589,-1491.3405)"
-       x1="-584.19934"
-       y1="782.33563"
-       x2="-496.29703"
-       y2="937.71399" />
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5562" id="linearGradient4328" gradientUnits="userSpaceOnUse" gradientTransform="translate(70.650339,-1055.1511)" x1="200.59668" y1="351.41116" x2="290.08701" y2="506.18814"></linearGradient>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5053" id="linearGradient4330" gradientUnits="userSpaceOnUse" gradientTransform="translate(864.69589,-1491.3405)" x1="-584.19934" y1="782.33563" x2="-496.29703" y2="937.71399"></linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.70904368"
-     inkscape:cx="99.429699"
-     inkscape:cy="195.33352"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3"
-     showgrid="false"
-     inkscape:window-width="1920"
-     inkscape:window-height="1050"
-     inkscape:window-x="1920"
-     inkscape:window-y="30"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:showpageshadow="2"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1" />
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
+  <namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="0.70904368" inkscape:cx="99.429699" inkscape:cy="195.33352" inkscape:document-units="px" inkscape:current-layer="layer3" showgrid="false" inkscape:window-width="1920" inkscape:window-height="1050" inkscape:window-x="1920" inkscape:window-y="30" inkscape:window-maximized="1" inkscape:snap-global="true" fit-margin-top="0" fit-margin-left="0" fit-margin-right="0" fit-margin-bottom="0" inkscape:showpageshadow="2" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1"></namedview>
+  <metadata id="metadata7">
+    <RDF>
+      <Work xmlns:_="http://www.w3.org/1999/02/22-rdf-syntax-ns#" _:about="">
+        <format>image/svg+xml</format>
+        <type _:resource="http://purl.org/dc/dcmitype/StillImage"></type>
+      </Work>
+    </RDF>
   </metadata>
-  <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="gradient-logo"
-     style="display:inline;opacity:1"
-     transform="translate(-156.41121,933.30685)">
-    <g
-       id="g2"
-       transform="matrix(0.99994059,0,0,0.99994059,-0.06321798,33.188377)"
-       style="stroke-width:1.00006">
-      <path
-         sodipodi:nodetypes="cccccccccc"
-         inkscape:connector-curvature="0"
-         id="path3336-6"
-         d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
-         style="opacity:1;fill:url(#linearGradient4328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00018;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <use
-         height="100%"
-         width="100%"
-         transform="rotate(60,407.11155,-715.78724)"
-         id="use3439-6"
-         inkscape:transform-center-y="151.59082"
-         inkscape:transform-center-x="124.43045"
-         xlink:href="#path3336-6"
-         y="0"
-         x="0"
-         style="stroke-width:1.00006" />
-      <use
-         height="100%"
-         width="100%"
-         transform="rotate(-60,407.31177,-715.70016)"
-         id="use3445-0"
-         inkscape:transform-center-y="75.573958"
-         inkscape:transform-center-x="-168.20651"
-         xlink:href="#path3336-6"
-         y="0"
-         x="0"
-         style="stroke-width:1.00006" />
-      <use
-         height="100%"
-         width="100%"
-         transform="rotate(180,407.41868,-715.7565)"
-         id="use3449-5"
-         inkscape:transform-center-y="-139.94592"
-         inkscape:transform-center-x="59.669705"
-         xlink:href="#path3336-6"
-         y="0"
-         x="0"
-         style="stroke-width:1.00006" />
-      <path
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4330);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00018;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
-         id="path4260-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccc" />
-      <use
-         height="100%"
-         width="100%"
-         transform="rotate(120,407.33916,-716.08356)"
-         id="use4354-5"
-         xlink:href="#path4260-0"
-         y="0"
-         x="0"
-         style="display:inline;stroke-width:1.00006" />
-      <use
-         height="100%"
-         width="100%"
-         transform="rotate(-120,407.28823,-715.86995)"
-         id="use4362-2"
-         xlink:href="#path4260-0"
-         y="0"
-         x="0"
-         style="display:inline;stroke-width:1.00006" />
+  <g inkscape:groupmode="layer" id="layer3" inkscape:label="gradient-logo" style="display:inline;opacity:1" transform="translate(-156.41121,933.30685)">
+    <g id="g2" transform="matrix(0.99994059,0,0,0.99994059,-0.06321798,33.188377)" style="stroke-width:1.00006">
+      <path sodipodi-0.dtd:nodetypes="cccccccccc" inkscape:connector-curvature="0" id="path3336-6" d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z" style="opacity:1;fill:url(#linearGradient4328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00018;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"></path>
+      <use height="100%" width="100%" transform="rotate(60,407.11155,-715.78724)" id="use3439-6" inkscape:transform-center-y="151.59082" inkscape:transform-center-x="124.43045" xlink:href="#path3336-6" y="0" x="0" style="stroke-width:1.00006"></use>
+      <use height="100%" width="100%" transform="rotate(-60,407.31177,-715.70016)" id="use3445-0" inkscape:transform-center-y="75.573958" inkscape:transform-center-x="-168.20651" xlink:href="#path3336-6" y="0" x="0" style="stroke-width:1.00006"></use>
+      <use height="100%" width="100%" transform="rotate(180,407.41868,-715.7565)" id="use3449-5" inkscape:transform-center-y="-139.94592" inkscape:transform-center-x="59.669705" xlink:href="#path3336-6" y="0" x="0" style="stroke-width:1.00006"></use>
+      <path style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4330);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00018;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z" id="path4260-0" inkscape:connector-curvature="0" sodipodi-0.dtd:nodetypes="cccccccccc"></path>
+      <use height="100%" width="100%" transform="rotate(120,407.33916,-716.08356)" id="use4354-5" xlink:href="#path4260-0" y="0" x="0" style="display:inline;stroke-width:1.00006"></use>
+      <use height="100%" width="100%" transform="rotate(-120,407.28823,-715.86995)" id="use4362-2" xlink:href="#path4260-0" y="0" x="0" style="display:inline;stroke-width:1.00006"></use>
     </g>
   </g>
 </svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,8 +37,8 @@
         --color-fog-0: oklch(0.98 0.005 255);   /* pure text */
         --color-fog-1: oklch(0.88 0.01 255);    /* body text */
         --color-fog-2: oklch(0.72 0.012 255);   /* secondary */
-        --color-fog-3: oklch(0.56 0.014 255);   /* muted */
-        --color-fog-4: oklch(0.42 0.014 255);   /* very muted */
+        --color-fog-3: oklch(0.62 0.014 255);   /* muted — AA on ink-0/1/2 */
+        --color-fog-4: oklch(0.60 0.014 255);   /* very muted — AA on ink-0/1 */
 
         /* Nix blue family */
         --color-nix-300: oklch(0.82 0.08 255);
@@ -197,10 +197,24 @@
 
         /* Focus ring on interactive elements */
         :focus-visible { outline: 2px solid var(--color-nix-500); outline-offset: 2px; border-radius: 2px; }
+
+        /* Skip link — hidden until focused */
+        .skip-link {
+          position: absolute; top: 0; left: 0;
+          transform: translateY(-110%);
+          padding: 0.5rem 0.75rem;
+          font-family: var(--font-mono); font-size: 12px;
+          background: var(--color-nix-600); color: oklch(0.98 0.01 255);
+          border: 1px solid var(--color-nix-400);
+          border-radius: 2px; z-index: 100;
+          transition: transform 120ms ease;
+        }
+        .skip-link:focus { transform: translateY(0.5rem) translateX(0.5rem); }
       }
     </style>
   </head>
   <body class="min-h-screen">
+    <a class="skip-link" href="#main">Skip to main content</a>
     <!-- Top command bar -->
     <header class="hairline-b sticky top-0 z-30 backdrop-blur" style="background: color-mix(in oklch, var(--color-ink-0) 92%, transparent);">
       <div class="mx-auto max-w-[1320px] px-6 h-14 flex items-center gap-6">
@@ -226,13 +240,13 @@
         <div class="flex-1"></div>
 
         <button id="paletteTrigger" class="hidden sm:flex items-center gap-2 px-2.5 py-1.5 hairline rounded-[2px] mono text-[11px] text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
           <span>jump to…</span>
           <span class="kbd">⌘K</span>
         </button>
 
-        <a href="https://github.com/utensils/nxv" target="_blank" rel="noopener" class="p-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition" title="GitHub">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        <a href="https://github.com/utensils/nxv" target="_blank" rel="noopener" class="p-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition" aria-label="nxv on GitHub">
+          <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         </a>
       </div>
       <!-- Status strip -->
@@ -250,7 +264,7 @@
       </div>
     </header>
 
-    <main class="mx-auto max-w-[1320px] px-6 pb-32 relative">
+    <main id="main" tabindex="-1" class="mx-auto max-w-[1320px] px-6 pb-32 relative">
       <!-- Hero / search -->
       <section class="pt-10 md:pt-14">
         <div class="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-10 items-end">
@@ -292,9 +306,10 @@
             <span class="mono text-[13px] text-[var(--color-fog-3)] select-none hidden sm:inline">search</span>
             <input
               id="searchInput"
-              type="text"
+              type="search"
               autocomplete="off"
               autofocus
+              aria-label="Search nixpkgs by package and version"
               placeholder="python 2.7   •   nodejs 18   •   ruby 2.6   •   gcc 12.3"
               class="mono flex-1 bg-transparent border-0 outline-none text-[15px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]"
             />
@@ -411,14 +426,14 @@
     <!-- Version history drawer (right-side) -->
     <div id="drawerOverlay" class="fixed inset-0 z-40 hidden" aria-hidden="true">
       <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-close></div>
-      <aside class="absolute right-0 top-0 h-full w-full max-w-[640px] panel border-l overflow-y-auto flex flex-col" style="background: var(--color-ink-1)">
+      <div role="dialog" aria-modal="true" aria-labelledby="drawerTitle" class="absolute right-0 top-0 h-full w-full max-w-[640px] panel border-l overflow-y-auto flex flex-col" style="background: var(--color-ink-1)">
         <div class="sticky top-0 z-10 px-6 py-4 hairline-b flex items-start gap-4" style="background: var(--color-ink-1)">
           <div class="flex-1 min-w-0">
             <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">version history</div>
-            <h3 id="drawerTitle" class="mono text-[18px] font-semibold text-[var(--color-fog-0)] mt-1 truncate">—</h3>
+            <h2 id="drawerTitle" class="mono text-[18px] font-semibold text-[var(--color-fog-0)] mt-1 truncate">—</h2>
             <div id="drawerSub" class="mono text-[11px] text-[var(--color-fog-3)] mt-0.5">—</div>
           </div>
-          <button class="btn btn-ghost" data-close>esc ✕</button>
+          <button class="btn btn-ghost" data-close aria-label="Close version history">esc ✕</button>
         </div>
 
         <!-- Timeline visualization -->
@@ -435,16 +450,16 @@
           <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">all versions <span id="drawerCount" class="text-[var(--color-fog-2)]"></span></div>
           <ul id="drawerList" class="space-y-1"></ul>
         </div>
-      </aside>
+      </div>
     </div>
 
     <!-- Command palette -->
     <div id="palette" class="fixed inset-0 z-50 hidden items-start justify-center pt-[12vh] px-4" aria-hidden="true">
       <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-palette-close></div>
-      <div class="relative w-full max-w-[620px] panel rounded-[2px] overflow-hidden shadow-2xl">
+      <div role="dialog" aria-modal="true" aria-label="Command palette" class="relative w-full max-w-[620px] panel rounded-[2px] overflow-hidden shadow-2xl">
         <div class="flex items-center gap-3 h-12 px-4 hairline-b">
           <span class="mono text-[13px] text-[var(--color-nix-400)]">»</span>
-          <input id="paletteInput" placeholder="jump to package, run command, or search…" class="mono flex-1 bg-transparent outline-none text-[14px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]" />
+          <input id="paletteInput" type="search" aria-label="Command palette — jump to package or run command" placeholder="jump to package, run command, or search…" class="mono flex-1 bg-transparent outline-none text-[14px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]" />
           <span class="kbd">esc</span>
         </div>
         <ul id="paletteList" class="max-h-[50vh] overflow-y-auto py-1"></ul>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -447,11 +447,9 @@
 
         <!-- Timeline visualization -->
         <div class="px-6 py-5 hairline-b">
-          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">timeline · 2017 → 2026</div>
+          <div id="timelineLabel" class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">timeline</div>
           <div id="timelineViz" class="relative h-[120px]"></div>
-          <div class="mt-2 grid grid-cols-10 mono text-[10px] text-[var(--color-fog-4)] tabular-nums">
-            <span>'17</span><span>'18</span><span>'19</span><span>'20</span><span>'21</span><span>'22</span><span>'23</span><span>'24</span><span>'25</span><span class="text-right">'26</span>
-          </div>
+          <div id="timelineTicks" class="mt-2 flex justify-between mono text-[10px] text-[var(--color-fog-4)] tabular-nums"></div>
         </div>
 
         <!-- Version list -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,11 +34,11 @@
         --color-ink-4: oklch(0.34 0.014 255);   /* border */
         --color-ink-5: oklch(0.48 0.013 255);   /* muted line */
 
-        --color-fog-0: oklch(0.98 0.005 255);   /* pure text */
-        --color-fog-1: oklch(0.88 0.01 255);    /* body text */
-        --color-fog-2: oklch(0.76 0.012 255);   /* secondary */
-        --color-fog-3: oklch(0.70 0.014 255);   /* muted — AA on ink-0/1/2 */
-        --color-fog-4: oklch(0.64 0.014 255);   /* very muted — AA on ink-0/1/2 */
+        --color-fog-0: oklch(0.99 0.003 255);   /* pure text */
+        --color-fog-1: oklch(0.93 0.008 255);   /* body text */
+        --color-fog-2: oklch(0.82 0.012 255);   /* secondary */
+        --color-fog-3: oklch(0.76 0.014 255);   /* muted — AAA on ink-0/1 */
+        --color-fog-4: oklch(0.70 0.014 255);   /* very muted — AA+ on ink-0/1/2 */
 
         /* Nix blue family */
         --color-nix-300: oklch(0.82 0.08 255);
@@ -197,6 +197,15 @@
 
         /* Focus ring on interactive elements */
         :focus-visible { outline: 2px solid var(--color-nix-500); outline-offset: 2px; border-radius: 2px; }
+
+        /* Softer dim for modal backdrops — tints toward the page ink
+           rather than pitch-black, with a gentle blur so the content
+           stays visible but clearly out of focus. */
+        .overlay-dim {
+          background: color-mix(in oklch, var(--color-ink-0) 55%, transparent);
+          backdrop-filter: blur(10px) saturate(130%);
+          -webkit-backdrop-filter: blur(10px) saturate(130%);
+        }
 
         /* Skip link — hidden until focused */
         .skip-link {
@@ -425,9 +434,9 @@
 
     <!-- Version history drawer (right-side) -->
     <div id="drawerOverlay" class="fixed inset-0 z-40 hidden" aria-hidden="true">
-      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-close></div>
-      <div role="dialog" aria-modal="true" aria-labelledby="drawerTitle" class="absolute right-0 top-0 h-full w-full max-w-[640px] panel border-l overflow-y-auto flex flex-col" style="background: var(--color-ink-1)">
-        <div class="sticky top-0 z-10 px-6 py-4 hairline-b flex items-start gap-4" style="background: var(--color-ink-1)">
+      <div class="absolute inset-0 overlay-dim" data-close></div>
+      <div role="dialog" aria-modal="true" aria-labelledby="drawerTitle" class="absolute right-0 top-0 h-full w-full max-w-[640px] border-l overflow-y-auto flex flex-col shadow-2xl" style="background: var(--color-ink-2); border-color: var(--color-ink-4)">
+        <div class="sticky top-0 z-10 px-6 py-4 hairline-b flex items-start gap-4" style="background: var(--color-ink-2)">
           <div class="flex-1 min-w-0">
             <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">version history</div>
             <h2 id="drawerTitle" class="mono text-[18px] font-semibold text-[var(--color-fog-0)] mt-1 truncate">—</h2>
@@ -455,7 +464,7 @@
 
     <!-- Command palette -->
     <div id="palette" class="fixed inset-0 z-50 hidden items-start justify-center pt-[12vh] px-4" aria-hidden="true">
-      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-palette-close></div>
+      <div class="absolute inset-0 overlay-dim" data-palette-close></div>
       <div role="dialog" aria-modal="true" aria-label="Command palette" class="relative w-full max-w-[620px] panel rounded-[2px] overflow-hidden shadow-2xl">
         <div class="flex items-center gap-3 h-12 px-4 hairline-b">
           <span class="mono text-[13px] text-[var(--color-nix-400)]">»</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -220,7 +220,7 @@
           <a class="px-2.5 py-1.5 text-[var(--color-fog-0)] hairline rounded-[2px]" href="/">search</a>
           <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="#stats">stats</a>
           <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="/docs">api</a>
-          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="https://github.com/utensils/nxv#installation">cli</a>
+          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="https://utensils.io/nxv/">cli</a>
         </nav>
 
         <div class="flex-1"></div>
@@ -367,13 +367,10 @@
       <!-- Stats / about -->
       <section id="stats" class="mt-24 grid grid-cols-1 md:grid-cols-3 gap-4">
         <div class="panel rounded-[2px] p-5 relative scanlines">
-          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">uptime · 30d</div>
-          <div class="mt-3 flex items-end gap-1 h-14">
-            <!-- 30 mini bars -->
-          </div>
-          <div id="uptimeBars" class="flex items-end gap-[3px] h-14 mt-3"></div>
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">activity · 30m</div>
+          <div id="activityBars" class="flex items-end gap-[3px] h-14 mt-3"></div>
           <div class="mt-3 flex justify-between mono text-[10.5px] text-[var(--color-fog-3)]">
-            <span>30d</span><span class="text-[var(--color-green-glow)]">99.97% up</span><span>now</span>
+            <span>30m ago</span><span id="activitySummary" class="text-[var(--color-green-glow)]">—</span><span>now</span>
           </div>
         </div>
         <div class="panel rounded-[2px] p-5">
@@ -394,7 +391,7 @@
           <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">self-host</div>
           <pre class="mt-3 mono text-[12px] text-[var(--color-fog-1)] leading-relaxed whitespace-pre-wrap select-all">nix run github:utensils/nxv \
   -- serve --host 0.0.0.0</pre>
-          <a href="#" class="mt-4 btn w-full justify-center">read the guide →</a>
+          <a href="https://utensils.io/nxv/" target="_blank" rel="noopener" class="mt-4 btn w-full justify-center">read the guide →</a>
         </div>
       </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark" style="background: oklch(0.14 0.012 255);">
+<html lang="en" class="dark" style="background: oklch(0.14 0.012 255)">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,10 +7,14 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <style>
       /* Applied immediately — before Tailwind CDN finishes loading, to avoid FOUC */
-      html, body {
+      html,
+      body {
         background: oklch(0.14 0.012 255);
         color: oklch(0.88 0.01 255);
         margin: 0;
@@ -27,18 +31,18 @@
         --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
 
         /* Deep, slightly cool ink — oklch for clean tonal steps */
-        --color-ink-0: oklch(0.14 0.012 255);   /* page bg */
-        --color-ink-1: oklch(0.175 0.012 255);  /* panel */
-        --color-ink-2: oklch(0.215 0.013 255);  /* elevated */
-        --color-ink-3: oklch(0.27 0.014 255);   /* hover */
-        --color-ink-4: oklch(0.34 0.014 255);   /* border */
-        --color-ink-5: oklch(0.48 0.013 255);   /* muted line */
+        --color-ink-0: oklch(0.14 0.012 255); /* page bg */
+        --color-ink-1: oklch(0.175 0.012 255); /* panel */
+        --color-ink-2: oklch(0.215 0.013 255); /* elevated */
+        --color-ink-3: oklch(0.27 0.014 255); /* hover */
+        --color-ink-4: oklch(0.34 0.014 255); /* border */
+        --color-ink-5: oklch(0.48 0.013 255); /* muted line */
 
-        --color-fog-0: oklch(0.99 0.003 255);   /* pure text */
-        --color-fog-1: oklch(0.93 0.008 255);   /* body text */
-        --color-fog-2: oklch(0.82 0.012 255);   /* secondary */
-        --color-fog-3: oklch(0.76 0.014 255);   /* muted — AAA on ink-0/1 */
-        --color-fog-4: oklch(0.70 0.014 255);   /* very muted — AA+ on ink-0/1/2 */
+        --color-fog-0: oklch(0.99 0.003 255); /* pure text */
+        --color-fog-1: oklch(0.93 0.008 255); /* body text */
+        --color-fog-2: oklch(0.82 0.012 255); /* secondary */
+        --color-fog-3: oklch(0.76 0.014 255); /* muted — AAA on ink-0/1 */
+        --color-fog-4: oklch(0.7 0.014 255); /* very muted — AA+ on ink-0/1/2 */
 
         /* Nix blue family */
         --color-nix-300: oklch(0.82 0.08 255);
@@ -49,7 +53,7 @@
 
         /* Phosphor/CRT secondary — cool cyan */
         --color-phos-400: oklch(0.78 0.12 195);
-        --color-phos-500: oklch(0.70 0.14 198);
+        --color-phos-500: oklch(0.7 0.14 198);
 
         /* Warn & danger */
         --color-amber-glow: oklch(0.78 0.14 80);
@@ -58,29 +62,58 @@
       }
 
       @layer base {
-        html { scrollbar-color: var(--color-ink-4) transparent; }
+        html {
+          scrollbar-color: var(--color-ink-4) transparent;
+        }
         body {
           background: var(--color-ink-0);
           color: var(--color-fog-1);
           font-family: var(--font-sans);
-          font-feature-settings: "ss01", "cv11";
+          font-feature-settings: 'ss01', 'cv11';
           -webkit-font-smoothing: antialiased;
         }
-        ::selection { background: oklch(0.55 0.17 262 / 0.4); color: var(--color-fog-0); }
+        ::selection {
+          background: oklch(0.55 0.17 262 / 0.4);
+          color: var(--color-fog-0);
+        }
         /* Hairline, dense scrollbar */
-        ::-webkit-scrollbar { width: 10px; height: 10px; }
-        ::-webkit-scrollbar-track { background: transparent; }
-        ::-webkit-scrollbar-thumb { background: var(--color-ink-3); border: 2px solid var(--color-ink-0); border-radius: 6px; }
-        ::-webkit-scrollbar-thumb:hover { background: var(--color-ink-4); }
+        ::-webkit-scrollbar {
+          width: 10px;
+          height: 10px;
+        }
+        ::-webkit-scrollbar-track {
+          background: transparent;
+        }
+        ::-webkit-scrollbar-thumb {
+          background: var(--color-ink-3);
+          border: 2px solid var(--color-ink-0);
+          border-radius: 6px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+          background: var(--color-ink-4);
+        }
       }
 
       @layer components {
-        .mono { font-family: var(--font-mono); font-feature-settings: "ss01", "zero"; }
-        .hairline { box-shadow: inset 0 0 0 1px var(--color-ink-4); }
-        .hairline-b { border-bottom: 1px solid var(--color-ink-4); }
-        .hairline-t { border-top: 1px solid var(--color-ink-4); }
-        .hairline-r { border-right: 1px solid var(--color-ink-4); }
-        .hairline-l { border-left: 1px solid var(--color-ink-4); }
+        .mono {
+          font-family: var(--font-mono);
+          font-feature-settings: 'ss01', 'zero';
+        }
+        .hairline {
+          box-shadow: inset 0 0 0 1px var(--color-ink-4);
+        }
+        .hairline-b {
+          border-bottom: 1px solid var(--color-ink-4);
+        }
+        .hairline-t {
+          border-top: 1px solid var(--color-ink-4);
+        }
+        .hairline-r {
+          border-right: 1px solid var(--color-ink-4);
+        }
+        .hairline-l {
+          border-left: 1px solid var(--color-ink-4);
+        }
 
         /* Terminal prompt bar */
         .prompt-shell {
@@ -95,7 +128,7 @@
 
         /* Subtle scanline flourish — very faint */
         .scanlines::before {
-          content: "";
+          content: '';
           position: absolute;
           inset: 0;
           pointer-events: none;
@@ -121,7 +154,9 @@
 
         /* Badge / chip */
         .chip {
-          display: inline-flex; align-items: center; gap: 0.35rem;
+          display: inline-flex;
+          align-items: center;
+          gap: 0.35rem;
           padding: 0.125rem 0.5rem;
           font-family: var(--font-mono);
           font-size: 11px;
@@ -154,7 +189,9 @@
         }
 
         .btn {
-          display: inline-flex; align-items: center; gap: 0.4rem;
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
           padding: 0.35rem 0.65rem;
           font-family: var(--font-mono);
           font-size: 12px;
@@ -165,10 +202,23 @@
           cursor: pointer;
           transition: all 120ms ease;
         }
-        .btn:hover { border-color: var(--color-fog-4); background: var(--color-ink-3); color: var(--color-fog-0); }
-        .btn-primary { background: var(--color-nix-600); color: oklch(0.98 0.01 255); border-color: var(--color-nix-500); }
-        .btn-primary:hover { background: var(--color-nix-500); color: white; }
-        .btn-ghost { background: transparent; }
+        .btn:hover {
+          border-color: var(--color-fog-4);
+          background: var(--color-ink-3);
+          color: var(--color-fog-0);
+        }
+        .btn-primary {
+          background: var(--color-nix-600);
+          color: oklch(0.98 0.01 255);
+          border-color: var(--color-nix-500);
+        }
+        .btn-primary:hover {
+          background: var(--color-nix-500);
+          color: white;
+        }
+        .btn-ghost {
+          background: transparent;
+        }
 
         .kbd {
           font-family: var(--font-mono);
@@ -182,21 +232,47 @@
           line-height: 1.4;
         }
 
-        .panel { background: var(--color-ink-1); border: 1px solid var(--color-ink-4); }
+        .panel {
+          background: var(--color-ink-1);
+          border: 1px solid var(--color-ink-4);
+        }
 
         /* Blinking caret */
-        @keyframes caret { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
-        .caret-blink { animation: caret 1.1s steps(1) infinite; }
+        @keyframes caret {
+          0%,
+          49% {
+            opacity: 1;
+          }
+          50%,
+          100% {
+            opacity: 0;
+          }
+        }
+        .caret-blink {
+          animation: caret 1.1s steps(1) infinite;
+        }
 
         /* Subtle enter animation for result rows */
         @keyframes slideUp {
-          from { opacity: 0; transform: translateY(4px); }
-          to { opacity: 1; transform: translateY(0); }
+          from {
+            opacity: 0;
+            transform: translateY(4px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
         }
-        .anim-in { animation: slideUp 220ms ease-out backwards; }
+        .anim-in {
+          animation: slideUp 220ms ease-out backwards;
+        }
 
         /* Focus ring on interactive elements */
-        :focus-visible { outline: 2px solid var(--color-nix-500); outline-offset: 2px; border-radius: 2px; }
+        :focus-visible {
+          outline: 2px solid var(--color-nix-500);
+          outline-offset: 2px;
+          border-radius: 2px;
+        }
 
         /* Softer dim for modal backdrops — tints toward the page ink
            rather than pitch-black, with a light blur so the content
@@ -209,67 +285,170 @@
 
         /* Skip link — hidden until focused */
         .skip-link {
-          position: absolute; top: 0; left: 0;
+          position: absolute;
+          top: 0;
+          left: 0;
           transform: translateY(-110%);
           padding: 0.5rem 0.75rem;
-          font-family: var(--font-mono); font-size: 12px;
-          background: var(--color-nix-600); color: oklch(0.98 0.01 255);
+          font-family: var(--font-mono);
+          font-size: 12px;
+          background: var(--color-nix-600);
+          color: oklch(0.98 0.01 255);
           border: 1px solid var(--color-nix-400);
-          border-radius: 2px; z-index: 100;
+          border-radius: 2px;
+          z-index: 100;
           transition: transform 120ms ease;
         }
-        .skip-link:focus { transform: translateY(0.5rem) translateX(0.5rem); }
+        .skip-link:focus {
+          transform: translateY(0.5rem) translateX(0.5rem);
+        }
       }
     </style>
   </head>
   <body class="min-h-screen">
     <a class="skip-link" href="#main">Skip to main content</a>
     <!-- Top command bar -->
-    <header class="hairline-b sticky top-0 z-30 backdrop-blur" style="background: color-mix(in oklch, var(--color-ink-0) 92%, transparent);">
+    <header
+      class="hairline-b sticky top-0 z-30 backdrop-blur"
+      style="background: color-mix(in oklch, var(--color-ink-0) 92%, transparent)"
+    >
       <div class="mx-auto max-w-[1320px] px-6 h-14 flex items-center gap-6">
         <a href="https://github.com/utensils/nxv" class="flex items-center gap-2.5 group">
           <!-- Monogram mark: nested brackets cradling the wordmark -->
-          <svg width="38" height="38" viewBox="0 0 38 38" class="text-[var(--color-nix-400)]" aria-hidden="true">
-            <path d="M4 6 L4 32 M4 6 L10 6 M4 32 L10 32" stroke="currentColor" stroke-width="1.75" stroke-linecap="square" fill="none"/>
-            <path d="M34 6 L34 32 M34 6 L28 6 M34 32 L28 32" stroke="currentColor" stroke-width="1.75" stroke-linecap="square" fill="none"/>
-            <text x="19" y="23.5" text-anchor="middle" font-family="JetBrains Mono" font-size="12.5" font-weight="700" fill="currentColor" letter-spacing="-0.3">nxv</text>
+          <svg
+            width="38"
+            height="38"
+            viewBox="0 0 38 38"
+            class="text-[var(--color-nix-400)]"
+            aria-hidden="true"
+          >
+            <path
+              d="M4 6 L4 32 M4 6 L10 6 M4 32 L10 32"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="square"
+              fill="none"
+            />
+            <path
+              d="M34 6 L34 32 M34 6 L28 6 M34 32 L28 32"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="square"
+              fill="none"
+            />
+            <text
+              x="19"
+              y="23.5"
+              text-anchor="middle"
+              font-family="JetBrains Mono"
+              font-size="12.5"
+              font-weight="700"
+              fill="currentColor"
+              letter-spacing="-0.3"
+            >
+              nxv
+            </text>
           </svg>
           <span class="mono text-[13px] text-[var(--color-fog-2)] tracking-tight">
-            <span class="text-[var(--color-fog-0)] font-semibold">nxv</span><span class="text-[var(--color-fog-4)]">@</span><span>urandom.io</span>
+            <span class="text-[var(--color-fog-0)] font-semibold">nxv</span>
+            <span class="text-[var(--color-fog-4)]">@</span>
+            <span>urandom.io</span>
           </span>
         </a>
 
         <nav class="ml-4 hidden md:flex items-center gap-1 mono text-[12px]">
-          <a class="px-2.5 py-1.5 text-[var(--color-fog-0)] hairline rounded-[2px]" href="/">search</a>
-          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="#stats">stats</a>
-          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="/docs">api</a>
-          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="https://utensils.io/nxv/">cli</a>
+          <a class="px-2.5 py-1.5 text-[var(--color-fog-0)] hairline rounded-[2px]" href="/">
+            search
+          </a>
+          <a
+            class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]"
+            href="#stats"
+          >
+            stats
+          </a>
+          <a
+            class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]"
+            href="/docs"
+          >
+            api
+          </a>
+          <a
+            class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]"
+            href="https://utensils.io/nxv/"
+          >
+            cli
+          </a>
         </nav>
 
         <div class="flex-1"></div>
 
-        <button id="paletteTrigger" class="hidden sm:flex items-center gap-2 px-2.5 py-1.5 hairline rounded-[2px] mono text-[11px] text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition">
-          <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+        <button
+          id="paletteTrigger"
+          class="hidden sm:flex items-center gap-2 px-2.5 py-1.5 hairline rounded-[2px] mono text-[11px] text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition"
+        >
+          <svg
+            aria-hidden="true"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m20 20-3.5-3.5" />
+          </svg>
           <span>jump to…</span>
           <span class="kbd">⌘K</span>
         </button>
 
-        <a href="https://github.com/utensils/nxv" target="_blank" rel="noopener" class="p-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition" aria-label="nxv on GitHub">
-          <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        <a
+          href="https://github.com/utensils/nxv"
+          target="_blank"
+          rel="noopener"
+          class="p-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition"
+          aria-label="nxv on GitHub"
+        >
+          <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+            <path
+              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+            />
+          </svg>
         </a>
       </div>
       <!-- Status strip -->
-      <div class="mx-auto max-w-[1320px] px-6 h-6 flex items-center gap-4 mono text-[10.5px] text-[var(--color-fog-4)] border-t" style="border-color: var(--color-ink-2)">
+      <div
+        class="mx-auto max-w-[1320px] px-6 h-6 flex items-center gap-4 mono text-[10.5px] text-[var(--color-fog-4)] border-t"
+        style="border-color: var(--color-ink-2)"
+      >
         <span class="flex items-center gap-1.5">
-          <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: var(--color-green-glow); box-shadow: 0 0 6px oklch(0.74 0.15 150 / 0.6);"></span>
+          <span
+            class="inline-block w-1.5 h-1.5 rounded-full"
+            style="
+              background: var(--color-green-glow);
+              box-shadow: 0 0 6px oklch(0.74 0.15 150 / 0.6);
+            "
+          ></span>
           api operational · p50 34ms
         </span>
         <span class="text-[var(--color-ink-4)]">│</span>
-        <span>index · <span class="text-[var(--color-fog-2)]">2026-04-19</span> · commit <span class="text-[var(--color-fog-2)]">a7f2c91</span></span>
+        <span>
+          index ·
+          <span class="text-[var(--color-fog-2)]">2026-04-19</span>
+          · commit
+          <span class="text-[var(--color-fog-2)]">a7f2c91</span>
+        </span>
         <span class="text-[var(--color-ink-4)]">│</span>
-        <span>nixpkgs · <span class="text-[var(--color-fog-2)]">2017-01 → 2026-04</span></span>
+        <span>
+          nixpkgs ·
+          <span class="text-[var(--color-fog-2)]">2017-01 → 2026-04</span>
+        </span>
         <span class="flex-1"></span>
-        <span class="hidden md:inline">press <span class="kbd">/</span> to focus</span>
+        <span class="hidden md:inline">
+          press
+          <span class="kbd">/</span>
+          to focus
+        </span>
       </div>
     </header>
 
@@ -278,31 +457,50 @@
       <section class="pt-10 md:pt-14">
         <div class="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-10 items-end">
           <div>
-            <div class="mono text-[11px] text-[var(--color-fog-4)] mb-3 tracking-widest">// NIX VERSION INDEX &nbsp;·&nbsp; v0.6.2</div>
-            <h1 class="text-[44px] md:text-[60px] leading-[0.95] font-semibold tracking-[-0.03em] text-[var(--color-fog-0)]">
-              Every version of every<br/>
+            <div class="mono text-[11px] text-[var(--color-fog-4)] mb-3 tracking-widest">
+              // NIX VERSION INDEX &nbsp;·&nbsp; v0.6.2
+            </div>
+            <h1
+              class="text-[44px] md:text-[60px] leading-[0.95] font-semibold tracking-[-0.03em] text-[var(--color-fog-0)]"
+            >
+              Every version of every
+              <br />
               <span class="mono text-[var(--color-nix-400)] font-semibold">nix</span>
-              <span class="mono text-[var(--color-fog-0)] font-semibold">package</span>,<br/>
+              <span class="mono text-[var(--color-fog-0)] font-semibold">package</span>
+              ,
+              <br />
               <span class="text-[var(--color-fog-2)]">indexed since 2017.</span>
             </h1>
             <p class="mt-5 text-[15px] text-[var(--color-fog-2)] max-w-[560px] leading-relaxed">
-              Find the exact <span class="mono text-[var(--color-fog-0)]">nixpkgs</span> commit for the version you need —
-              Python 2.7 for that legacy project, or an obscure patched Ruby from 2019.
-              Query locally, via the CLI, or against <span class="mono text-[var(--color-fog-0)]">nxv serve</span>.
+              Find the exact
+              <span class="mono text-[var(--color-fog-0)]">nixpkgs</span>
+              commit for the version you need — Python 2.7 for that legacy project, or an obscure
+              patched Ruby from 2019. Query locally, via the CLI, or against
+              <span class="mono text-[var(--color-fog-0)]">nxv serve</span>
+              .
             </p>
           </div>
 
           <!-- Stats block, minimal -->
           <aside class="mono text-[12px] text-[var(--color-fog-3)] leading-[1.8] select-none">
-            <div class="ascii-rule text-[10px] leading-none mb-2">┌─ INDEX STATS ──────────────────────┐</div>
-            <div class="grid grid-cols-2 gap-x-6 gap-y-1 px-3">
-              <span>packages</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">186,417</span>
-              <span>versions</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">4,209,881</span>
-              <span>records</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">12,384,502</span>
-              <span>commits</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">98,317</span>
-              <span>history</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">9+ yrs</span>
+            <div class="ascii-rule text-[10px] leading-none mb-2">
+              ┌─ INDEX STATS ──────────────────────┐
             </div>
-            <div class="ascii-rule text-[10px] leading-none mt-2">└────────────────────────────────────┘</div>
+            <div class="grid grid-cols-2 gap-x-6 gap-y-1 px-3">
+              <span>packages</span>
+              <span class="text-right text-[var(--color-fog-0)] tabular-nums">186,417</span>
+              <span>versions</span>
+              <span class="text-right text-[var(--color-fog-0)] tabular-nums">4,209,881</span>
+              <span>records</span>
+              <span class="text-right text-[var(--color-fog-0)] tabular-nums">12,384,502</span>
+              <span>commits</span>
+              <span class="text-right text-[var(--color-fog-0)] tabular-nums">98,317</span>
+              <span>history</span>
+              <span class="text-right text-[var(--color-fog-0)] tabular-nums">9+ yrs</span>
+            </div>
+            <div class="ascii-rule text-[10px] leading-none mt-2">
+              └────────────────────────────────────┘
+            </div>
           </aside>
         </div>
 
@@ -310,9 +508,13 @@
         <div class="mt-10 relative">
           <div class="prompt-shell rounded-[2px] flex items-center h-14 px-4 gap-3">
             <span class="mono text-[13px] text-[var(--color-nix-400)] select-none">
-              nxv<span class="text-[var(--color-fog-4)]">:~</span><span class="text-[var(--color-fog-0)]">$</span>
+              nxv
+              <span class="text-[var(--color-fog-4)]">:~</span>
+              <span class="text-[var(--color-fog-0)]">$</span>
             </span>
-            <span class="mono text-[13px] text-[var(--color-fog-3)] select-none hidden sm:inline">search</span>
+            <span class="mono text-[13px] text-[var(--color-fog-3)] select-none hidden sm:inline">
+              search
+            </span>
             <input
               id="searchInput"
               type="search"
@@ -323,7 +525,9 @@
               class="mono flex-1 bg-transparent border-0 outline-none text-[15px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]"
             />
             <span class="mono text-[15px] text-[var(--color-nix-400)] caret-blink">▌</span>
-            <span class="hidden sm:inline-flex items-center gap-1 mono text-[10px] text-[var(--color-fog-4)]">
+            <span
+              class="hidden sm:inline-flex items-center gap-1 mono text-[10px] text-[var(--color-fog-4)]"
+            >
               <span class="kbd">↵</span>
               run
             </span>
@@ -331,12 +535,27 @@
 
           <!-- Filter strip -->
           <div class="mt-3 flex flex-wrap items-center gap-2">
-            <button data-filter="exact" class="chip">exact: <span class="ml-1 text-[var(--color-fog-0)]">off</span></button>
-            <button data-filter="version" class="chip">version: <span class="ml-1 text-[var(--color-fog-0)]">any</span></button>
-            <button data-filter="arch" class="chip">arch: <span class="ml-1 text-[var(--color-fog-0)]">any</span></button>
-            <button data-filter="license" class="chip">license: <span class="ml-1 text-[var(--color-fog-0)]">any</span></button>
+            <button data-filter="exact" class="chip">
+              exact:
+              <span class="ml-1 text-[var(--color-fog-0)]">off</span>
+            </button>
+            <button data-filter="version" class="chip">
+              version:
+              <span class="ml-1 text-[var(--color-fog-0)]">any</span>
+            </button>
+            <button data-filter="arch" class="chip">
+              arch:
+              <span class="ml-1 text-[var(--color-fog-0)]">any</span>
+            </button>
+            <button data-filter="license" class="chip">
+              license:
+              <span class="ml-1 text-[var(--color-fog-0)]">any</span>
+            </button>
             <button data-filter="include-insecure" class="chip">include insecure</button>
-            <button data-filter="sort" class="chip">sort: <span class="ml-1 text-[var(--color-fog-0)]">date</span></button>
+            <button data-filter="sort" class="chip">
+              sort:
+              <span class="ml-1 text-[var(--color-fog-0)]">date</span>
+            </button>
             <div class="flex-1"></div>
             <span class="mono text-[11px] text-[var(--color-fog-4)]">try:</span>
             <button class="chip example">python 2.7</button>
@@ -356,8 +575,18 @@
           <span id="resultsTime">—</span>
           <span class="flex-1"></span>
           <span class="text-[var(--color-fog-4)]">view:</span>
-          <button data-view="rows" class="px-2 py-0.5 hairline rounded-[2px] text-[var(--color-fog-0)]">rows</button>
-          <button data-view="cards" class="px-2 py-0.5 text-[var(--color-fog-4)] hover:text-[var(--color-fog-1)]">cards</button>
+          <button
+            data-view="rows"
+            class="px-2 py-0.5 hairline rounded-[2px] text-[var(--color-fog-0)]"
+          >
+            rows
+          </button>
+          <button
+            data-view="cards"
+            class="px-2 py-0.5 text-[var(--color-fog-4)] hover:text-[var(--color-fog-1)]"
+          >
+            cards
+          </button>
         </div>
 
         <div class="ascii-rule text-[10px] leading-none mt-1 mb-2">
@@ -367,7 +596,10 @@
         <!-- Rows view — dense terminal-ish -->
         <div id="resultsRows" class="panel rounded-[2px] overflow-hidden">
           <!-- Table header -->
-          <div class="grid grid-cols-[minmax(180px,1.6fr)_100px_minmax(200px,2fr)_120px_130px_90px] gap-3 px-4 py-2 mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]" style="border-bottom: 1px solid var(--color-ink-4)">
+          <div
+            class="grid grid-cols-[minmax(180px,1.6fr)_100px_minmax(200px,2fr)_120px_130px_90px] gap-3 px-4 py-2 mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]"
+            style="border-bottom: 1px solid var(--color-ink-4)"
+          >
             <span>package · attr</span>
             <span>version</span>
             <span class="hidden md:block">description</span>
@@ -379,8 +611,20 @@
         </div>
 
         <!-- Pagination -->
-        <div id="pagination" class="mt-4 flex items-center justify-between mono text-[11px] text-[var(--color-fog-3)]">
-          <span>page <span class="text-[var(--color-fog-0)]">1</span> / <span class="text-[var(--color-fog-0)]">42</span> · showing <span class="text-[var(--color-fog-0)]">1–25</span> of <span class="text-[var(--color-fog-0)]">1,047</span></span>
+        <div
+          id="pagination"
+          class="mt-4 flex items-center justify-between mono text-[11px] text-[var(--color-fog-3)]"
+        >
+          <span>
+            page
+            <span class="text-[var(--color-fog-0)]">1</span>
+            /
+            <span class="text-[var(--color-fog-0)]">42</span>
+            · showing
+            <span class="text-[var(--color-fog-0)]">1–25</span>
+            of
+            <span class="text-[var(--color-fog-0)]">1,047</span>
+          </span>
           <div class="flex items-center gap-1.5">
             <button class="btn btn-ghost">← prev</button>
             <button class="btn btn-ghost">next →</button>
@@ -391,55 +635,111 @@
       <!-- Stats / about -->
       <section id="stats" class="mt-24 grid grid-cols-1 md:grid-cols-3 gap-4">
         <div class="panel rounded-[2px] p-5 relative scanlines">
-          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">activity · 30m</div>
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">
+            activity · 30m
+          </div>
           <div id="activityBars" class="flex items-end gap-[3px] h-14 mt-3"></div>
           <div class="mt-3 flex justify-between mono text-[10.5px] text-[var(--color-fog-3)]">
-            <span>30m ago</span><span id="activitySummary" class="text-[var(--color-green-glow)]">—</span><span>now</span>
+            <span>30m ago</span>
+            <span id="activitySummary" class="text-[var(--color-green-glow)]">—</span>
+            <span>now</span>
           </div>
         </div>
         <div class="panel rounded-[2px] p-5">
-          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">latency · p50 / p95 / p99</div>
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">
+            latency · p50 / p95 / p99
+          </div>
           <div class="mt-3 mono text-[28px] leading-none text-[var(--color-fog-0)] tabular-nums">
-            34<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+            34
+            <span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
             <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
-            112<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+            112
+            <span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
             <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
-            287<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+            287
+            <span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
           </div>
           <div class="mt-5 mono text-[10.5px] text-[var(--color-fog-3)]">
-            bloom filter hit rate · <span class="text-[var(--color-fog-0)]">97.2%</span><br/>
-            fts5 queries · <span class="text-[var(--color-fog-0)]">124,918 / day</span>
+            bloom filter hit rate ·
+            <span class="text-[var(--color-fog-0)]">97.2%</span>
+            <br />
+            fts5 queries ·
+            <span class="text-[var(--color-fog-0)]">124,918 / day</span>
           </div>
         </div>
         <div class="panel rounded-[2px] p-5">
-          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">self-host</div>
-          <pre class="mt-3 mono text-[12px] text-[var(--color-fog-1)] leading-relaxed whitespace-pre-wrap select-all">nix run github:utensils/nxv \
-  -- serve --host 0.0.0.0</pre>
-          <a href="https://utensils.io/nxv/" target="_blank" rel="noopener" class="mt-4 btn w-full justify-center">read the guide →</a>
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">
+            self-host
+          </div>
+          <pre
+            class="mt-3 mono text-[12px] text-[var(--color-fog-1)] leading-relaxed whitespace-pre-wrap select-all"
+          >
+nix run github:utensils/nxv \
+  -- serve --host 0.0.0.0</pre
+          >
+          <a
+            href="https://utensils.io/nxv/"
+            target="_blank"
+            rel="noopener"
+            class="mt-4 btn w-full justify-center"
+          >
+            read the guide →
+          </a>
         </div>
       </section>
 
       <!-- Footer -->
-      <footer class="mt-24 pt-6 hairline-t mono text-[11px] text-[var(--color-fog-4)] flex flex-wrap items-center gap-x-4 gap-y-2">
+      <footer
+        class="mt-24 pt-6 hairline-t mono text-[11px] text-[var(--color-fog-4)] flex flex-wrap items-center gap-x-4 gap-y-2"
+      >
         <span>© 2026 utensils.io</span>
         <span class="text-[var(--color-ink-4)]">│</span>
         <a href="https://github.com/utensils/nxv" class="hover:text-[var(--color-fog-1)]">source</a>
         <a href="/docs" class="hover:text-[var(--color-fog-1)]">/docs</a>
         <a href="/openapi.json" class="hover:text-[var(--color-fog-1)]">/openapi.json</a>
-        <a href="https://github.com/utensils/nxv/blob/main/LICENSE" class="hover:text-[var(--color-fog-1)]">mit license</a>
+        <a
+          href="https://github.com/utensils/nxv/blob/main/LICENSE"
+          class="hover:text-[var(--color-fog-1)]"
+        >
+          mit license
+        </a>
         <span class="flex-1"></span>
-        <span>built for the nix community by <a href="https://github.com/jamesbrink" class="text-[var(--color-fog-2)] hover:text-[var(--color-fog-0)]">@jamesbrink</a></span>
+        <span>
+          built for the nix community by
+          <a
+            href="https://github.com/jamesbrink"
+            class="text-[var(--color-fog-2)] hover:text-[var(--color-fog-0)]"
+          >
+            @jamesbrink
+          </a>
+        </span>
       </footer>
     </main>
 
     <!-- Version history drawer (right-side) -->
     <div id="drawerOverlay" class="fixed inset-0 z-40 hidden" aria-hidden="true">
       <div class="absolute inset-0 overlay-dim" data-close></div>
-      <div role="dialog" aria-modal="true" aria-labelledby="drawerTitle" class="absolute right-0 top-0 h-full w-full max-w-[640px] border-l overflow-y-auto flex flex-col shadow-2xl" style="background: var(--color-ink-2); border-color: var(--color-ink-4)">
-        <div class="sticky top-0 z-10 px-6 py-4 hairline-b flex items-start gap-4" style="background: var(--color-ink-2)">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawerTitle"
+        class="absolute right-0 top-0 h-full w-full max-w-[640px] border-l overflow-y-auto flex flex-col shadow-2xl"
+        style="background: var(--color-ink-2); border-color: var(--color-ink-4)"
+      >
+        <div
+          class="sticky top-0 z-10 px-6 py-4 hairline-b flex items-start gap-4"
+          style="background: var(--color-ink-2)"
+        >
           <div class="flex-1 min-w-0">
-            <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">version history</div>
-            <h2 id="drawerTitle" class="mono text-[18px] font-semibold text-[var(--color-fog-0)] mt-1 truncate">—</h2>
+            <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">
+              version history
+            </div>
+            <h2
+              id="drawerTitle"
+              class="mono text-[18px] font-semibold text-[var(--color-fog-0)] mt-1 truncate"
+            >
+              —
+            </h2>
             <div id="drawerSub" class="mono text-[11px] text-[var(--color-fog-3)] mt-0.5">—</div>
           </div>
           <button class="btn btn-ghost" data-close aria-label="Close version history">esc ✕</button>
@@ -447,32 +747,66 @@
 
         <!-- Timeline visualization -->
         <div class="px-6 py-5 hairline-b">
-          <div id="timelineLabel" class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">timeline</div>
+          <div
+            id="timelineLabel"
+            class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3"
+          >
+            timeline
+          </div>
           <div id="timelineViz" class="relative h-[120px]"></div>
-          <div id="timelineTicks" class="mt-2 flex justify-between mono text-[10px] text-[var(--color-fog-4)] tabular-nums"></div>
+          <div
+            id="timelineTicks"
+            class="mt-2 flex justify-between mono text-[10px] text-[var(--color-fog-4)] tabular-nums"
+          ></div>
         </div>
 
         <!-- Version list -->
         <div class="flex-1 px-6 py-5">
-          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">all versions <span id="drawerCount" class="text-[var(--color-fog-2)]"></span></div>
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">
+            all versions
+            <span id="drawerCount" class="text-[var(--color-fog-2)]"></span>
+          </div>
           <ul id="drawerList" class="space-y-1"></ul>
         </div>
       </div>
     </div>
 
     <!-- Command palette -->
-    <div id="palette" class="fixed inset-0 z-50 hidden items-start justify-center pt-[12vh] px-4" aria-hidden="true">
+    <div
+      id="palette"
+      class="fixed inset-0 z-50 hidden items-start justify-center pt-[12vh] px-4"
+      aria-hidden="true"
+    >
       <div class="absolute inset-0 overlay-dim" data-palette-close></div>
-      <div role="dialog" aria-modal="true" aria-label="Command palette" class="relative w-full max-w-[620px] panel rounded-[2px] overflow-hidden shadow-2xl">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        class="relative w-full max-w-[620px] panel rounded-[2px] overflow-hidden shadow-2xl"
+      >
         <div class="flex items-center gap-3 h-12 px-4 hairline-b">
           <span class="mono text-[13px] text-[var(--color-nix-400)]">»</span>
-          <input id="paletteInput" type="search" aria-label="Command palette — jump to package or run command" placeholder="jump to package, run command, or search…" class="mono flex-1 bg-transparent outline-none text-[14px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]" />
+          <input
+            id="paletteInput"
+            type="search"
+            aria-label="Command palette — jump to package or run command"
+            placeholder="jump to package, run command, or search…"
+            class="mono flex-1 bg-transparent outline-none text-[14px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]"
+          />
           <span class="kbd">esc</span>
         </div>
         <ul id="paletteList" class="max-h-[50vh] overflow-y-auto py-1"></ul>
-        <div class="px-4 py-2 hairline-t flex items-center gap-3 mono text-[10.5px] text-[var(--color-fog-4)]">
-          <span><span class="kbd">↑↓</span> navigate</span>
-          <span><span class="kbd">↵</span> select</span>
+        <div
+          class="px-4 py-2 hairline-t flex items-center gap-3 mono text-[10.5px] text-[var(--color-fog-4)]"
+        >
+          <span>
+            <span class="kbd">↑↓</span>
+            navigate
+          </span>
+          <span>
+            <span class="kbd">↵</span>
+            select
+          </span>
           <span class="flex-1"></span>
           <span>⌘K palette</span>
         </div>
@@ -480,7 +814,10 @@
     </div>
 
     <!-- Toast -->
-    <div id="toast" class="fixed bottom-6 right-6 z-50 opacity-0 translate-y-4 transition mono text-[12px] px-4 py-2.5 panel rounded-[2px] pointer-events-none">
+    <div
+      id="toast"
+      class="fixed bottom-6 right-6 z-50 opacity-0 translate-y-4 transition mono text-[12px] px-4 py-2.5 panel rounded-[2px] pointer-events-none"
+    >
       copied.
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -199,12 +199,12 @@
         :focus-visible { outline: 2px solid var(--color-nix-500); outline-offset: 2px; border-radius: 2px; }
 
         /* Softer dim for modal backdrops — tints toward the page ink
-           rather than pitch-black, with a gentle blur so the content
-           stays visible but clearly out of focus. */
+           rather than pitch-black, with a light blur so the content
+           stays readable behind an open modal. */
         .overlay-dim {
-          background: color-mix(in oklch, var(--color-ink-0) 55%, transparent);
-          backdrop-filter: blur(10px) saturate(130%);
-          -webkit-backdrop-filter: blur(10px) saturate(130%);
+          background: color-mix(in oklch, var(--color-ink-0) 35%, transparent);
+          backdrop-filter: blur(3px) saturate(115%);
+          -webkit-backdrop-filter: blur(3px) saturate(115%);
         }
 
         /* Skip link — hidden until focused */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,1536 +1,471 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark" style="background: oklch(0.14 0.012 255);">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>nxv - Nix Version Search</title>
+    <title>nxv // nix version index</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
     <style>
-      :root {
-        --bg: #0d1117;
-        --bg-secondary: #161b22;
-        --bg-tertiary: #21262d;
-        --border: #30363d;
-        --text: #e6edf3;
-        --text-muted: #8b949e;
-        --accent: #58a6ff;
-        --accent-hover: #79b8ff;
-        --success: #388bfd;
-        --warning: #d29922;
-        --error: #f85149;
-        --radius: 8px;
-        --shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-      }
-
-      * {
-        box-sizing: border-box;
+      /* Applied immediately — before Tailwind CDN finishes loading, to avoid FOUC */
+      html, body {
+        background: oklch(0.14 0.012 255);
+        color: oklch(0.88 0.01 255);
         margin: 0;
         padding: 0;
-      }
-
-      body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-        background: var(--bg);
-        color: var(--text);
         min-height: 100vh;
-        line-height: 1.5;
+        font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4.1.6/dist/index.global.min.js"></script>
+    <style type="text/tailwindcss">
+      @theme {
+        --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+        --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+        /* Deep, slightly cool ink — oklch for clean tonal steps */
+        --color-ink-0: oklch(0.14 0.012 255);   /* page bg */
+        --color-ink-1: oklch(0.175 0.012 255);  /* panel */
+        --color-ink-2: oklch(0.215 0.013 255);  /* elevated */
+        --color-ink-3: oklch(0.27 0.014 255);   /* hover */
+        --color-ink-4: oklch(0.34 0.014 255);   /* border */
+        --color-ink-5: oklch(0.48 0.013 255);   /* muted line */
+
+        --color-fog-0: oklch(0.98 0.005 255);   /* pure text */
+        --color-fog-1: oklch(0.88 0.01 255);    /* body text */
+        --color-fog-2: oklch(0.72 0.012 255);   /* secondary */
+        --color-fog-3: oklch(0.56 0.014 255);   /* muted */
+        --color-fog-4: oklch(0.42 0.014 255);   /* very muted */
+
+        /* Nix blue family */
+        --color-nix-300: oklch(0.82 0.08 255);
+        --color-nix-400: oklch(0.72 0.12 258);
+        --color-nix-500: oklch(0.63 0.16 260);
+        --color-nix-600: oklch(0.55 0.17 262);
+        --color-nix-700: oklch(0.46 0.15 263);
+
+        /* Phosphor/CRT secondary — cool cyan */
+        --color-phos-400: oklch(0.78 0.12 195);
+        --color-phos-500: oklch(0.70 0.14 198);
+
+        /* Warn & danger */
+        --color-amber-glow: oklch(0.78 0.14 80);
+        --color-red-glow: oklch(0.66 0.19 25);
+        --color-green-glow: oklch(0.74 0.15 150);
       }
 
-      .container {
-        max-width: 1200px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-      }
-
-      header {
-        text-align: center;
-        margin-bottom: 2rem;
-      }
-
-      .logo {
-        font-size: 3rem;
-        font-weight: 700;
-        letter-spacing: -0.05em;
-        background: linear-gradient(135deg, var(--accent), #a371f7);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
-
-      .tagline {
-        color: var(--text-muted);
-        margin-top: 0.5rem;
-        font-size: 1.1rem;
-      }
-
-      .search-container {
-        max-width: 700px;
-        margin: 0 auto 2rem;
-      }
-
-      .search-box {
-        display: flex;
-        gap: 0.5rem;
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 0.5rem;
-        transition: border-color 0.2s;
-      }
-
-      .search-box:focus-within {
-        border-color: var(--accent);
-      }
-
-      .search-input {
-        flex: 1;
-        background: transparent;
-        border: none;
-        color: var(--text);
-        font-size: 1.1rem;
-        padding: 0.75rem;
-        outline: none;
-      }
-
-      .search-input::placeholder {
-        color: var(--text-muted);
-      }
-
-      .search-btn {
-        background: var(--accent);
-        color: var(--bg);
-        border: none;
-        padding: 0.75rem 1.5rem;
-        border-radius: calc(var(--radius) - 2px);
-        font-weight: 600;
-        cursor: pointer;
-        transition: background 0.2s;
-      }
-
-      .search-btn:hover {
-        background: var(--accent-hover);
-      }
-
-      .search-options {
-        display: flex;
-        gap: 1rem;
-        margin-top: 0.75rem;
-        flex-wrap: wrap;
-        justify-content: center;
-      }
-
-      .search-option {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        color: var(--text-muted);
-        font-size: 0.9rem;
-      }
-
-      .search-option input,
-      .search-option select {
-        background: var(--bg-tertiary);
-        border: 1px solid var(--border);
-        color: var(--text);
-        padding: 0.35rem 0.5rem;
-        border-radius: 4px;
-        font-size: 0.85rem;
-      }
-
-      .search-option select {
-        cursor: pointer;
-      }
-
-      .stats-bar {
-        display: flex;
-        justify-content: center;
-        gap: 2rem;
-        padding: 1rem;
-        background: var(--bg-secondary);
-        border-radius: var(--radius);
-        margin-bottom: 2rem;
-        flex-wrap: wrap;
-      }
-
-      .stat {
-        text-align: center;
-      }
-
-      .stat-value {
-        font-size: 1.5rem;
-        font-weight: 700;
-        color: var(--accent);
-      }
-
-      .stat-label {
-        font-size: 0.85rem;
-        color: var(--text-muted);
-      }
-
-      .results-info {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        margin-bottom: 1rem;
-        color: var(--text-muted);
-        font-size: 0.9rem;
-      }
-
-      .results-grid {
-        display: grid;
-        gap: 1rem;
-      }
-
-      .result-card {
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 1.25rem;
-        transition: border-color 0.2s;
-      }
-
-      .result-card:hover {
-        border-color: var(--accent);
-      }
-
-      .result-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 1rem;
-        margin-bottom: 0.75rem;
-      }
-
-      .result-name {
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--accent);
-        word-break: break-word;
-      }
-
-      .result-version {
-        background: var(--bg-tertiary);
-        padding: 0.25rem 0.75rem;
-        border-radius: 999px;
-        font-size: 0.85rem;
-        font-weight: 500;
-        white-space: nowrap;
-      }
-
-      .result-attr {
-        font-family: 'SF Mono', Monaco, monospace;
-        font-size: 0.85rem;
-        color: var(--text-muted);
-        margin-bottom: 0.5rem;
-      }
-
-      .result-desc {
-        color: var(--text-muted);
-        font-size: 0.9rem;
-        margin-bottom: 1rem;
-        display: -webkit-box;
-        -webkit-line-clamp: 2;
-        line-clamp: 2;
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-      }
-
-      .result-meta {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1rem;
-        font-size: 0.8rem;
-        color: var(--text-muted);
-        margin-bottom: 1rem;
-      }
-
-      .result-meta-item {
-        display: flex;
-        align-items: center;
-        gap: 0.35rem;
-      }
-
-      .result-actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-      }
-
-      .btn {
-        background: var(--bg-tertiary);
-        border: 1px solid var(--border);
-        color: var(--text);
-        padding: 0.5rem 0.75rem;
-        border-radius: 6px;
-        font-size: 0.8rem;
-        cursor: pointer;
-        transition: all 0.2s;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        text-decoration: none;
-      }
-
-      .btn:hover {
-        border-color: var(--accent);
-        color: var(--accent);
-      }
-
-      .btn-primary {
-        background: var(--accent);
-        border-color: var(--accent);
-        color: var(--bg);
-      }
-
-      .btn-primary:hover {
-        background: var(--accent-hover);
-        border-color: var(--accent-hover);
-        color: var(--bg);
-      }
-
-      .btn-copied {
-        background: var(--success);
-        border-color: var(--success);
-        color: var(--bg);
-      }
-
-      .loading {
-        text-align: center;
-        padding: 3rem;
-        color: var(--text-muted);
-      }
-
-      .spinner {
-        width: 40px;
-        height: 40px;
-        border: 3px solid var(--border);
-        border-top-color: var(--accent);
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-        margin: 0 auto 1rem;
-      }
-
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
+      @layer base {
+        html { scrollbar-color: var(--color-ink-4) transparent; }
+        body {
+          background: var(--color-ink-0);
+          color: var(--color-fog-1);
+          font-family: var(--font-sans);
+          font-feature-settings: "ss01", "cv11";
+          -webkit-font-smoothing: antialiased;
         }
+        ::selection { background: oklch(0.55 0.17 262 / 0.4); color: var(--color-fog-0); }
+        /* Hairline, dense scrollbar */
+        ::-webkit-scrollbar { width: 10px; height: 10px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb { background: var(--color-ink-3); border: 2px solid var(--color-ink-0); border-radius: 6px; }
+        ::-webkit-scrollbar-thumb:hover { background: var(--color-ink-4); }
       }
 
-      .empty-state {
-        text-align: center;
-        padding: 3rem;
-        color: var(--text-muted);
-      }
+      @layer components {
+        .mono { font-family: var(--font-mono); font-feature-settings: "ss01", "zero"; }
+        .hairline { box-shadow: inset 0 0 0 1px var(--color-ink-4); }
+        .hairline-b { border-bottom: 1px solid var(--color-ink-4); }
+        .hairline-t { border-top: 1px solid var(--color-ink-4); }
+        .hairline-r { border-right: 1px solid var(--color-ink-4); }
+        .hairline-l { border-left: 1px solid var(--color-ink-4); }
 
-      .empty-state svg {
-        width: 64px;
-        height: 64px;
-        margin-bottom: 1rem;
-        opacity: 0.5;
-      }
-
-      .error-state {
-        text-align: center;
-        padding: 2rem;
-        background: rgba(248, 81, 73, 0.1);
-        border: 1px solid var(--error);
-        border-radius: var(--radius);
-        color: var(--error);
-      }
-
-      .pagination {
-        display: flex;
-        justify-content: center;
-        gap: 0.5rem;
-        margin-top: 2rem;
-      }
-
-      .modal-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.75);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 1rem;
-        z-index: 1000;
-        opacity: 0;
-        visibility: hidden;
-        transition: all 0.2s;
-      }
-
-      .modal-overlay.active {
-        opacity: 1;
-        visibility: visible;
-      }
-
-      .modal {
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        max-width: 700px;
-        width: 100%;
-        max-height: 80vh;
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-        box-shadow: var(--shadow);
-        transform: scale(0.95);
-        transition: transform 0.2s;
-      }
-
-      .modal-overlay.active .modal {
-        transform: scale(1);
-      }
-
-      .modal-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 1rem 1.25rem;
-        border-bottom: 1px solid var(--border);
-      }
-
-      .modal-title {
-        font-size: 1.1rem;
-        font-weight: 600;
-      }
-
-      .modal-close {
-        background: none;
-        border: none;
-        color: var(--text-muted);
-        cursor: pointer;
-        padding: 0.5rem;
-        font-size: 1.25rem;
-        line-height: 1;
-      }
-
-      .modal-close:hover {
-        color: var(--text);
-      }
-
-      .modal-body {
-        padding: 1.25rem;
-        overflow-y: auto;
-      }
-
-      .version-list {
-        display: grid;
-        gap: 0.75rem;
-      }
-
-      .version-item {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        padding: 0.75rem 1rem;
-        background: var(--bg-tertiary);
-        border-radius: 6px;
-        gap: 1rem;
-      }
-
-      .version-info {
-        flex: 1;
-        min-width: 0;
-      }
-
-      .version-number {
-        font-weight: 600;
-        margin-bottom: 0.25rem;
-      }
-
-      .version-dates {
-        font-size: 0.8rem;
-        color: var(--text-muted);
-      }
-
-      .version-commit {
-        font-family: 'SF Mono', Monaco, monospace;
-        font-size: 0.75rem;
-        color: var(--text-muted);
-        margin-top: 0.25rem;
-      }
-
-      .version-item .btn {
-        flex-shrink: 0;
-        margin-top: 0.25rem;
-      }
-
-      .platform-badges {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin: 0.75rem 0;
-      }
-
-      .platform-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.4rem;
-        background: var(--bg);
-        border: 1px solid var(--border);
-        padding: 0.3rem 0.6rem;
-        border-radius: 4px;
-        font-size: 0.7rem;
-        color: var(--text-muted);
-        font-family: 'SF Mono', Monaco, monospace;
-      }
-
-      .platform-badge svg {
-        opacity: 0.6;
-        flex-shrink: 0;
-      }
-
-      .platform-badge.highlighted {
-        background: var(--accent);
-        border-color: var(--accent);
-        color: var(--bg);
-      }
-
-      .platform-badge.highlighted svg {
-        opacity: 1;
-      }
-
-      .legacy-warning {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        background: rgba(210, 153, 34, 0.15);
-        border: 1px solid var(--warning);
-        color: var(--warning);
-        padding: 0.5rem 0.75rem;
-        border-radius: 6px;
-        font-size: 0.8rem;
-        margin: 0.75rem 0;
-      }
-
-      .legacy-warning svg {
-        flex-shrink: 0;
-      }
-
-      .insecure-warning {
-        display: flex;
-        align-items: flex-start;
-        gap: 0.5rem;
-        background: rgba(248, 81, 73, 0.15);
-        border: 1px solid var(--error);
-        color: var(--error);
-        padding: 0.5rem 0.75rem;
-        border-radius: 6px;
-        font-size: 0.8rem;
-        margin: 0.75rem 0;
-      }
-
-      .insecure-warning svg {
-        flex-shrink: 0;
-        margin-top: 2px;
-      }
-
-      .insecure-warning-content {
-        flex: 1;
-      }
-
-      .insecure-warning-title {
-        font-weight: 600;
-        margin-bottom: 0.25rem;
-      }
-
-      .insecure-warning-list {
-        font-size: 0.75rem;
-        opacity: 0.9;
-        line-height: 1.4;
-      }
-
-      .code-block {
-        background: var(--bg);
-        border: 1px solid var(--border);
-        border-radius: 6px;
-        padding: 1rem;
-        font-family: 'SF Mono', Monaco, monospace;
-        font-size: 0.85rem;
-        overflow-x: auto;
-        position: relative;
-      }
-
-      .code-block .copy-btn {
-        position: absolute;
-        top: 0.5rem;
-        right: 0.5rem;
-      }
-
-      footer {
-        text-align: center;
-        padding: 2rem;
-        color: var(--text-muted);
-        font-size: 0.85rem;
-      }
-
-      footer a {
-        color: var(--accent);
-        text-decoration: none;
-      }
-
-      footer a:hover {
-        text-decoration: underline;
-      }
-
-      .toast {
-        position: fixed;
-        bottom: 1.5rem;
-        right: 1.5rem;
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        padding: 0.75rem 1rem;
-        border-radius: var(--radius);
-        box-shadow: var(--shadow);
-        transform: translateY(100px);
-        opacity: 0;
-        transition: all 0.3s;
-        z-index: 1001;
-      }
-
-      .toast.show {
-        transform: translateY(0);
-        opacity: 1;
-      }
-
-      @media (max-width: 640px) {
-        .logo {
-          font-size: 2rem;
+        /* Terminal prompt bar */
+        .prompt-shell {
+          background: var(--color-ink-1);
+          border: 1px solid var(--color-ink-4);
+          font-family: var(--font-mono);
         }
-        .stats-bar {
-          gap: 1rem;
+        .prompt-shell:focus-within {
+          border-color: var(--color-nix-500);
+          box-shadow: 0 0 0 3px oklch(0.55 0.17 262 / 0.18);
         }
-        .stat-value {
-          font-size: 1.2rem;
+
+        /* Subtle scanline flourish — very faint */
+        .scanlines::before {
+          content: "";
+          position: absolute;
+          inset: 0;
+          pointer-events: none;
+          background-image: repeating-linear-gradient(
+            to bottom,
+            transparent 0,
+            transparent 2px,
+            oklch(1 0 0 / 0.012) 2px,
+            oklch(1 0 0 / 0.012) 3px
+          );
+          mix-blend-mode: overlay;
         }
-        .result-header {
-          flex-direction: column;
-          gap: 0.5rem;
+
+        /* ASCII divider line */
+        .ascii-rule {
+          color: var(--color-ink-4);
+          font-family: var(--font-mono);
+          user-select: none;
+          white-space: nowrap;
+          overflow: hidden;
+          letter-spacing: 0;
         }
-        .result-actions {
-          flex-direction: column;
+
+        /* Badge / chip */
+        .chip {
+          display: inline-flex; align-items: center; gap: 0.35rem;
+          padding: 0.125rem 0.5rem;
+          font-family: var(--font-mono);
+          font-size: 11px;
+          line-height: 1.6;
+          border: 1px solid var(--color-ink-4);
+          background: var(--color-ink-1);
+          color: var(--color-fog-2);
+          border-radius: 2px;
+          white-space: nowrap;
         }
+        .chip.active {
+          border-color: var(--color-nix-500);
+          color: var(--color-nix-300);
+          background: oklch(0.55 0.17 262 / 0.08);
+        }
+        .chip.danger {
+          border-color: oklch(0.66 0.19 25 / 0.6);
+          color: var(--color-red-glow);
+          background: oklch(0.66 0.19 25 / 0.08);
+        }
+        .chip.warn {
+          border-color: oklch(0.78 0.14 80 / 0.5);
+          color: var(--color-amber-glow);
+          background: oklch(0.78 0.14 80 / 0.06);
+        }
+        .chip.ok {
+          border-color: oklch(0.74 0.15 150 / 0.45);
+          color: var(--color-green-glow);
+          background: oklch(0.74 0.15 150 / 0.06);
+        }
+
         .btn {
-          width: 100%;
-          justify-content: center;
+          display: inline-flex; align-items: center; gap: 0.4rem;
+          padding: 0.35rem 0.65rem;
+          font-family: var(--font-mono);
+          font-size: 12px;
+          color: var(--color-fog-1);
+          background: var(--color-ink-2);
+          border: 1px solid var(--color-ink-4);
+          border-radius: 2px;
+          cursor: pointer;
+          transition: all 120ms ease;
         }
+        .btn:hover { border-color: var(--color-fog-4); background: var(--color-ink-3); color: var(--color-fog-0); }
+        .btn-primary { background: var(--color-nix-600); color: oklch(0.98 0.01 255); border-color: var(--color-nix-500); }
+        .btn-primary:hover { background: var(--color-nix-500); color: white; }
+        .btn-ghost { background: transparent; }
+
+        .kbd {
+          font-family: var(--font-mono);
+          font-size: 10px;
+          padding: 1px 5px;
+          border: 1px solid var(--color-ink-4);
+          border-bottom-width: 2px;
+          border-radius: 3px;
+          color: var(--color-fog-2);
+          background: var(--color-ink-1);
+          line-height: 1.4;
+        }
+
+        .panel { background: var(--color-ink-1); border: 1px solid var(--color-ink-4); }
+
+        /* Blinking caret */
+        @keyframes caret { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+        .caret-blink { animation: caret 1.1s steps(1) infinite; }
+
+        /* Subtle enter animation for result rows */
+        @keyframes slideUp {
+          from { opacity: 0; transform: translateY(4px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        .anim-in { animation: slideUp 220ms ease-out backwards; }
+
+        /* Focus ring on interactive elements */
+        :focus-visible { outline: 2px solid var(--color-nix-500); outline-offset: 2px; border-radius: 2px; }
       }
     </style>
   </head>
-  <body>
-    <div class="container">
-      <header>
-        <h1 class="logo">nxv</h1>
-        <p class="tagline">Find any version of any Nix package, instantly</p>
-      </header>
-
-      <div class="search-container">
-        <div class="search-box">
-          <input
-            type="text"
-            class="search-input"
-            id="searchInput"
-            placeholder="Search packages... (e.g., python, nodejs 18, ruby 2.7)"
-            autocomplete="off"
-          />
-          <button class="search-btn" id="searchBtn">Search</button>
-        </div>
-        <div class="search-options">
-          <label class="search-option">
-            <input type="checkbox" id="exactMatch" />
-            Exact match
-          </label>
-          <label class="search-option">
-            Version:
-            <input type="text" id="versionFilter" placeholder="e.g., 3.11" style="width: 80px" />
-          </label>
-          <label class="search-option">
-            Arch:
-            <select id="archFilter">
-              <option value="">All</option>
-              <option value="x86_64-linux">x86_64 Linux</option>
-              <option value="aarch64-linux">aarch64 Linux</option>
-              <option value="x86_64-darwin">x86_64 macOS</option>
-              <option value="aarch64-darwin">aarch64 macOS</option>
-            </select>
-          </label>
-          <label class="search-option">
-            Sort:
-            <select id="sortOrder">
-              <option value="date">Date</option>
-              <option value="name">Name</option>
-              <option value="version">Version</option>
-            </select>
-          </label>
-        </div>
-      </div>
-
-      <div class="stats-bar" id="statsBar">
-        <div class="stat">
-          <div class="stat-value" id="statPackages">-</div>
-          <div class="stat-label">Packages</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value" id="statVersions">-</div>
-          <div class="stat-label">Versions</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value" id="statRanges">-</div>
-          <div class="stat-label">Records</div>
-        </div>
-        <div class="stat">
-          <div class="stat-value" id="statHistory">-</div>
-          <div class="stat-label">Years of History</div>
-        </div>
-      </div>
-      <div
-        class="index-updated"
-        id="indexUpdated"
-        style="
-          display: none;
-          text-align: center;
-          color: var(--text-muted);
-          font-size: 0.85rem;
-          margin-top: -1rem;
-          margin-bottom: 1.5rem;
-        "
-      >
-        Index updated
-        <span id="indexUpdatedDate"></span>
-      </div>
-
-      <div id="resultsInfo" class="results-info" style="display: none">
-        <span id="resultsCount"></span>
-        <span id="resultsTime"></span>
-      </div>
-
-      <div id="resultsContainer">
-        <div class="empty-state" id="emptyState">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="11" cy="11" r="8" />
-            <path d="m21 21-4.35-4.35" />
+  <body class="min-h-screen">
+    <!-- Top command bar -->
+    <header class="hairline-b sticky top-0 z-30 backdrop-blur" style="background: color-mix(in oklch, var(--color-ink-0) 92%, transparent);">
+      <div class="mx-auto max-w-[1320px] px-6 h-14 flex items-center gap-6">
+        <a href="#" class="flex items-center gap-2.5 group">
+          <!-- Monogram mark: nested brackets -->
+          <svg width="28" height="28" viewBox="0 0 28 28" class="text-[var(--color-nix-400)]" aria-hidden="true">
+            <path d="M5 4 L5 24 M5 4 L10 4 M5 24 L10 24" stroke="currentColor" stroke-width="1.5" fill="none"/>
+            <path d="M23 4 L23 24 M23 4 L18 4 M23 24 L18 24" stroke="currentColor" stroke-width="1.5" fill="none"/>
+            <text x="14" y="18" text-anchor="middle" font-family="JetBrains Mono" font-size="11" font-weight="700" fill="currentColor">nxv</text>
           </svg>
-          <p>Start typing to search for Nix packages</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="modal-overlay" id="historyModal">
-      <div class="modal">
-        <div class="modal-header">
-          <h3 class="modal-title" id="historyTitle">Version History</h3>
-          <button class="modal-close" id="historyClose">&times;</button>
-        </div>
-        <div class="modal-body" id="historyBody">
-          <div class="loading">
-            <div class="spinner"></div>
-            <p>Loading version history...</p>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="toast" id="toast"></div>
-
-    <footer>
-      <p
-        style="
-          margin-bottom: 0.75rem;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 0.5rem;
-          flex-wrap: wrap;
-        "
-      >
-        <a
-          href="https://github.com/utensils/nxv"
-          target="_blank"
-          style="display: inline-flex; align-items: center; gap: 0.35rem"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            style="vertical-align: middle"
-          >
-            <path
-              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
-            />
-          </svg>
-          GitHub
+          <span class="mono text-[13px] text-[var(--color-fog-2)] tracking-tight">
+            <span class="text-[var(--color-fog-0)] font-semibold">nxv</span><span class="text-[var(--color-fog-4)]">@</span><span>urandom.io</span>
+          </span>
         </a>
-        <span>&mdash;</span>
-        <a href="/docs">API Docs</a>
-        <span>&mdash;</span>
-        <a href="/openapi.json">OpenAPI Spec</a>
-      </p>
-      <p style="color: var(--text-muted); font-size: 0.8rem">
-        Built with love for the Nix community by
-        <a href="https://github.com/jamesbrink">James Brink</a>
-        &mdash;
-        <a href="https://github.com/utensils/nxv/blob/main/LICENSE">MIT License</a>
-      </p>
-    </footer>
 
-    <script>
-      const API_BASE = '/api/v1';
-      let searchTimeout;
-      let currentOffset = 0;
-      const LIMIT = 25;
-      let versionAutoPopulated = false; // Track if version was auto-filled
+        <nav class="ml-4 hidden md:flex items-center gap-1 mono text-[12px]">
+          <a class="px-2.5 py-1.5 text-[var(--color-fog-0)] hairline rounded-[2px]" href="/">search</a>
+          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="#stats">stats</a>
+          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="/docs">api</a>
+          <a class="px-2.5 py-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)]" href="https://github.com/utensils/nxv#installation">cli</a>
+        </nav>
 
-      // Store expressions by ID to avoid HTML escaping issues
-      const expressionStore = new Map();
+        <div class="flex-1"></div>
 
-      // Parse "package version" style queries (e.g., "python 2.7", "nodejs 18.0.0")
-      const parseSearchQuery = (input) => {
-        const trimmed = input.trim();
+        <button id="paletteTrigger" class="hidden sm:flex items-center gap-2 px-2.5 py-1.5 hairline rounded-[2px] mono text-[11px] text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+          <span>jump to…</span>
+          <span class="kbd">⌘K</span>
+        </button>
 
-        // Match patterns like:
-        // - "python 2.7", "python 2.7.18"
-        // - "nodejs 18", "nodejs 18.0.0"
-        // - "gcc 12.3.0"
-        // - "ruby 2.7.6-p219", "node 18.0.0-alpha.1"
-        // - "package v1.2.3" (version with 'v' prefix)
-        // - "package 20230101" (date-based versions)
-        //
-        // Version pattern: starts with digit or 'v' followed by digit,
-        // then any combo of digits, dots, dashes, underscores, and alphanumerics
-        const match = trimmed.match(/^(.+?)\s+(v?\d[\d.]*[\w.-]*)$/i);
+        <a href="https://github.com/utensils/nxv" target="_blank" rel="noopener" class="p-1.5 text-[var(--color-fog-3)] hover:text-[var(--color-fog-0)] transition" title="GitHub">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        </a>
+      </div>
+      <!-- Status strip -->
+      <div class="mx-auto max-w-[1320px] px-6 h-6 flex items-center gap-4 mono text-[10.5px] text-[var(--color-fog-4)] border-t" style="border-color: var(--color-ink-2)">
+        <span class="flex items-center gap-1.5">
+          <span class="inline-block w-1.5 h-1.5 rounded-full" style="background: var(--color-green-glow); box-shadow: 0 0 6px oklch(0.74 0.15 150 / 0.6);"></span>
+          api operational · p50 34ms
+        </span>
+        <span class="text-[var(--color-ink-4)]">│</span>
+        <span>index · <span class="text-[var(--color-fog-2)]">2026-04-19</span> · commit <span class="text-[var(--color-fog-2)]">a7f2c91</span></span>
+        <span class="text-[var(--color-ink-4)]">│</span>
+        <span>nixpkgs · <span class="text-[var(--color-fog-2)]">2017-01 → 2026-04</span></span>
+        <span class="flex-1"></span>
+        <span class="hidden md:inline">press <span class="kbd">/</span> to focus</span>
+      </div>
+    </header>
 
-        if (match) {
-          const [, pkg, ver] = match;
-          // Only split if the package part doesn't look like it ends with a version
-          // (e.g., don't split "python3" into "python" + "3")
-          if (pkg.length > 0 && !pkg.match(/\d$/)) {
-            return { package: pkg.trim(), version: ver };
-          }
-        }
-
-        return { package: trimmed, version: null };
-      };
-
-      // Format number with commas
-      const formatNumber = (n) => n?.toLocaleString() ?? '-';
-
-      // Get user-friendly error message for HTTP status codes
-      const getHttpErrorMessage = (status, defaultMsg = 'Request failed') => {
-        switch (status) {
-          case 502:
-            return 'Bad gateway - the server is temporarily unavailable. Please try again later.';
-          case 503:
-            return 'Service unavailable - the server is overloaded or under maintenance.';
-          case 504:
-            return 'Gateway timeout - the server took too long to respond. Please try again.';
-          default:
-            return status >= 500
-              ? `Server error (HTTP ${status}). Please try again later.`
-              : `${defaultMsg} (HTTP ${status})`;
-        }
-      };
-
-      // Format date nicely
-      const formatDate = (dateStr) => {
-        const d = new Date(dateStr);
-        return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
-      };
-
-      // Check if a date predates flake.nix in nixpkgs (Feb 10, 2020)
-      const FLAKE_EPOCH = new Date('2020-02-10T00:00:00Z');
-      const predatesFlakes = (dateStr) => new Date(dateStr) < FLAKE_EPOCH;
-
-      // Parse known_vulnerabilities field into an array (handles JSON string or array)
-      const parseVulnerabilities = (pkg) => {
-        if (!pkg.known_vulnerabilities) return [];
-        try {
-          const vulns =
-            typeof pkg.known_vulnerabilities === 'string'
-              ? JSON.parse(pkg.known_vulnerabilities)
-              : pkg.known_vulnerabilities;
-          return Array.isArray(vulns) ? vulns : [];
-        } catch {
-          return [];
-        }
-      };
-
-      // Check if package has known vulnerabilities (is insecure)
-      const isInsecure = (pkg) => parseVulnerabilities(pkg).length > 0;
-
-      // Get vulnerabilities list from package
-      const getVulnerabilities = (pkg) => parseVulnerabilities(pkg);
-
-      // Safely get short commit hash (7 chars) with null/undefined handling
-      const getShortHash = (hash) => {
-        if (!hash || typeof hash !== 'string') return '';
-        return hash.substring(0, Math.min(7, hash.length));
-      };
-
-      // Format platforms into clean arch badges
-      const formatPlatforms = (platforms) => {
-        if (!platforms) return [];
-        const archMap = {
-          'x86_64-linux': 'x86_64 Linux',
-          'aarch64-linux': 'aarch64 Linux',
-          'x86_64-darwin': 'x86_64 macOS',
-          'aarch64-darwin': 'aarch64 macOS',
-          'i686-linux': 'i686 Linux',
-          'armv7l-linux': 'armv7 Linux',
-        };
-        // Parse platforms string (could be JSON array or comma-separated)
-        let platformList = [];
-        try {
-          platformList = JSON.parse(platforms);
-        } catch {
-          platformList = platforms.split(',').map((p) => p.trim());
-        }
-        return platformList
-          .map((p) => archMap[p] || p)
-          .filter((p) => p && p.length > 0)
-          .slice(0, 4); // Limit to 4 to avoid clutter
-      };
-
-      // Format platforms with raw values for matching against filter
-      const formatPlatformsWithRaw = (platforms) => {
-        if (!platforms) return [];
-        const archMap = {
-          'x86_64-linux': 'x86_64 Linux',
-          'aarch64-linux': 'aarch64 Linux',
-          'x86_64-darwin': 'x86_64 macOS',
-          'aarch64-darwin': 'aarch64 macOS',
-          'i686-linux': 'i686 Linux',
-          'armv7l-linux': 'armv7 Linux',
-        };
-        let platformList = [];
-        try {
-          platformList = JSON.parse(platforms);
-        } catch {
-          platformList = platforms.split(',').map((p) => p.trim());
-        }
-        return platformList
-          .filter((p) => p && p.length > 0)
-          .slice(0, 4)
-          .map((p) => ({ raw: p, display: archMap[p] || p }));
-      };
-
-      // Show toast notification
-      const showToast = (message) => {
-        const toast = document.getElementById('toast');
-        toast.textContent = message;
-        toast.classList.add('show');
-        setTimeout(() => toast.classList.remove('show'), 2000);
-      };
-
-      // Copy to clipboard with fallback
-      const copyToClipboard = async (text, btn) => {
-        if (!text) {
-          showToast('Nothing to copy');
-          return;
-        }
-
-        const showSuccess = () => {
-          const originalText = btn.innerHTML;
-          btn.classList.add('btn-copied');
-          btn.innerHTML =
-            '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
-          setTimeout(() => {
-            btn.classList.remove('btn-copied');
-            btn.innerHTML = originalText;
-          }, 1500);
-        };
-
-        // Try modern clipboard API first
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-          try {
-            await navigator.clipboard.writeText(text);
-            showSuccess();
-            return;
-          } catch (err) {
-            // Fall through to fallback
-          }
-        }
-
-        // Fallback for older browsers or non-HTTPS
-        try {
-          const textarea = document.createElement('textarea');
-          textarea.value = text;
-          textarea.style.position = 'fixed';
-          textarea.style.opacity = '0';
-          document.body.appendChild(textarea);
-          textarea.select();
-          document.execCommand('copy');
-          document.body.removeChild(textarea);
-          showSuccess();
-        } catch (err) {
-          showToast('Failed to copy - try manually selecting');
-        }
-      };
-
-      // Load stats
-      const loadStats = async () => {
-        try {
-          const res = await fetch(`${API_BASE}/stats`);
-
-          if (!res.ok) {
-            console.error(`Failed to load stats: HTTP ${res.status}`);
-            return;
-          }
-
-          // Check content-type before parsing JSON
-          const contentType = res.headers.get('content-type');
-          if (!contentType || !contentType.includes('application/json')) {
-            console.error('Stats response was not JSON');
-            return;
-          }
-
-          const { data } = await res.json();
-
-          document.getElementById('statPackages').textContent = formatNumber(data.unique_names);
-          document.getElementById('statVersions').textContent = formatNumber(data.unique_versions);
-          document.getElementById('statRanges').textContent = formatNumber(data.total_ranges);
-
-          if (data.oldest_commit_date && data.newest_commit_date) {
-            const oldest = new Date(data.oldest_commit_date).getFullYear();
-            const newest = new Date(data.newest_commit_date).getFullYear();
-            document.getElementById('statHistory').textContent = `${newest - oldest}+`;
-          }
-
-          // Show index updated date (prefer last_indexed_date, fall back to newest_commit_date)
-          const indexDate = data.last_indexed_date || data.newest_commit_date;
-          if (indexDate) {
-            const updatedDate = new Date(indexDate);
-            document.getElementById('indexUpdatedDate').textContent =
-              updatedDate.toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              });
-            document.getElementById('indexUpdated').style.display = 'block';
-          }
-        } catch (err) {
-          console.error('Failed to load stats:', err);
-        }
-      };
-
-      // Search packages
-      const search = async (query, offset = 0) => {
-        const container = document.getElementById('resultsContainer');
-        const resultsInfo = document.getElementById('resultsInfo');
-        const versionInput = document.getElementById('versionFilter');
-
-        if (!query.trim()) {
-          // Clear auto-populated version when search is cleared
-          if (versionAutoPopulated) {
-            versionInput.value = '';
-            versionAutoPopulated = false;
-          }
-          container.innerHTML = `
-          <div class="empty-state" id="emptyState">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <circle cx="11" cy="11" r="8"/>
-              <path d="m21 21-4.35-4.35"/>
-            </svg>
-            <p>Start typing to search for Nix packages</p>
+    <main class="mx-auto max-w-[1320px] px-6 pb-32 relative">
+      <!-- Hero / search -->
+      <section class="pt-10 md:pt-14">
+        <div class="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-10 items-end">
+          <div>
+            <div class="mono text-[11px] text-[var(--color-fog-4)] mb-3 tracking-widest">// NIX VERSION INDEX &nbsp;·&nbsp; v0.6.2</div>
+            <h1 class="text-[44px] md:text-[60px] leading-[0.95] font-semibold tracking-[-0.03em] text-[var(--color-fog-0)]">
+              Every version of every<br/>
+              <span class="mono text-[var(--color-nix-400)] font-semibold">nix</span>
+              <span class="mono text-[var(--color-fog-0)] font-semibold">package</span>,<br/>
+              <span class="text-[var(--color-fog-2)]">indexed since 2017.</span>
+            </h1>
+            <p class="mt-5 text-[15px] text-[var(--color-fog-2)] max-w-[560px] leading-relaxed">
+              Find the exact <span class="mono text-[var(--color-fog-0)]">nixpkgs</span> commit for the version you need —
+              Python 2.7 for that legacy project, or an obscure patched Ruby from 2019.
+              Query locally, via the CLI, or against <span class="mono text-[var(--color-fog-0)]">nxv serve</span>.
+            </p>
           </div>
-        `;
-          resultsInfo.style.display = 'none';
-          return;
-        }
 
-        container.innerHTML =
-          '<div class="loading"><div class="spinner"></div><p>Searching...</p></div>';
-        resultsInfo.style.display = 'none';
-
-        const startTime = performance.now();
-
-        try {
-          // Smart parse: detect "python 2.7" style queries
-          const parsed = parseSearchQuery(query);
-          const currentVersion = versionInput.value.trim();
-
-          // If query contains a version (e.g., "python 2.7"), always use just the package name
-          // The version goes to the version filter (either auto-populated or manually overridden)
-          let effectiveQuery = parsed.version ? parsed.package : query;
-          let effectiveVersion = currentVersion;
-
-          if (parsed.version && (!currentVersion || versionAutoPopulated)) {
-            // Auto-populate version field when user types "python 2.7" style query
-            effectiveVersion = parsed.version;
-            versionInput.value = parsed.version;
-            versionAutoPopulated = true;
-            versionInput.style.borderColor = 'var(--accent)';
-            versionInput.style.transition = 'border-color 0.3s';
-            setTimeout(() => {
-              versionInput.style.borderColor = '';
-            }, 2000);
-          } else if (!parsed.version && versionAutoPopulated) {
-            // Clear auto-populated version if query no longer has version
-            versionInput.value = '';
-            versionAutoPopulated = false;
-            effectiveVersion = '';
-          }
-
-          const params = new URLSearchParams({
-            q: effectiveQuery,
-            limit: LIMIT,
-            offset: offset,
-            sort: document.getElementById('sortOrder').value,
-          });
-
-          if (document.getElementById('exactMatch').checked) {
-            params.append('exact', 'true');
-          }
-
-          if (effectiveVersion) {
-            params.append('version', effectiveVersion);
-          }
-
-          const res = await fetch(`${API_BASE}/search?${params}`);
-          const elapsed = ((performance.now() - startTime) / 1000).toFixed(2);
-
-          // Handle non-OK responses with user-friendly messages
-          if (!res.ok) {
-            // Check if response is JSON before trying to parse
-            const contentType = res.headers.get('content-type');
-            if (contentType && contentType.includes('application/json')) {
-              const errorJson = await res.json().catch(() => null);
-              throw new Error(errorJson?.message || errorJson?.error || getHttpErrorMessage(res.status, 'Search failed'));
-            }
-            throw new Error(getHttpErrorMessage(res.status, 'Search failed'));
-          }
-
-          const json = await res.json();
-
-          let { data, meta } = json;
-          currentOffset = offset;
-
-          // Client-side architecture filter
-          const archFilter = document.getElementById('archFilter').value;
-          if (archFilter) {
-            data = data.filter((pkg) => {
-              if (!pkg.platforms) return false;
-              try {
-                const platforms = JSON.parse(pkg.platforms);
-                return platforms.includes(archFilter);
-              } catch {
-                return pkg.platforms.includes(archFilter);
-              }
-            });
-          }
-
-          if (data.length === 0) {
-            container.innerHTML = `
-            <div class="empty-state">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="10"/>
-                <path d="m15 9-6 6M9 9l6 6"/>
-              </svg>
-              <p>No packages found for "${escapeHtml(query)}"${archFilter ? ` on ${archFilter}` : ''}</p>
+          <!-- Stats block, minimal -->
+          <aside class="mono text-[12px] text-[var(--color-fog-3)] leading-[1.8] select-none">
+            <div class="ascii-rule text-[10px] leading-none mb-2">┌─ INDEX STATS ──────────────────────┐</div>
+            <div class="grid grid-cols-2 gap-x-6 gap-y-1 px-3">
+              <span>packages</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">186,417</span>
+              <span>versions</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">4,209,881</span>
+              <span>records</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">12,384,502</span>
+              <span>commits</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">98,317</span>
+              <span>history</span><span class="text-right text-[var(--color-fog-0)] tabular-nums">9+ yrs</span>
             </div>
-          `;
-            resultsInfo.style.display = 'none';
-            return;
-          }
+            <div class="ascii-rule text-[10px] leading-none mt-2">└────────────────────────────────────┘</div>
+          </aside>
+        </div>
 
-          resultsInfo.style.display = 'flex';
-          const filteredNote = archFilter ? ` (filtered from ${meta?.total || '?'})` : '';
-          document.getElementById('resultsCount').textContent =
-            `Showing ${offset + 1}-${offset + data.length} of ${formatNumber(data.length)} results${filteredNote}`;
-          document.getElementById('resultsTime').textContent = `${elapsed}s`;
-
-          container.innerHTML = `
-          <div class="results-grid">
-            ${data.map((pkg) => renderPackageCard(pkg)).join('')}
-          </div>
-          ${archFilter ? '' : renderPagination(meta?.total || data.length, offset)}
-        `;
-
-          // Attach event listeners
-          attachCardListeners();
-          attachPaginationListeners(query);
-        } catch (err) {
-          container.innerHTML = `
-          <div class="error-state">
-            <p>Error: ${escapeHtml(err.message)}</p>
-          </div>
-        `;
-        }
-      };
-
-      // Escape HTML
-      const escapeHtml = (str) => {
-        const div = document.createElement('div');
-        div.textContent = str;
-        return div.innerHTML;
-      };
-
-      // Validate URL has safe protocol (http: or https: only)
-      const isSafeUrl = (url) => {
-        try {
-          const parsed = new URL(url);
-          return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-        } catch {
-          return false;
-        }
-      };
-
-      // Render a package card
-      const renderPackageCard = (pkg) => {
-        const cardId = `pkg-${pkg.id}`;
-        const isLegacy = predatesFlakes(pkg.last_commit_date);
-        const shortHash = getShortHash(pkg.last_commit_hash);
-        const hasCommitHash = shortHash.length > 0;
-
-        // Use flake syntax for modern packages, legacy fetchTarball for old ones
-        // Add NIXPKGS_ALLOW_INSECURE=1 and --impure for insecure packages
-        const pkgInsecure = isInsecure(pkg);
-        const insecurePrefix = pkgInsecure ? 'NIXPKGS_ALLOW_INSECURE=1 ' : '';
-        const impureFlag = pkgInsecure ? ' --impure' : '';
-
-        // Only generate expressions if we have a valid commit hash
-        const nixExpr = hasCommitHash
-          ? (isLegacy
-              ? `(import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${shortHash}.tar.gz") {}).${pkg.attribute_path}`
-              : `nixpkgs#${pkg.attribute_path}  # or nixpkgs/${shortHash}#${pkg.attribute_path}`)
-          : '';
-        const nixShell = hasCommitHash
-          ? (isLegacy
-              ? `${insecurePrefix}nix-shell -p '(import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${shortHash}.tar.gz") {}).${pkg.attribute_path}'`
-              : `${insecurePrefix}nix shell${impureFlag} nixpkgs/${shortHash}#${pkg.attribute_path}`)
-          : '';
-
-        // Store expressions in the map (only if valid)
-        if (hasCommitHash) {
-          expressionStore.set(`${cardId}-expr`, nixExpr);
-          expressionStore.set(`${cardId}-shell`, nixShell);
-          expressionStore.set(`${cardId}-legacy`, isLegacy);
-        }
-
-        return `
-        <div class="result-card" data-attr="${escapeHtml(pkg.attribute_path)}">
-          <div class="result-header">
-            <span class="result-name">${escapeHtml(pkg.name)}</span>
-            <span class="result-version" ${isInsecure(pkg) ? 'style="background: rgba(248, 81, 73, 0.3); border: 1px solid var(--error);"' : ''}>${escapeHtml(pkg.version)}${isInsecure(pkg) ? ' ⚠' : ''}</span>
-          </div>
-          <div class="result-attr">${escapeHtml(pkg.attribute_path)}</div>
-          ${pkg.description ? `<div class="result-desc">${escapeHtml(pkg.description)}</div>` : ''}
-          <div class="result-meta">
-            ${pkg.license ? `<span class="result-meta-item"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><circle cx="12" cy="16" r="1"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg> ${escapeHtml(pkg.license)}</span>` : ''}
-            <span class="result-meta-item">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
-              ${formatDate(pkg.first_commit_date)} - ${formatDate(pkg.last_commit_date)}
+        <!-- Prompt-style search -->
+        <div class="mt-10 relative">
+          <div class="prompt-shell rounded-[2px] flex items-center h-14 px-4 gap-3">
+            <span class="mono text-[13px] text-[var(--color-nix-400)] select-none">
+              nxv<span class="text-[var(--color-fog-4)]">:~</span><span class="text-[var(--color-fog-0)]">$</span>
+            </span>
+            <span class="mono text-[13px] text-[var(--color-fog-3)] select-none hidden sm:inline">search</span>
+            <input
+              id="searchInput"
+              type="text"
+              autocomplete="off"
+              autofocus
+              placeholder="python 2.7   •   nodejs 18   •   ruby 2.6   •   gcc 12.3"
+              class="mono flex-1 bg-transparent border-0 outline-none text-[15px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]"
+            />
+            <span class="mono text-[15px] text-[var(--color-nix-400)] caret-blink">▌</span>
+            <span class="hidden sm:inline-flex items-center gap-1 mono text-[10px] text-[var(--color-fog-4)]">
+              <span class="kbd">↵</span>
+              run
             </span>
           </div>
-          ${(() => {
-            const platforms = formatPlatformsWithRaw(pkg.platforms);
-            if (platforms.length === 0) return '';
-            const activeArch = document.getElementById('archFilter').value;
-            return `<div class="platform-badges">${platforms
-              .map((p) => {
-                const isHighlighted = activeArch && p.raw === activeArch;
-                return `<span class="platform-badge${isHighlighted ? ' highlighted' : ''}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>${escapeHtml(p.display)}</span>`;
-              })
-              .join('')}</div>`;
-          })()}
-          ${
-            isInsecure(pkg)
-              ? `
-          <div class="insecure-warning">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-            <div class="insecure-warning-content">
-              <div class="insecure-warning-title">This package has known vulnerabilities</div>
-              <div class="insecure-warning-list">${getVulnerabilities(pkg)
-                .map((v) => escapeHtml(v))
-                .join(', ')}</div>
-            </div>
-          </div>
-          `
-              : ''
-          }
-          ${
-            predatesFlakes(pkg.last_commit_date)
-              ? `
-          <div class="legacy-warning">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-            Very old nixpkgs (pre-2020) may not build with modern Nix
-          </div>
-          `
-              : ''
-          }
-          <div class="result-actions">
-            ${hasCommitHash ? `
-            <button class="btn copy-expr" data-id="${cardId}-expr">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-              ${isLegacy ? 'Copy Nix Expression' : 'Copy Flake Ref'}
-            </button>
-            <button class="btn copy-shell" data-id="${cardId}-shell">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m4 17 6-6-6-6M12 19h8"/></svg>
-              ${isLegacy ? 'Copy nix-shell' : 'Copy nix shell'}
-            </button>
-            ` : ''}
-            ${
-              hasCommitHash && pkg.source_path
-                ? `
-              <a class="btn" href="https://github.com/NixOS/nixpkgs/blob/${pkg.last_commit_hash}/${escapeHtml(pkg.source_path)}" target="_blank" rel="noopener" title="View source in nixpkgs">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
-                View Source
-              </a>
-            `
-                : hasCommitHash ? `
-              <a class="btn" href="https://github.com/NixOS/nixpkgs/tree/${pkg.last_commit_hash}" target="_blank" rel="noopener" title="View nixpkgs at this commit">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
-                View nixpkgs
-              </a>
-            ` : ''
-            }
-            ${
-              pkg.homepage && isSafeUrl(pkg.homepage)
-                ? `
-              <a class="btn" href="${escapeHtml(pkg.homepage)}" target="_blank" rel="noopener" title="Visit project homepage">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-                Homepage
-              </a>
-            `
-                : ''
-            }
-            <button class="btn btn-primary view-history" data-attr="${escapeHtml(pkg.attribute_path)}">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-              All Versions
-            </button>
+
+          <!-- Filter strip -->
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <button data-filter="exact" class="chip">exact: <span class="ml-1 text-[var(--color-fog-0)]">off</span></button>
+            <button data-filter="version" class="chip">version: <span class="ml-1 text-[var(--color-fog-0)]">any</span></button>
+            <button data-filter="arch" class="chip">arch: <span class="ml-1 text-[var(--color-fog-0)]">any</span></button>
+            <button data-filter="license" class="chip">license: <span class="ml-1 text-[var(--color-fog-0)]">any</span></button>
+            <button data-filter="include-insecure" class="chip">include insecure</button>
+            <button data-filter="sort" class="chip">sort: <span class="ml-1 text-[var(--color-fog-0)]">date</span></button>
+            <div class="flex-1"></div>
+            <span class="mono text-[11px] text-[var(--color-fog-4)]">try:</span>
+            <button class="chip example">python 2.7</button>
+            <button class="chip example">nodejs 18</button>
+            <button class="chip example">gcc 4.9</button>
+            <button class="chip example">ffmpeg 5</button>
           </div>
         </div>
-      `;
-      };
+      </section>
 
-      // Render pagination
-      const renderPagination = (total, offset) => {
-        if (total <= LIMIT) return '';
-
-        const pages = Math.ceil(total / LIMIT);
-        const currentPage = Math.floor(offset / LIMIT) + 1;
-
-        return `
-        <div class="pagination">
-          <button class="btn" ${currentPage === 1 ? 'disabled' : ''} data-page="${currentPage - 1}">Previous</button>
-          <span style="padding: 0.5rem 1rem; color: var(--text-muted);">Page ${currentPage} of ${pages}</span>
-          <button class="btn" ${currentPage === pages ? 'disabled' : ''} data-page="${currentPage + 1}">Next</button>
+      <!-- Results pane -->
+      <section class="mt-10" id="resultsSection">
+        <!-- Result meta bar -->
+        <div class="flex items-center gap-4 mono text-[11.5px] text-[var(--color-fog-3)] h-8">
+          <span id="resultsCount" class="text-[var(--color-fog-1)]">results / —</span>
+          <span class="text-[var(--color-ink-4)]">│</span>
+          <span id="resultsTime">—</span>
+          <span class="flex-1"></span>
+          <span class="text-[var(--color-fog-4)]">view:</span>
+          <button data-view="rows" class="px-2 py-0.5 hairline rounded-[2px] text-[var(--color-fog-0)]">rows</button>
+          <button data-view="cards" class="px-2 py-0.5 text-[var(--color-fog-4)] hover:text-[var(--color-fog-1)]">cards</button>
         </div>
-      `;
-      };
 
-      // Attach card event listeners
-      const attachCardListeners = () => {
-        document.querySelectorAll('.copy-expr').forEach((btn) => {
-          btn.addEventListener('click', () => {
-            const text = expressionStore.get(btn.dataset.id);
-            copyToClipboard(text, btn);
-          });
-        });
+        <div class="ascii-rule text-[10px] leading-none mt-1 mb-2">
+          ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+        </div>
 
-        document.querySelectorAll('.copy-shell').forEach((btn) => {
-          btn.addEventListener('click', () => {
-            const text = expressionStore.get(btn.dataset.id);
-            copyToClipboard(text, btn);
-          });
-        });
-
-        document.querySelectorAll('.view-history').forEach((btn) => {
-          btn.addEventListener('click', () => showHistory(btn.dataset.attr));
-        });
-      };
-
-      // Attach pagination listeners
-      const attachPaginationListeners = (query) => {
-        document.querySelectorAll('.pagination .btn').forEach((btn) => {
-          btn.addEventListener('click', () => {
-            const page = parseInt(btn.dataset.page);
-            search(query, (page - 1) * LIMIT);
-            window.scrollTo({ top: 0, behavior: 'smooth' });
-          });
-        });
-      };
-
-      // Show version history modal
-      const showHistory = async (attr) => {
-        const modal = document.getElementById('historyModal');
-        const body = document.getElementById('historyBody');
-        const title = document.getElementById('historyTitle');
-
-        title.textContent = `Version History: ${attr}`;
-        body.innerHTML =
-          '<div class="loading"><div class="spinner"></div><p>Loading version history...</p></div>';
-        modal.classList.add('active');
-
-        try {
-          const res = await fetch(`${API_BASE}/packages/${encodeURIComponent(attr)}/history`);
-          if (!res.ok) {
-            body.innerHTML = `<p>${escapeHtml(getHttpErrorMessage(res.status, 'Failed to load version history'))}</p>`;
-            return;
-          }
-
-          // Check content-type before parsing JSON
-          const contentType = res.headers.get('content-type');
-          if (!contentType || !contentType.includes('application/json')) {
-            body.innerHTML = '<p>Unexpected response from server. Please try again.</p>';
-            return;
-          }
-
-          const { data } = await res.json();
-
-          if (!data || data.length === 0) {
-            body.innerHTML = '<p>No version history found.</p>';
-            return;
-          }
-
-          // Fetch full version info for each version to get commit hashes and vulnerability info
-          const versionsWithHashes = await Promise.all(
-            data.map(async (v, idx) => {
-              try {
-                const vRes = await fetch(
-                  `${API_BASE}/packages/${encodeURIComponent(attr)}/versions/${encodeURIComponent(v.version)}`
-                );
-                const vJson = await vRes.json();
-                return {
-                  ...v,
-                  commit_hash: vJson.data?.last_commit_hash,
-                  known_vulnerabilities: vJson.data?.known_vulnerabilities,
-                  idx,
-                };
-              } catch {
-                return { ...v, commit_hash: null, known_vulnerabilities: null, idx };
-              }
-            })
-          );
-
-          // Store expressions in the map for history items
-          // Use escapeHtml(attr) to match the data-id attribute in the rendered HTML
-          const escapedAttr = escapeHtml(attr);
-          versionsWithHashes.forEach((v) => {
-            if (v.commit_hash) {
-              const isLegacy = predatesFlakes(v.last_seen);
-              const shortHash = v.commit_hash.substring(0, 7);
-              const versionInsecure = isInsecure(v);
-              const insecurePrefix = versionInsecure ? 'NIXPKGS_ALLOW_INSECURE=1 ' : '';
-              const impureFlag = versionInsecure ? ' --impure' : '';
-              const nixExpr = isLegacy
-                ? `${insecurePrefix}nix-shell -p '(import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${shortHash}.tar.gz") {}).${attr}'`
-                : `${insecurePrefix}nix shell${impureFlag} nixpkgs/${shortHash}#${attr}`;
-              expressionStore.set(`history-${escapedAttr}-${v.idx}`, nixExpr);
-            }
-          });
-
-          body.innerHTML = `
-          <div class="version-list">
-            ${versionsWithHashes
-              .map((v) => {
-                const hasCommit = v.commit_hash;
-                const isLegacy = predatesFlakes(v.last_seen);
-                const versionInsecure = isInsecure(v);
-                return `
-                <div class="version-item">
-                  <div class="version-info">
-                    <div class="version-number">${escapeHtml(v.version)}${versionInsecure ? ' <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--error)" stroke-width="2" style="vertical-align: middle" title="Has known vulnerabilities"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>' : ''}${isLegacy ? ' <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--warning)" stroke-width="2" style="vertical-align: middle" title="May not build with modern Nix"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>' : ''}</div>
-                    <div class="version-dates">${formatDate(v.first_seen)} - ${formatDate(v.last_seen)}</div>
-                    ${hasCommit ? `<div class="version-commit">${v.commit_hash.substring(0, 7)}</div>` : ''}
-                  </div>
-                  ${
-                    hasCommit
-                      ? `
-                    <button class="btn copy-version-expr" data-id="history-${escapeHtml(attr)}-${v.idx}">
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                      Copy
-                    </button>
-                  `
-                      : '<span style="color: var(--text-muted); font-size: 0.8rem;">No commit</span>'
-                  }
-                </div>
-              `;
-              })
-              .join('')}
+        <!-- Rows view — dense terminal-ish -->
+        <div id="resultsRows" class="panel rounded-[2px] overflow-hidden">
+          <!-- Table header -->
+          <div class="grid grid-cols-[minmax(180px,1.6fr)_100px_minmax(200px,2fr)_120px_130px_90px] gap-3 px-4 py-2 mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]" style="border-bottom: 1px solid var(--color-ink-4)">
+            <span>package · attr</span>
+            <span>version</span>
+            <span class="hidden md:block">description</span>
+            <span>first seen</span>
+            <span>last seen</span>
+            <span class="text-right">actions</span>
           </div>
-        `;
+          <div id="resultsBody"></div>
+        </div>
 
-          body.querySelectorAll('.copy-version-expr').forEach((btn) => {
-            btn.addEventListener('click', () => {
-              const text = expressionStore.get(btn.dataset.id);
-              copyToClipboard(text, btn);
-            });
-          });
-        } catch (err) {
-          body.innerHTML = `<div class="error-state"><p>Failed to load history: ${escapeHtml(err.message)}</p></div>`;
-        }
-      };
+        <!-- Pagination -->
+        <div id="pagination" class="mt-4 flex items-center justify-between mono text-[11px] text-[var(--color-fog-3)]">
+          <span>page <span class="text-[var(--color-fog-0)]">1</span> / <span class="text-[var(--color-fog-0)]">42</span> · showing <span class="text-[var(--color-fog-0)]">1–25</span> of <span class="text-[var(--color-fog-0)]">1,047</span></span>
+          <div class="flex items-center gap-1.5">
+            <button class="btn btn-ghost">← prev</button>
+            <button class="btn btn-ghost">next →</button>
+          </div>
+        </div>
+      </section>
 
-      // Close modal
-      document.getElementById('historyClose').addEventListener('click', () => {
-        document.getElementById('historyModal').classList.remove('active');
-      });
+      <!-- Stats / about -->
+      <section id="stats" class="mt-24 grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="panel rounded-[2px] p-5 relative scanlines">
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">uptime · 30d</div>
+          <div class="mt-3 flex items-end gap-1 h-14">
+            <!-- 30 mini bars -->
+          </div>
+          <div id="uptimeBars" class="flex items-end gap-[3px] h-14 mt-3"></div>
+          <div class="mt-3 flex justify-between mono text-[10.5px] text-[var(--color-fog-3)]">
+            <span>30d</span><span class="text-[var(--color-green-glow)]">99.97% up</span><span>now</span>
+          </div>
+        </div>
+        <div class="panel rounded-[2px] p-5">
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">latency · p50 / p95 / p99</div>
+          <div class="mt-3 mono text-[28px] leading-none text-[var(--color-fog-0)] tabular-nums">
+            34<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+            <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
+            112<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+            <span class="mx-2 text-[var(--color-ink-4)] text-[16px]">/</span>
+            287<span class="text-[var(--color-fog-4)] text-[16px]">ms</span>
+          </div>
+          <div class="mt-5 mono text-[10.5px] text-[var(--color-fog-3)]">
+            bloom filter hit rate · <span class="text-[var(--color-fog-0)]">97.2%</span><br/>
+            fts5 queries · <span class="text-[var(--color-fog-0)]">124,918 / day</span>
+          </div>
+        </div>
+        <div class="panel rounded-[2px] p-5">
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">self-host</div>
+          <pre class="mt-3 mono text-[12px] text-[var(--color-fog-1)] leading-relaxed whitespace-pre-wrap select-all">nix run github:utensils/nxv \
+  -- serve --host 0.0.0.0</pre>
+          <a href="#" class="mt-4 btn w-full justify-center">read the guide →</a>
+        </div>
+      </section>
 
-      document.getElementById('historyModal').addEventListener('click', (e) => {
-        if (e.target.id === 'historyModal') {
-          document.getElementById('historyModal').classList.remove('active');
-        }
-      });
+      <!-- Footer -->
+      <footer class="mt-24 pt-6 hairline-t mono text-[11px] text-[var(--color-fog-4)] flex flex-wrap items-center gap-x-4 gap-y-2">
+        <span>© 2026 utensils.io</span>
+        <span class="text-[var(--color-ink-4)]">│</span>
+        <a href="https://github.com/utensils/nxv" class="hover:text-[var(--color-fog-1)]">source</a>
+        <a href="/docs" class="hover:text-[var(--color-fog-1)]">/docs</a>
+        <a href="/openapi.json" class="hover:text-[var(--color-fog-1)]">/openapi.json</a>
+        <a href="https://github.com/utensils/nxv/blob/main/LICENSE" class="hover:text-[var(--color-fog-1)]">mit license</a>
+        <span class="flex-1"></span>
+        <span>built for the nix community by <a href="https://github.com/jamesbrink" class="text-[var(--color-fog-2)] hover:text-[var(--color-fog-0)]">@jamesbrink</a></span>
+      </footer>
+    </main>
 
-      // Search input handling
-      const searchInput = document.getElementById('searchInput');
-      const searchBtn = document.getElementById('searchBtn');
+    <!-- Version history drawer (right-side) -->
+    <div id="drawerOverlay" class="fixed inset-0 z-40 hidden" aria-hidden="true">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-close></div>
+      <aside class="absolute right-0 top-0 h-full w-full max-w-[640px] panel border-l overflow-y-auto flex flex-col" style="background: var(--color-ink-1)">
+        <div class="sticky top-0 z-10 px-6 py-4 hairline-b flex items-start gap-4" style="background: var(--color-ink-1)">
+          <div class="flex-1 min-w-0">
+            <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)]">version history</div>
+            <h3 id="drawerTitle" class="mono text-[18px] font-semibold text-[var(--color-fog-0)] mt-1 truncate">—</h3>
+            <div id="drawerSub" class="mono text-[11px] text-[var(--color-fog-3)] mt-0.5">—</div>
+          </div>
+          <button class="btn btn-ghost" data-close>esc ✕</button>
+        </div>
 
-      searchInput.addEventListener('input', () => {
-        clearTimeout(searchTimeout);
-        searchTimeout = setTimeout(() => search(searchInput.value), 300);
-      });
+        <!-- Timeline visualization -->
+        <div class="px-6 py-5 hairline-b">
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">timeline · 2017 → 2026</div>
+          <div id="timelineViz" class="relative h-[120px]"></div>
+          <div class="mt-2 grid grid-cols-10 mono text-[10px] text-[var(--color-fog-4)] tabular-nums">
+            <span>'17</span><span>'18</span><span>'19</span><span>'20</span><span>'21</span><span>'22</span><span>'23</span><span>'24</span><span>'25</span><span class="text-right">'26</span>
+          </div>
+        </div>
 
-      searchInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-          clearTimeout(searchTimeout);
-          search(searchInput.value);
-        }
-      });
+        <!-- Version list -->
+        <div class="flex-1 px-6 py-5">
+          <div class="mono text-[10.5px] uppercase tracking-widest text-[var(--color-fog-4)] mb-3">all versions <span id="drawerCount" class="text-[var(--color-fog-2)]"></span></div>
+          <ul id="drawerList" class="space-y-1"></ul>
+        </div>
+      </aside>
+    </div>
 
-      searchBtn.addEventListener('click', () => {
-        clearTimeout(searchTimeout);
-        search(searchInput.value);
-      });
+    <!-- Command palette -->
+    <div id="palette" class="fixed inset-0 z-50 hidden items-start justify-center pt-[12vh] px-4" aria-hidden="true">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-palette-close></div>
+      <div class="relative w-full max-w-[620px] panel rounded-[2px] overflow-hidden shadow-2xl">
+        <div class="flex items-center gap-3 h-12 px-4 hairline-b">
+          <span class="mono text-[13px] text-[var(--color-nix-400)]">»</span>
+          <input id="paletteInput" placeholder="jump to package, run command, or search…" class="mono flex-1 bg-transparent outline-none text-[14px] text-[var(--color-fog-0)] placeholder:text-[var(--color-fog-4)]" />
+          <span class="kbd">esc</span>
+        </div>
+        <ul id="paletteList" class="max-h-[50vh] overflow-y-auto py-1"></ul>
+        <div class="px-4 py-2 hairline-t flex items-center gap-3 mono text-[10.5px] text-[var(--color-fog-4)]">
+          <span><span class="kbd">↑↓</span> navigate</span>
+          <span><span class="kbd">↵</span> select</span>
+          <span class="flex-1"></span>
+          <span>⌘K palette</span>
+        </div>
+      </div>
+    </div>
 
-      // Filter changes trigger search (dropdowns and checkbox on change)
-      ['exactMatch', 'sortOrder', 'archFilter'].forEach((id) => {
-        document.getElementById(id).addEventListener('change', () => {
-          if (searchInput.value.trim()) {
-            search(searchInput.value);
-          }
-        });
-      });
+    <!-- Toast -->
+    <div id="toast" class="fixed bottom-6 right-6 z-50 opacity-0 translate-y-4 transition mono text-[12px] px-4 py-2.5 panel rounded-[2px] pointer-events-none">
+      copied.
+    </div>
 
-      // Version filter triggers on input with debounce (like search input)
-      const versionFilter = document.getElementById('versionFilter');
-      versionFilter.addEventListener('input', () => {
-        // User is manually editing, so reset auto-populated flag
-        versionAutoPopulated = false;
-        if (searchInput.value.trim()) {
-          clearTimeout(searchTimeout);
-          searchTimeout = setTimeout(() => search(searchInput.value), 300);
-        }
-      });
-
-      // Keyboard shortcut: focus search with /
-      document.addEventListener('keydown', (e) => {
-        if (e.key === '/' && document.activeElement !== searchInput) {
-          e.preventDefault();
-          searchInput.focus();
-        }
-        if (e.key === 'Escape') {
-          document.getElementById('historyModal').classList.remove('active');
-        }
-      });
-
-      // Initialize
-      loadStats();
-      searchInput.focus();
-    </script>
+    <!-- Hide Tailwind CDN missing-source warning -->
+    <script src="./app.js" defer></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,9 +36,9 @@
 
         --color-fog-0: oklch(0.98 0.005 255);   /* pure text */
         --color-fog-1: oklch(0.88 0.01 255);    /* body text */
-        --color-fog-2: oklch(0.72 0.012 255);   /* secondary */
-        --color-fog-3: oklch(0.62 0.014 255);   /* muted — AA on ink-0/1/2 */
-        --color-fog-4: oklch(0.60 0.014 255);   /* very muted — AA on ink-0/1 */
+        --color-fog-2: oklch(0.76 0.012 255);   /* secondary */
+        --color-fog-3: oklch(0.70 0.014 255);   /* muted — AA on ink-0/1/2 */
+        --color-fog-4: oklch(0.64 0.014 255);   /* very muted — AA on ink-0/1/2 */
 
         /* Nix blue family */
         --color-nix-300: oklch(0.82 0.08 255);
@@ -218,7 +218,7 @@
     <!-- Top command bar -->
     <header class="hairline-b sticky top-0 z-30 backdrop-blur" style="background: color-mix(in oklch, var(--color-ink-0) 92%, transparent);">
       <div class="mx-auto max-w-[1320px] px-6 h-14 flex items-center gap-6">
-        <a href="#" class="flex items-center gap-2.5 group">
+        <a href="https://github.com/utensils/nxv" class="flex items-center gap-2.5 group">
           <!-- Monogram mark: nested brackets -->
           <svg width="28" height="28" viewBox="0 0 28 28" class="text-[var(--color-nix-400)]" aria-hidden="true">
             <path d="M5 4 L5 24 M5 4 L10 4 M5 24 L10 24" stroke="currentColor" stroke-width="1.5" fill="none"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -228,11 +228,11 @@
     <header class="hairline-b sticky top-0 z-30 backdrop-blur" style="background: color-mix(in oklch, var(--color-ink-0) 92%, transparent);">
       <div class="mx-auto max-w-[1320px] px-6 h-14 flex items-center gap-6">
         <a href="https://github.com/utensils/nxv" class="flex items-center gap-2.5 group">
-          <!-- Monogram mark: nested brackets -->
-          <svg width="28" height="28" viewBox="0 0 28 28" class="text-[var(--color-nix-400)]" aria-hidden="true">
-            <path d="M5 4 L5 24 M5 4 L10 4 M5 24 L10 24" stroke="currentColor" stroke-width="1.5" fill="none"/>
-            <path d="M23 4 L23 24 M23 4 L18 4 M23 24 L18 24" stroke="currentColor" stroke-width="1.5" fill="none"/>
-            <text x="14" y="18" text-anchor="middle" font-family="JetBrains Mono" font-size="11" font-weight="700" fill="currentColor">nxv</text>
+          <!-- Monogram mark: nested brackets cradling the wordmark -->
+          <svg width="38" height="38" viewBox="0 0 38 38" class="text-[var(--color-nix-400)]" aria-hidden="true">
+            <path d="M4 6 L4 32 M4 6 L10 6 M4 32 L10 32" stroke="currentColor" stroke-width="1.75" stroke-linecap="square" fill="none"/>
+            <path d="M34 6 L34 32 M34 6 L28 6 M34 32 L28 32" stroke="currentColor" stroke-width="1.75" stroke-linecap="square" fill="none"/>
+            <text x="19" y="23.5" text-anchor="middle" font-family="JetBrains Mono" font-size="12.5" font-weight="700" fill="currentColor" letter-spacing="-0.3">nxv</text>
           </svg>
           <span class="mono text-[13px] text-[var(--color-fog-2)] tracking-tight">
             <span class="text-[var(--color-fog-0)] font-semibold">nxv</span><span class="text-[var(--color-fog-4)]">@</span><span>urandom.io</span>

--- a/scripts/a11y_check.py
+++ b/scripts/a11y_check.py
@@ -171,6 +171,7 @@ CONTRAST_PAIRS: list[tuple[str, str, str]] = [
     ("fog-4", "ink-1", "text"),
     ("fog-2", "ink-2", "text"),
     ("fog-3", "ink-2", "text"),
+    ("fog-4", "ink-2", "text"),
     # accent / semantic on ground
     ("nix-300", "ink-0", "text"),
     ("nix-400", "ink-0", "text"),

--- a/scripts/a11y_check.py
+++ b/scripts/a11y_check.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Static WCAG 2.1 audit for nxv's frontend.
+
+Parses frontend/index.html (or any path passed on the command line), enforces
+a markup rule set tuned to this project, and audits contrast of the oklch
+design tokens declared in the `@theme` block.
+
+Exit code: 0 on success, 1 if any error-level findings, 2 on usage errors.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from bs4 import BeautifulSoup, Tag
+import wcag_contrast_ratio as wcag
+
+
+RESET = "\033[0m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+GREEN = "\033[32m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+
+
+@dataclass
+class Finding:
+    severity: str  # "error" | "warn" | "info"
+    rule: str
+    message: str
+    where: str = ""
+    hint: str = ""
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+
+    def error(self, rule: str, message: str, where: str = "", hint: str = "") -> None:
+        self.findings.append(Finding("error", rule, message, where, hint))
+
+    def warn(self, rule: str, message: str, where: str = "", hint: str = "") -> None:
+        self.findings.append(Finding("warn", rule, message, where, hint))
+
+    def info(self, rule: str, message: str, where: str = "", hint: str = "") -> None:
+        self.findings.append(Finding("info", rule, message, where, hint))
+
+    def has_errors(self) -> bool:
+        return any(f.severity == "error" for f in self.findings)
+
+    def print(self, use_color: bool) -> None:
+        def c(code: str, text: str) -> str:
+            return f"{code}{text}{RESET}" if use_color else text
+
+        if not self.findings:
+            print(c(GREEN, "✓ no a11y findings"))
+            return
+
+        by_sev = {"error": [], "warn": [], "info": []}
+        for f in self.findings:
+            by_sev[f.severity].append(f)
+
+        for sev, color in (("error", RED), ("warn", YELLOW), ("info", DIM)):
+            items = by_sev[sev]
+            if not items:
+                continue
+            print(c(BOLD, f"{sev.upper()} ({len(items)})"))
+            for f in items:
+                head = f"  {c(color, '•')} [{f.rule}] {f.message}"
+                if f.where:
+                    head += c(DIM, f"  — {f.where}")
+                print(head)
+                if f.hint:
+                    print(c(DIM, f"      → {f.hint}"))
+            print()
+
+        counts = ", ".join(
+            f"{len(by_sev[s])} {s}" for s in ("error", "warn", "info") if by_sev[s]
+        )
+        print(c(BOLD, f"summary: {counts}"))
+
+
+# ---------------------------------------------------------------------------
+# oklch → sRGB, then wcag contrast.
+# Math per https://bottosson.github.io/posts/oklab/ — standard D65 sRGB pipeline.
+
+
+def _oklch_to_oklab(L: float, C: float, h_deg: float) -> tuple[float, float, float]:
+    h = math.radians(h_deg)
+    return (L, C * math.cos(h), C * math.sin(h))
+
+
+def _oklab_to_linear_srgb(L: float, a: float, b: float) -> tuple[float, float, float]:
+    l_ = L + 0.3963377774 * a + 0.2158037573 * b
+    m_ = L - 0.1055613458 * a - 0.0638541728 * b
+    s_ = L - 0.0894841775 * a - 1.2914855480 * b
+    l, m, s = l_ ** 3, m_ ** 3, s_ ** 3
+    return (
+        +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+        -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+        -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
+    )
+
+
+def _linear_to_srgb(c: float) -> float:
+    c = max(0.0, min(1.0, c))
+    if c <= 0.0031308:
+        return 12.92 * c
+    return 1.055 * (c ** (1.0 / 2.4)) - 0.055
+
+
+def oklch_to_srgb(L: float, C: float, h: float) -> tuple[float, float, float]:
+    lab = _oklch_to_oklab(L, C, h)
+    lin = _oklab_to_linear_srgb(*lab)
+    return tuple(_linear_to_srgb(c) for c in lin)  # type: ignore[return-value]
+
+
+_OKLCH_RE = re.compile(
+    r"oklch\(\s*([0-9.]+)\s+([0-9.]+)\s+([0-9.]+)(?:\s*/\s*[0-9.]+)?\s*\)"
+)
+
+
+def parse_oklch(value: str) -> tuple[float, float, float] | None:
+    m = _OKLCH_RE.search(value)
+    if not m:
+        return None
+    return (float(m.group(1)), float(m.group(2)), float(m.group(3)))
+
+
+# ---------------------------------------------------------------------------
+# Design tokens — extracted from the @theme block inside <style type="text/tailwindcss">.
+
+
+_THEME_BLOCK_RE = re.compile(r"@theme\s*\{(.*?)\}", re.DOTALL)
+_TOKEN_RE = re.compile(r"--color-([a-z0-9-]+)\s*:\s*([^;]+?)\s*;")
+
+
+def extract_color_tokens(html: str) -> dict[str, tuple[float, float, float]]:
+    """Return {name: (L, C, h)} for each `--color-*: oklch(...)` token in @theme."""
+    tokens: dict[str, tuple[float, float, float]] = {}
+    for theme in _THEME_BLOCK_RE.finditer(html):
+        for name, value in _TOKEN_RE.findall(theme.group(1)):
+            parsed = parse_oklch(value)
+            if parsed:
+                tokens[name] = parsed
+    return tokens
+
+
+# Documented foreground/background pairs used across the design.
+# (fg_token, bg_token, role) — role controls the WCAG threshold.
+# role="text": 4.5:1 required (AA normal text)
+# role="large": 3.0:1 required (AA large / bold text)
+# role="ui":   3.0:1 required (AA non-text UI component boundary)
+CONTRAST_PAIRS: list[tuple[str, str, str]] = [
+    # body text on primary surfaces
+    ("fog-0", "ink-0", "text"),
+    ("fog-1", "ink-0", "text"),
+    ("fog-2", "ink-0", "text"),
+    ("fog-3", "ink-0", "text"),
+    ("fog-4", "ink-0", "text"),
+    ("fog-0", "ink-1", "text"),
+    ("fog-1", "ink-1", "text"),
+    ("fog-2", "ink-1", "text"),
+    ("fog-3", "ink-1", "text"),
+    ("fog-4", "ink-1", "text"),
+    ("fog-2", "ink-2", "text"),
+    ("fog-3", "ink-2", "text"),
+    # accent / semantic on ground
+    ("nix-300", "ink-0", "text"),
+    ("nix-400", "ink-0", "text"),
+    ("phos-400", "ink-0", "text"),
+    ("amber-glow", "ink-0", "text"),
+    ("red-glow", "ink-0", "text"),
+    ("green-glow", "ink-0", "text"),
+    # primary button: white text on nix-600
+    # we synthesize "white" below
+]
+
+
+def audit_contrast(
+    tokens: dict[str, tuple[float, float, float]], report: Report
+) -> None:
+    if not tokens:
+        report.warn(
+            "theme-tokens",
+            "no `--color-*: oklch(...)` tokens found in @theme block",
+            hint="skipped contrast audit — verify the inline <style type=\"text/tailwindcss\"> block is present",
+        )
+        return
+
+    for fg, bg, role in CONTRAST_PAIRS:
+        if fg not in tokens or bg not in tokens:
+            continue
+        fg_rgb = oklch_to_srgb(*tokens[fg])
+        bg_rgb = oklch_to_srgb(*tokens[bg])
+        ratio = wcag.rgb(fg_rgb, bg_rgb)
+        threshold = 4.5 if role == "text" else 3.0
+        where = f"--color-{fg} on --color-{bg}"
+        if ratio < threshold:
+            report.error(
+                "contrast",
+                f"{ratio:.2f}:1 fails WCAG AA ({role}: needs ≥{threshold}:1)",
+                where=where,
+                hint="darken the background or lighten the foreground token until ratio ≥ threshold",
+            )
+        elif ratio < threshold + 1.5:
+            report.info(
+                "contrast",
+                f"{ratio:.2f}:1 passes AA ({role} ≥{threshold}:1) but below AAA",
+                where=where,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Markup rules.
+
+
+def _selector(tag: Tag) -> str:
+    tag_name = tag.name or "?"
+    id_ = tag.get("id")
+    cls = tag.get("class") or []
+    bits = [tag_name]
+    if id_:
+        bits.append(f"#{id_}")
+    if cls:
+        bits.append("." + ".".join(cls[:2]))
+    return "".join(bits)
+
+
+def _accessible_text(tag: Tag) -> str:
+    if tag.get("aria-label"):
+        return str(tag["aria-label"]).strip()
+    if tag.get("aria-labelledby"):
+        return f"[labelledby:{tag['aria-labelledby']}]"
+    text = tag.get_text(strip=True)
+    if text:
+        return text
+    # titled child svg/img counts as an accessible name
+    title = tag.find("title")
+    if title and title.get_text(strip=True):
+        return title.get_text(strip=True)
+    for child in tag.find_all(["svg", "img"]):
+        if child.get("aria-label") or child.get("title"):
+            return str(child.get("aria-label") or child.get("title"))
+    return ""
+
+
+def check_document(soup: BeautifulSoup, report: Report) -> None:
+    html_tag = soup.find("html")
+    if not isinstance(html_tag, Tag) or not html_tag.get("lang"):
+        report.error(
+            "html-lang",
+            "<html> element has no lang attribute",
+            hint='add lang="en" (or appropriate) so assistive tech announces the language',
+        )
+
+    title = soup.find("title")
+    if not title or not title.get_text(strip=True):
+        report.error("title", "missing or empty <title>")
+
+    body = soup.find("body")
+    if not isinstance(body, Tag):
+        report.error("body", "no <body> element found")
+
+
+def check_landmarks(soup: BeautifulSoup, report: Report) -> None:
+    main_tags = soup.find_all("main")
+    if len(main_tags) == 0:
+        report.error(
+            "landmark-main",
+            "no <main> landmark",
+            hint="wrap the primary page content in <main> so screen-reader users can jump to it",
+        )
+    elif len(main_tags) > 1:
+        report.warn("landmark-main", f"{len(main_tags)} <main> elements — there should be exactly one")
+
+    for lm in ("header", "nav", "footer"):
+        if not soup.find(lm):
+            report.warn(
+                "landmark",
+                f"no <{lm}> landmark found",
+                hint=f"use <{lm}> to group page chrome; helps landmark navigation",
+            )
+
+
+def check_skip_link(soup: BeautifulSoup, report: Report) -> None:
+    body = soup.find("body")
+    if not isinstance(body, Tag):
+        return
+    # First focusable descendant should be a same-page link targeting #main-ish.
+    first_focusable = body.find(lambda t: isinstance(t, Tag) and t.name in ("a", "button"))
+    if not isinstance(first_focusable, Tag):
+        return
+    is_skip = (
+        first_focusable.name == "a"
+        and str(first_focusable.get("href", "")).startswith("#")
+        and "skip" in (first_focusable.get_text(strip=True) or "").lower()
+    )
+    if not is_skip:
+        report.error(
+            "skip-link",
+            "no skip-to-content link as first focusable element in <body>",
+            hint='add e.g. <a href="#main" class="sr-only focus:not-sr-only">Skip to main content</a> and ensure <main id="main">',
+        )
+
+
+def check_form_controls(soup: BeautifulSoup, report: Report) -> None:
+    for ctrl in soup.find_all(["input", "textarea", "select"]):
+        if ctrl.get("type") in ("hidden", "submit", "button", "reset", "image"):
+            continue
+        id_ = ctrl.get("id")
+        has_label = False
+        if id_:
+            has_label = bool(soup.find("label", attrs={"for": id_}))
+        has_label = has_label or bool(ctrl.get("aria-label") or ctrl.get("aria-labelledby"))
+        # title as a last-resort accessible name
+        has_label = has_label or bool(ctrl.get("title"))
+        # wrapped <label>input</label> pattern
+        if not has_label:
+            parent = ctrl.find_parent("label")
+            has_label = parent is not None
+        if not has_label:
+            report.error(
+                "form-label",
+                "form control has no associated label",
+                where=_selector(ctrl),
+                hint='attach a <label for="id">, aria-label, or aria-labelledby — placeholder text is not a label',
+            )
+
+
+def check_images(soup: BeautifulSoup, report: Report) -> None:
+    for img in soup.find_all("img"):
+        if img.get("alt") is None:
+            report.error(
+                "img-alt",
+                "<img> missing alt attribute",
+                where=_selector(img),
+                hint='add alt="" for decorative images, or descriptive alt for meaningful ones',
+            )
+
+
+def check_svgs(soup: BeautifulSoup, report: Report) -> None:
+    for svg in soup.find_all("svg"):
+        if svg.get("aria-hidden") == "true":
+            continue
+        if svg.get("role") == "img" and (svg.get("aria-label") or svg.find("title")):
+            continue
+        # svg embedded inside a button/link with its own accessible name is OK
+        parent = svg.find_parent(lambda t: isinstance(t, Tag) and t.name in ("a", "button"))
+        if parent is not None and _accessible_text(parent).replace(
+            _accessible_text(svg), ""
+        ).strip():
+            continue
+        report.warn(
+            "svg-a11y",
+            "decorative <svg> should be hidden, or meaningful <svg> needs role+label",
+            where=_selector(svg),
+            hint='add aria-hidden="true" if decorative, or role="img" + <title> / aria-label if informative',
+        )
+
+
+def check_headings(soup: BeautifulSoup, report: Report) -> None:
+    headings = soup.find_all(re.compile(r"^h[1-6]$"))
+    levels = [int(h.name[1]) for h in headings]
+    if not levels:
+        report.warn("headings", "no headings found")
+        return
+    if 1 not in levels:
+        report.warn("headings", "no <h1> on the page")
+    prev = 0
+    for i, lvl in enumerate(levels):
+        if prev and lvl > prev + 1:
+            report.warn(
+                "heading-skip",
+                f"heading jumps from h{prev} to h{lvl} — skipping levels",
+                where=_selector(headings[i]),
+                hint="don't skip levels — a user navigating by heading expects a continuous outline",
+            )
+        prev = lvl
+
+
+def check_interactive_text(soup: BeautifulSoup, report: Report) -> None:
+    for el in soup.find_all(["button", "a"]):
+        if el.name == "a" and not el.get("href"):
+            continue  # anchor without href isn't focusable
+        if el.get("aria-hidden") == "true":
+            continue
+        if not _accessible_text(el):
+            report.error(
+                "accessible-name",
+                f"<{el.name}> has no accessible name",
+                where=_selector(el),
+                hint="add text content, aria-label, or a titled <svg> child",
+            )
+
+
+def check_dialog_roles(soup: BeautifulSoup, report: Report) -> None:
+    for el in soup.find_all(attrs={"role": "dialog"}):
+        if el.get("aria-modal") != "true":
+            report.warn(
+                "dialog-modal",
+                'role="dialog" missing aria-modal="true"',
+                where=_selector(el),
+            )
+        if not (el.get("aria-label") or el.get("aria-labelledby")):
+            report.error(
+                "dialog-label",
+                'role="dialog" needs aria-label or aria-labelledby',
+                where=_selector(el),
+            )
+
+
+# Callable ordering for the markup pass.
+MARKUP_CHECKS = [
+    check_document,
+    check_landmarks,
+    check_skip_link,
+    check_form_controls,
+    check_images,
+    check_svgs,
+    check_headings,
+    check_interactive_text,
+    check_dialog_roles,
+]
+
+
+# ---------------------------------------------------------------------------
+# Entry point.
+
+
+def run(paths: Iterable[Path]) -> int:
+    any_errors = False
+    for path in paths:
+        html = path.read_text(encoding="utf-8")
+        soup = BeautifulSoup(html, "html.parser")
+        report = Report()
+
+        print(f"{BOLD}a11y check · {path}{RESET}")
+        for check in MARKUP_CHECKS:
+            check(soup, report)
+        audit_contrast(extract_color_tokens(html), report)
+        report.print(use_color=sys.stdout.isatty())
+        if report.has_errors():
+            any_errors = True
+        print()
+
+    return 1 if any_errors else 0
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    if not args:
+        args = ["frontend/index.html"]
+    paths = [Path(a) for a in args]
+    missing = [p for p in paths if not p.exists()]
+    if missing:
+        for p in missing:
+            print(f"error: {p} does not exist", file=sys.stderr)
+        return 2
+    return run(paths)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -655,6 +655,8 @@ pub async fn get_metrics(State(state): State<Arc<AppState>>) -> Json<types::Metr
             enabled: true,
         });
 
+    let snapshot = state.metrics.snapshot();
+
     Json(types::MetricsResponse {
         server: types::ServerMetrics {
             version: version::full_version(),
@@ -667,5 +669,24 @@ pub async fn get_metrics(State(state): State<Arc<AppState>>) -> Json<types::Metr
             timeout_seconds: state.db_timeout.as_secs(),
         },
         rate_limit,
+        runtime: types::RuntimeMetrics {
+            started_at: snapshot.started_at,
+            uptime_seconds: snapshot.uptime_seconds,
+            total_requests: snapshot.total_requests,
+        },
+        latency: types::LatencyMetrics {
+            p50_ms: snapshot.p50_ms,
+            p95_ms: snapshot.p95_ms,
+            p99_ms: snapshot.p99_ms,
+            samples: snapshot.latency_samples,
+        },
+        activity: snapshot
+            .activity
+            .into_iter()
+            .map(|b| types::ActivityBucketSchema {
+                minute: b.minute,
+                count: b.count,
+            })
+            .collect(),
     })
 }

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -1,0 +1,217 @@
+//! In-memory runtime metrics: rolling request-latency window, per-minute
+//! activity ring buffer, process start time, and a total-request counter.
+//!
+//! All state is in-memory and lost on restart — the front end labels the
+//! corresponding panels "activity · 30m" and "uptime since start", so the
+//! numbers remain honest.
+
+use chrono::{DateTime, Utc};
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Number of most-recent request durations kept for percentile computation.
+const LATENCY_WINDOW: usize = 1024;
+/// Number of one-minute activity buckets reported (last 30 minutes).
+pub const ACTIVITY_BUCKETS: usize = 30;
+
+/// Aggregate metrics store. Shared across request handlers via `AppState`.
+pub struct MetricsStore {
+    started_at: SystemTime,
+    total_requests: AtomicU64,
+    /// Rolling window of per-request latencies in microseconds, for API routes only.
+    latency_us: Mutex<VecDeque<u32>>,
+    /// Sparse per-minute counts over all HTTP traffic, newest at the back.
+    activity: Mutex<VecDeque<(u64, u64)>>,
+}
+
+impl MetricsStore {
+    pub fn new() -> Self {
+        Self {
+            started_at: SystemTime::now(),
+            total_requests: AtomicU64::new(0),
+            latency_us: Mutex::new(VecDeque::with_capacity(LATENCY_WINDOW)),
+            activity: Mutex::new(VecDeque::with_capacity(ACTIVITY_BUCKETS + 1)),
+        }
+    }
+
+    /// Record a completed request.
+    ///
+    /// `is_api` gates inclusion in the latency percentile window so static-asset
+    /// responses (which are sub-ms) don't distort the reported API latency.
+    pub fn record(&self, elapsed_micros: u128, is_api: bool) {
+        self.total_requests.fetch_add(1, Ordering::Relaxed);
+
+        let now_secs = now_epoch_secs();
+        if let Ok(mut act) = self.activity.lock() {
+            record_activity(&mut act, now_secs);
+        }
+
+        if is_api && let Ok(mut buf) = self.latency_us.lock() {
+            let micros = elapsed_micros.min(u32::MAX as u128) as u32;
+            if buf.len() >= LATENCY_WINDOW {
+                buf.pop_front();
+            }
+            buf.push_back(micros);
+        }
+    }
+
+    pub fn snapshot(&self) -> Snapshot {
+        let now_secs = now_epoch_secs();
+        let uptime = SystemTime::now()
+            .duration_since(self.started_at)
+            .unwrap_or_default();
+
+        // Latency percentiles
+        let (p50_ms, p95_ms, p99_ms, samples) = match self.latency_us.lock() {
+            Ok(buf) => {
+                let mut sorted: Vec<u32> = buf.iter().copied().collect();
+                sorted.sort_unstable();
+                let samples = sorted.len() as u64;
+                let pct = |q: f64| -> f64 {
+                    if sorted.is_empty() {
+                        return 0.0;
+                    }
+                    let idx = ((sorted.len() as f64 - 1.0) * q).round() as usize;
+                    sorted[idx.min(sorted.len() - 1)] as f64 / 1000.0
+                };
+                (pct(0.50), pct(0.95), pct(0.99), samples)
+            }
+            Err(_) => (0.0, 0.0, 0.0, 0),
+        };
+
+        // Activity: materialize a dense 30-entry array ending at the current minute
+        let activity = match self.activity.lock() {
+            Ok(buf) => snapshot_activity(&buf, now_secs),
+            Err(_) => (0..ACTIVITY_BUCKETS as u64)
+                .map(|i| ActivityBucket {
+                    minute: minute_to_datetime(
+                        now_secs - now_secs % 60 - (ACTIVITY_BUCKETS as u64 - 1 - i) * 60,
+                    ),
+                    count: 0,
+                })
+                .collect(),
+        };
+
+        Snapshot {
+            started_at: DateTime::<Utc>::from(self.started_at),
+            uptime_seconds: uptime.as_secs(),
+            total_requests: self.total_requests.load(Ordering::Relaxed),
+            p50_ms,
+            p95_ms,
+            p99_ms,
+            latency_samples: samples,
+            activity,
+        }
+    }
+}
+
+impl Default for MetricsStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct Snapshot {
+    pub started_at: DateTime<Utc>,
+    pub uptime_seconds: u64,
+    pub total_requests: u64,
+    pub p50_ms: f64,
+    pub p95_ms: f64,
+    pub p99_ms: f64,
+    pub latency_samples: u64,
+    pub activity: Vec<ActivityBucket>,
+}
+
+pub struct ActivityBucket {
+    pub minute: DateTime<Utc>,
+    pub count: u64,
+}
+
+fn now_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn minute_to_datetime(minute_secs: u64) -> DateTime<Utc> {
+    DateTime::<Utc>::from(UNIX_EPOCH + std::time::Duration::from_secs(minute_secs))
+}
+
+fn record_activity(buf: &mut VecDeque<(u64, u64)>, now_secs: u64) {
+    let minute = now_secs - now_secs % 60;
+    let cutoff = minute.saturating_sub(60 * (ACTIVITY_BUCKETS as u64 - 1));
+    while let Some(&(m, _)) = buf.front() {
+        if m < cutoff {
+            buf.pop_front();
+        } else {
+            break;
+        }
+    }
+    if let Some(back) = buf.back_mut()
+        && back.0 == minute
+    {
+        back.1 += 1;
+        return;
+    }
+    buf.push_back((minute, 1));
+}
+
+fn snapshot_activity(buf: &VecDeque<(u64, u64)>, now_secs: u64) -> Vec<ActivityBucket> {
+    let minute = now_secs - now_secs % 60;
+    (0..ACTIVITY_BUCKETS as u64)
+        .map(|i| {
+            let m = minute - (ACTIVITY_BUCKETS as u64 - 1 - i) * 60;
+            let count = buf
+                .iter()
+                .find(|(bm, _)| *bm == m)
+                .map(|(_, c)| *c)
+                .unwrap_or(0);
+            ActivityBucket {
+                minute: minute_to_datetime(m),
+                count,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_activity_appends_and_evicts() {
+        let mut buf = VecDeque::new();
+        // t = 1000s → minute 960
+        record_activity(&mut buf, 1000);
+        record_activity(&mut buf, 1010);
+        assert_eq!(buf.back().unwrap().1, 2);
+
+        // skip ahead to minute 60*35 → anything older than 29 mins should fall off
+        let new_now = 960 + 60 * 35;
+        record_activity(&mut buf, new_now);
+        assert!(buf.front().unwrap().0 >= new_now - new_now % 60 - 60 * 29);
+    }
+
+    #[test]
+    fn snapshot_gives_dense_30_buckets_even_when_idle() {
+        let buf = VecDeque::new();
+        let out = snapshot_activity(&buf, 10_000);
+        assert_eq!(out.len(), ACTIVITY_BUCKETS);
+        assert!(out.iter().all(|b| b.count == 0));
+    }
+
+    #[test]
+    fn percentile_math() {
+        let store = MetricsStore::new();
+        for us in [1000u128, 2000, 3000, 4000, 5000] {
+            store.record(us, true);
+        }
+        let s = store.snapshot();
+        // p50 of [1..5]ms should be 3ms
+        assert!((s.p50_ms - 3.0).abs() < 0.001);
+        assert_eq!(s.latency_samples, 5);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,17 +31,20 @@
 
 pub mod error;
 pub mod handlers;
+pub mod metrics;
 pub mod openapi;
 pub mod types;
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::{
     Router,
+    extract::{Request, State},
     http::{HeaderValue, header},
-    response::{Html, IntoResponse},
+    middleware::Next,
+    response::{Html, IntoResponse, Response},
     routing::get,
 };
 use tokio::sync::Semaphore;
@@ -155,6 +158,8 @@ pub struct AppState {
     pub db_timeout: Duration,
     /// Rate limit configuration (for metrics). None if rate limiting is disabled.
     pub rate_limit_config: Option<RateLimitConfig>,
+    /// In-memory runtime metrics (activity + latency + uptime).
+    pub metrics: metrics::MetricsStore,
 }
 
 impl AppState {
@@ -188,6 +193,7 @@ impl AppState {
             max_db_connections: max_connections,
             db_timeout: Duration::from_secs(timeout_secs),
             rate_limit_config: None,
+            metrics: metrics::MetricsStore::new(),
         }
     }
 
@@ -206,6 +212,7 @@ impl AppState {
             max_db_connections: max_connections,
             db_timeout: timeout,
             rate_limit_config: None,
+            metrics: metrics::MetricsStore::new(),
         }
     }
 
@@ -401,6 +408,10 @@ pub(crate) fn build_router(
         .merge(static_routes)
         .nest("/api/v1", api_routes)
         .layer(trace_layer)
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            record_request_metrics,
+        ))
         .with_state(state);
 
     if let Some(cors_layer) = cors {
@@ -560,6 +571,21 @@ async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("Failed to install CTRL+C signal handler");
+}
+
+/// Record every HTTP request in the metrics store. Latency samples are
+/// limited to `/api/v1/*` so that static-asset responses (sub-ms) don't
+/// distort the reported API percentiles; activity bars count all traffic.
+async fn record_request_metrics(
+    State(state): State<Arc<AppState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let is_api = req.uri().path().starts_with("/api/v1/");
+    let start = Instant::now();
+    let response = next.run(req).await;
+    state.metrics.record(start.elapsed().as_micros(), is_api);
+    response
 }
 
 #[cfg(test)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -61,6 +61,21 @@ const FRONTEND_HTML: &str = include_str!("../../frontend/index.html");
 /// Embedded favicon SVG.
 const FAVICON_SVG: &str = include_str!("../../frontend/favicon.svg");
 
+/// Embedded frontend JavaScript.
+const FRONTEND_JS: &str = include_str!("../../frontend/app.js");
+
+/// When `NXV_FRONTEND_DIR` is set, read `file_name` from disk on each request
+/// so HTML/JS changes are picked up without rebuilding. Falls back to the
+/// compile-time `embedded` constant if the env var is unset or the read fails.
+fn frontend_asset(file_name: &str, embedded: &'static str) -> String {
+    if let Ok(dir) = std::env::var("NXV_FRONTEND_DIR")
+        && let Ok(contents) = std::fs::read_to_string(PathBuf::from(dir).join(file_name))
+    {
+        return contents;
+    }
+    embedded.to_string()
+}
+
 /// Default maximum concurrent database operations.
 /// This limits file descriptor usage and prevents spawn_blocking pool exhaustion.
 /// Can be overridden via NXV_MAX_DB_CONNECTIONS environment variable.
@@ -315,7 +330,7 @@ pub(crate) fn build_router(
         .route("/metrics", get(handlers::get_metrics))
         .layer(SetResponseHeaderLayer::overriding(
             header::CACHE_CONTROL,
-            no_cache,
+            no_cache.clone(),
         ));
 
     // Combine API routes
@@ -325,17 +340,41 @@ pub(crate) fn build_router(
 
     // Static assets with long cache (24 hours)
     let static_routes = Router::new()
-        .route("/", get(|| async { Html(FRONTEND_HTML) }))
+        .route(
+            "/",
+            get(|| async { Html(frontend_asset("index.html", FRONTEND_HTML)) }),
+        )
         .route(
             "/favicon.svg",
             get(|| async {
-                ([(header::CONTENT_TYPE, "image/svg+xml")], FAVICON_SVG).into_response()
+                (
+                    [(header::CONTENT_TYPE, "image/svg+xml")],
+                    frontend_asset("favicon.svg", FAVICON_SVG),
+                )
+                    .into_response()
             }),
         )
         .route(
             "/favicon.ico",
             get(|| async {
-                ([(header::CONTENT_TYPE, "image/svg+xml")], FAVICON_SVG).into_response()
+                (
+                    [(header::CONTENT_TYPE, "image/svg+xml")],
+                    frontend_asset("favicon.svg", FAVICON_SVG),
+                )
+                    .into_response()
+            }),
+        )
+        .route(
+            "/app.js",
+            get(|| async {
+                (
+                    [(
+                        header::CONTENT_TYPE,
+                        "application/javascript; charset=utf-8",
+                    )],
+                    frontend_asset("app.js", FRONTEND_JS),
+                )
+                    .into_response()
             }),
         )
         .merge(Scalar::with_url("/docs", openapi::ApiDoc::openapi()))
@@ -345,7 +384,11 @@ pub(crate) fn build_router(
         )
         .layer(SetResponseHeaderLayer::if_not_present(
             header::CACHE_CONTROL,
-            cache_24h,
+            if std::env::var("NXV_FRONTEND_DIR").is_ok() {
+                no_cache.clone()
+            } else {
+                cache_24h
+            },
         ));
 
     // Configure tracing layer with request/response logging

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -162,6 +162,45 @@ pub struct MetricsResponse {
     /// Rate limiting metrics (if enabled).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<RateLimitMetrics>,
+    /// Process runtime information (start time, uptime, total requests).
+    pub runtime: RuntimeMetrics,
+    /// Request latency percentiles over a rolling window of recent API requests.
+    pub latency: LatencyMetrics,
+    /// Request activity bucketed per minute for the last 30 minutes (oldest first).
+    pub activity: Vec<ActivityBucketSchema>,
+}
+
+/// Runtime metrics: process start time and request count.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RuntimeMetrics {
+    /// When the server process started.
+    pub started_at: DateTime<Utc>,
+    /// Seconds since the process started.
+    pub uptime_seconds: u64,
+    /// Total HTTP requests served since start (all routes).
+    pub total_requests: u64,
+}
+
+/// Latency percentile snapshot in milliseconds.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LatencyMetrics {
+    /// 50th-percentile request latency, milliseconds.
+    pub p50_ms: f64,
+    /// 95th-percentile request latency, milliseconds.
+    pub p95_ms: f64,
+    /// 99th-percentile request latency, milliseconds.
+    pub p99_ms: f64,
+    /// Number of samples that back these percentiles.
+    pub samples: u64,
+}
+
+/// Per-minute request count.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ActivityBucketSchema {
+    /// Start of the minute (UTC, truncated to :00 seconds).
+    pub minute: DateTime<Utc>,
+    /// Number of requests served during that minute.
+    pub count: u64,
 }
 
 /// Server-level metrics.


### PR DESCRIPTION
## Summary

- **Add static WCAG + dynamic pa11y-ci tooling.** New `scripts/a11y_check.py` (offline, parses `frontend/index.html`, validates landmarks/labels/ARIA/headings/skip-link/dialog semantics and runs an oklch→sRGB contrast audit over every `@theme` color token). Wired into the devshell as `a11y` and into `nix flake check` as `nxv-a11y`. Adds `html5validator`, `python3 (bs4 + wcag-contrast-ratio)`, and `nodejs_22` to the devshell. Opt-in `a11y-live` command runs `pa11y-ci` via `npx` against a running `nxv serve`.
- **Fix the WCAG findings the new tooling surfaced.** Skip-to-content link, `aria-label`s on #searchInput / #paletteInput / GitHub link, `role="dialog"` + `aria-modal` + labelledby on drawer and palette, h3→h2 so the drawer doesn't skip the heading outline, fog-3/fog-4 tokens pushed above 4.5:1 on every surface they're used on.
- **Brighten the palette and tidy the modal overlay.** Fog tokens stepped up twice across two passes (fog-0 .98→.99, fog-1 .88→.93, fog-2 .72→.82, fog-3 .56→.76, fog-4 .42→.70). Drawer + palette overlays replaced `bg-black/60 backdrop-blur-sm` with `.overlay-dim` — a 35%-ink tint over `blur(3px) saturate(115%)` — so the page reads *behind* an open modal instead of blacking out. Drawer panel promoted to ink-2 with a shadow.
- **Persist search + filter state in the URL.** Query, every filter (exact/version/arch/license/sort/insecure), view mode, and page round-trip via `history.replaceState`. Refreshing the page or sharing a link restores the full UI state. Hydrate before boot so the search fires once, not twice.
- **Autoscale the version-history timeline.** The drawer graph no longer hard-codes the 2017 floor — axis spans the package's actual first_seen/last_seen with 4% padding and a 90-day minimum. Year gridlines, label, and tick row all derive from the window; flake-epoch line only draws when 2020-02-10 is visible.
- **Header polish.** `nxv@urandom.io` brand link now points at the repo; brand monogram enlarged 28→38 with square linecaps, wider bracket spacing, and a tightened wordmark. `cp` button labels → `copy`.

## Codex review

Ran `codex review --base main` (high reasoning). Three P2 findings, all fixed in `a14eb97`:

1. **Wrong ref in copy-flake / copy-run** — `first_commit_hash` was used for non-legacy packages whose first_commit predates flakes, producing invalid `nix shell nixpkgs/<pre-flake-ref>#...`. Now prefers `last_commit_hash` for the flake path; tarball-import path keeps first_commit_hash.
2. **`"null"` sentinel treated as insecure** — the literal string `"null"` that the DB sometimes stores for missing JSON was parsed as a one-element array, flipping rows insecure and hiding them. Normalized to `[]` to match server-side logic.
3. **Filtering after pagination** — `arch` / default `!includeInsecure` are client-only filters (the API has no params for them); applying them after server pagination left the count and prev/next inconsistent. When a client filter is active, now fetches `CLIENT_FILTER_LIMIT = 500` rows and paginates the filtered list on the client.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --features indexer -- -D warnings`, `cargo test --features indexer`
- [x] `prettier --check frontend/**/*.{html,js,json}`
- [x] `a11y` (devshell) — `nxv-a11y` check passes in `nix flake check`
- [x] Playwright smoke: URL hydration (`?q=python&sort=name&insecure=1` → input + chips + 653 results), default-filter pagination (`?q=python` → `results / 56`, `page 1/2 · 1–50 of 56`), drawer timeline autoscales (nodejs-slim → 2024→2026, python3Minimal → 2019→2026), drawer overlay lets page content show through
- [x] Manual spot-check on the dev server in a real browser