### PR TITLE
feat(update): check for newer nxv release after the index refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,30 +148,29 @@ nix shell nixpkgs/e4a45f9#python
 nix run nixpkgs/e4a45f9#python
 ```
 
-### Index Management
+### Keeping nxv up to date
 
 ```bash
-nxv update           # Download/update the index
-nxv update --force   # Force full re-download
-nxv stats            # Show index statistics
+nxv update                    # Refresh the index, then check for a newer nxv release
+nxv update --force            # Force a full re-download of the index
+nxv update --no-self-update   # Only refresh the index; skip the binary check
+nxv stats                     # Show index statistics
 ```
 
-### Updating nxv itself
+`nxv update` always refreshes the package index first. Afterwards it
+checks GitHub for a newer nxv release and behaves according to how nxv
+was installed:
 
-```bash
-nxv self-update              # Fetch the latest GitHub release and replace the binary
-nxv self-update --check      # Only report whether a newer release exists
-nxv self-update --version v0.2.0   # Pin to a specific release tag
-```
-
-`self-update` inspects how nxv was installed and does the right thing:
-
-- **Nix / cargo / Homebrew** — prints the command to run with your package
-  manager (e.g. `brew upgrade nxv`) and exits with status `2` without
-  touching the binary.
 - **Local install** (from `install.sh` or a manual download) — downloads
   the platform binary, verifies its SHA-256 against `SHA256SUMS.txt`, and
   atomically swaps the running executable.
+- **Nix / cargo / Homebrew** — leaves the binary alone and prints the
+  matching upgrade command (e.g. `brew upgrade nxv`,
+  `cargo install --locked nxv`).
+
+Set `NXV_NO_SELF_UPDATE=1` or pass `--no-self-update` to skip the binary
+check entirely (useful for CI or systemd timer units that only want to
+refresh the index).
 
 ## API Server
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ nxv update --force   # Force full re-download
 nxv stats            # Show index statistics
 ```
 
+### Updating nxv itself
+
+```bash
+nxv self-update              # Fetch the latest GitHub release and replace the binary
+nxv self-update --check      # Only report whether a newer release exists
+nxv self-update --version v0.2.0   # Pin to a specific release tag
+```
+
+`self-update` inspects how nxv was installed and does the right thing:
+
+- **Nix / cargo / Homebrew** — prints the command to run with your package
+  manager (e.g. `brew upgrade nxv`) and exits with status `2` without
+  touching the binary.
+- **Local install** (from `install.sh` or a manual download) — downloads
+  the platform binary, verifies its SHA-256 against `SHA256SUMS.txt`, and
+  atomically swaps the running executable.
+
 ## API Server
 
 Run nxv as an HTTP API server with a built-in web interface:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,27 +43,17 @@ pub enum Commands {
     /// Search for package versions.
     Search(SearchArgs),
 
-    /// Download or update the package index.
-    Update(UpdateArgs),
-
-    /// Update the nxv binary itself to the latest GitHub release.
+    /// Update the package index, then check for a newer nxv release.
     ///
-    /// Detects how nxv was installed. For managed installs (Nix, cargo,
-    /// Homebrew) this prints the correct upgrade command instead of
-    /// trying to overwrite a read-only binary. For local installs it
-    /// downloads the platform-specific release, verifies its SHA-256
-    /// checksum against SHA256SUMS.txt, and replaces the running
-    /// binary in place.
-    #[command(
-        disable_version_flag = true,
-        after_long_help = "\
-Examples:
-  nxv self-update                  Update to the latest release
-  nxv self-update --check          Only report whether a newer release exists
-  nxv self-update --version v0.2.0 Install a specific release tag
-  nxv self-update --force          Reinstall even if already up-to-date"
-    )]
-    SelfUpdate(SelfUpdateArgs),
+    /// This runs the index refresh first. Afterwards it checks GitHub
+    /// for a newer nxv binary. On a local install (install.sh, manual
+    /// download) the new binary is downloaded, its SHA-256 is verified
+    /// against SHA256SUMS.txt, and the running executable is replaced
+    /// atomically. On managed installs (Nix, cargo, Homebrew) the
+    /// binary is left alone and the matching upgrade command is
+    /// printed instead. Pass `--no-self-update` to skip the binary
+    /// check entirely and only refresh the index.
+    Update(UpdateArgs),
 
     /// Show detailed information about a package.
     Info(InfoArgs),
@@ -226,22 +216,14 @@ pub struct UpdateArgs {
     /// Can be the raw key (RW...) or path to a .pub file.
     #[arg(long, env = "NXV_PUBLIC_KEY")]
     pub public_key: Option<String>,
-}
 
-/// Arguments for the self-update command.
-#[derive(Parser, Debug)]
-pub struct SelfUpdateArgs {
-    /// Only check for updates; do not download or install anything.
-    #[arg(long)]
-    pub check: bool,
-
-    /// Reinstall even if the current version already matches the release.
-    #[arg(long)]
-    pub force: bool,
-
-    /// Install a specific release tag (e.g. `v0.2.0` or `0.2.0`).
-    #[arg(long)]
-    pub version: Option<String>,
+    /// Skip the binary self-update check after the index refresh.
+    ///
+    /// By default, `nxv update` also checks GitHub for a newer nxv release
+    /// and updates the binary (for local installs) or prints a hint (for
+    /// managed installs). Pass this flag to only refresh the index.
+    #[arg(long, env = "NXV_NO_SELF_UPDATE")]
+    pub no_self_update: bool,
 }
 
 /// Arguments for the history command.
@@ -714,28 +696,13 @@ mod tests {
     }
 
     #[test]
-    fn test_self_update_default() {
-        let args = Cli::try_parse_from(["nxv", "self-update"]).unwrap();
+    fn test_update_no_self_update_flag() {
+        let args = Cli::try_parse_from(["nxv", "update", "--no-self-update"]).unwrap();
         match args.command {
-            Commands::SelfUpdate(su) => {
-                assert!(!su.check);
-                assert!(!su.force);
-                assert!(su.version.is_none());
+            Commands::Update(u) => {
+                assert!(u.no_self_update);
             }
-            _ => panic!("Expected SelfUpdate command"),
-        }
-    }
-
-    #[test]
-    fn test_self_update_flags() {
-        let args =
-            Cli::try_parse_from(["nxv", "self-update", "--check", "--version", "v0.2.0"]).unwrap();
-        match args.command {
-            Commands::SelfUpdate(su) => {
-                assert!(su.check);
-                assert_eq!(su.version.as_deref(), Some("v0.2.0"));
-            }
-            _ => panic!("Expected SelfUpdate command"),
+            _ => panic!("Expected Update command"),
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,25 @@ pub enum Commands {
     /// Download or update the package index.
     Update(UpdateArgs),
 
+    /// Update the nxv binary itself to the latest GitHub release.
+    ///
+    /// Detects how nxv was installed. For managed installs (Nix, cargo,
+    /// Homebrew) this prints the correct upgrade command instead of
+    /// trying to overwrite a read-only binary. For local installs it
+    /// downloads the platform-specific release, verifies its SHA-256
+    /// checksum against SHA256SUMS.txt, and replaces the running
+    /// binary in place.
+    #[command(
+        disable_version_flag = true,
+        after_long_help = "\
+Examples:
+  nxv self-update                  Update to the latest release
+  nxv self-update --check          Only report whether a newer release exists
+  nxv self-update --version v0.2.0 Install a specific release tag
+  nxv self-update --force          Reinstall even if already up-to-date"
+    )]
+    SelfUpdate(SelfUpdateArgs),
+
     /// Show detailed information about a package.
     Info(InfoArgs),
 
@@ -207,6 +226,22 @@ pub struct UpdateArgs {
     /// Can be the raw key (RW...) or path to a .pub file.
     #[arg(long, env = "NXV_PUBLIC_KEY")]
     pub public_key: Option<String>,
+}
+
+/// Arguments for the self-update command.
+#[derive(Parser, Debug)]
+pub struct SelfUpdateArgs {
+    /// Only check for updates; do not download or install anything.
+    #[arg(long)]
+    pub check: bool,
+
+    /// Reinstall even if the current version already matches the release.
+    #[arg(long)]
+    pub force: bool,
+
+    /// Install a specific release tag (e.g. `v0.2.0` or `0.2.0`).
+    #[arg(long)]
+    pub version: Option<String>,
 }
 
 /// Arguments for the history command.
@@ -675,6 +710,32 @@ mod tests {
                 assert_eq!(update.public_key, Some("/path/to/key.pub".to_string()));
             }
             _ => panic!("Expected Update command"),
+        }
+    }
+
+    #[test]
+    fn test_self_update_default() {
+        let args = Cli::try_parse_from(["nxv", "self-update"]).unwrap();
+        match args.command {
+            Commands::SelfUpdate(su) => {
+                assert!(!su.check);
+                assert!(!su.force);
+                assert!(su.version.is_none());
+            }
+            _ => panic!("Expected SelfUpdate command"),
+        }
+    }
+
+    #[test]
+    fn test_self_update_flags() {
+        let args =
+            Cli::try_parse_from(["nxv", "self-update", "--check", "--version", "v0.2.0"]).unwrap();
+        match args.command {
+            Commands::SelfUpdate(su) => {
+                assert!(su.check);
+                assert_eq!(su.version.as_deref(), Some("v0.2.0"));
+            }
+            _ => panic!("Expected SelfUpdate command"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,6 @@ fn main() {
     let result = match &cli.command {
         Commands::Search(args) => cmd_search(&cli, args),
         Commands::Update(args) => cmd_update(&cli, args),
-        Commands::SelfUpdate(args) => cmd_self_update(&cli, args),
         Commands::Info(args) => cmd_pkg_info(&cli, args),
         Commands::Stats => cmd_stats(&cli),
         Commands::History(args) => cmd_history(&cli, args),
@@ -175,12 +174,16 @@ fn get_backend_with_prompt(cli: &Cli) -> Result<backend::Backend> {
                 let input = input.trim().to_lowercase();
 
                 if input.is_empty() || input == "y" || input == "yes" {
-                    // Run the update command
+                    // Run the update command. Skip the binary self-update check —
+                    // the user invoked search/info/etc., not an explicit update,
+                    // and we don't want to surprise them by replacing the binary
+                    // mid-session.
                     let update_args = cli::UpdateArgs {
                         force: false,
                         manifest_url: None,
                         skip_verify: false,
                         public_key: None,
+                        no_self_update: true,
                     };
                     cmd_update(cli, &update_args)?;
 
@@ -438,25 +441,29 @@ fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
         }
     }
 
-    Ok(())
-}
+    if !args.no_self_update {
+        eprintln!();
+        // Binary check is best-effort: a GitHub outage or rate limit should not
+        // fail the overall update (the index step already succeeded). Surface
+        // the error as a warning only.
+        let result = self_update::run(self_update::SelfUpdateOptions {
+            check: false,
+            force: false,
+            version: None,
+            // `api_timeout` is applied as a connect-timeout only; it does not
+            // bound the (potentially multi-MB) binary download.
+            connect_timeout_secs: cli.api_timeout,
+            show_progress,
+            quiet: cli.quiet,
+        });
+        if let Err(e) = result
+            && !cli.quiet
+        {
+            eprintln!("Skipping binary self-update check: {e}");
+        }
+    }
 
-/// Updates the `nxv` binary itself to the latest GitHub release.
-///
-/// Delegates to `self_update::run`, propagating CLI-level flags (quiet, timeout).
-/// For managed installs (Nix/cargo/Homebrew), the underlying call prints a
-/// helpful upgrade hint and exits with status 2 instead of touching disk.
-fn cmd_self_update(cli: &Cli, args: &cli::SelfUpdateArgs) -> Result<()> {
-    self_update::run(self_update::SelfUpdateOptions {
-        check: args.check,
-        force: args.force,
-        version: args.version.as_deref(),
-        // `api_timeout` is repurposed here as the connect-timeout only —
-        // it does *not* bound the (potentially multi-MB) binary download.
-        connect_timeout_secs: cli.api_timeout,
-        show_progress: !cli.quiet,
-        quiet: cli.quiet,
-    })
+    Ok(())
 }
 
 /// Display detailed information for a package in the format requested by the CLI.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod output;
 mod paths;
 mod remote;
 mod search;
+mod self_update;
 pub mod version;
 
 #[cfg(feature = "indexer")]
@@ -49,6 +50,7 @@ fn main() {
     let result = match &cli.command {
         Commands::Search(args) => cmd_search(&cli, args),
         Commands::Update(args) => cmd_update(&cli, args),
+        Commands::SelfUpdate(args) => cmd_self_update(&cli, args),
         Commands::Info(args) => cmd_pkg_info(&cli, args),
         Commands::Stats => cmd_stats(&cli),
         Commands::History(args) => cmd_history(&cli, args),
@@ -437,6 +439,22 @@ fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Updates the `nxv` binary itself to the latest GitHub release.
+///
+/// Delegates to `self_update::run`, propagating CLI-level flags (quiet, timeout).
+/// For managed installs (Nix/cargo/Homebrew), the underlying call prints a
+/// helpful upgrade hint and exits with status 2 instead of touching disk.
+fn cmd_self_update(cli: &Cli, args: &cli::SelfUpdateArgs) -> Result<()> {
+    self_update::run(self_update::SelfUpdateOptions {
+        check: args.check,
+        force: args.force,
+        version: args.version.as_deref(),
+        timeout_secs: cli.api_timeout,
+        show_progress: !cli.quiet,
+        quiet: cli.quiet,
+    })
 }
 
 /// Display detailed information for a package in the format requested by the CLI.

--- a/src/main.rs
+++ b/src/main.rs
@@ -442,7 +442,9 @@ fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
     }
 
     if !args.no_self_update {
-        eprintln!();
+        if !cli.quiet {
+            eprintln!();
+        }
         // Binary check is best-effort: a GitHub outage or rate limit should not
         // fail the overall update (the index step already succeeded). Surface
         // the error as a warning only.

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,7 +451,9 @@ fn cmd_self_update(cli: &Cli, args: &cli::SelfUpdateArgs) -> Result<()> {
         check: args.check,
         force: args.force,
         version: args.version.as_deref(),
-        timeout_secs: cli.api_timeout,
+        // `api_timeout` is repurposed here as the connect-timeout only —
+        // it does *not* bound the (potentially multi-MB) binary download.
+        connect_timeout_secs: cli.api_timeout,
         show_progress: !cli.quiet,
         quiet: cli.quiet,
     })

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,0 +1,671 @@
+//! Self-update command — replaces the running `nxv` binary with the latest
+//! release from GitHub, or prints guidance when managed by a package manager.
+//!
+//! The existing `nxv update` command continues to update the *index*; this
+//! is a separate, dedicated path for updating the *binary* itself.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use indicatif::{ProgressBar, ProgressStyle};
+use sha2::{Digest, Sha256};
+
+use crate::version;
+
+const GITHUB_REPO: &str = "utensils/nxv";
+const GITHUB_API_BASE: &str = "https://api.github.com";
+
+// ── GitHub API types ────────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    assets: Vec<GitHubAsset>,
+}
+
+#[derive(serde::Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+    size: u64,
+}
+
+// ── Install method detection ────────────────────────────────────────────────
+
+/// How the running `nxv` binary was installed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallMethod {
+    /// Installed via Nix (path under `/nix/store/`).
+    Nix,
+    /// Installed via `cargo install` (path under `~/.cargo/bin/`).
+    Cargo,
+    /// Installed via Homebrew.
+    Homebrew,
+    /// A local/manual install — safe to replace in-place.
+    Local,
+}
+
+impl InstallMethod {
+    /// Short human-readable label for diagnostics.
+    pub fn label(self) -> &'static str {
+        match self {
+            InstallMethod::Nix => "Nix",
+            InstallMethod::Cargo => "cargo install",
+            InstallMethod::Homebrew => "Homebrew",
+            InstallMethod::Local => "local install",
+        }
+    }
+
+    /// Command the user should run to update a managed install, if any.
+    pub fn update_hint(self) -> Option<&'static str> {
+        match self {
+            InstallMethod::Nix => Some("nix profile upgrade nxv  # or update your flake input"),
+            InstallMethod::Cargo => Some("cargo install --locked nxv"),
+            InstallMethod::Homebrew => Some("brew upgrade nxv"),
+            InstallMethod::Local => None,
+        }
+    }
+}
+
+/// Classify the install method from the path of the running executable.
+pub fn detect_install_method(exe_path: &Path) -> InstallMethod {
+    let path_str = exe_path.to_string_lossy();
+
+    if path_str.contains("/nix/store/") {
+        return InstallMethod::Nix;
+    }
+    if path_str.contains("/Cellar/") || path_str.contains("/homebrew/") {
+        return InstallMethod::Homebrew;
+    }
+    // `cargo install` drops binaries in $CARGO_HOME/bin (default ~/.cargo/bin).
+    // Match `/.cargo/bin/` and the CARGO_HOME override, if set.
+    if path_str.contains("/.cargo/bin/") {
+        return InstallMethod::Cargo;
+    }
+    if let Ok(cargo_home) = std::env::var("CARGO_HOME") {
+        let bin = format!("{}/bin/", cargo_home.trim_end_matches('/'));
+        if path_str.starts_with(&bin) {
+            return InstallMethod::Cargo;
+        }
+    }
+    InstallMethod::Local
+}
+
+// ── Version comparison ──────────────────────────────────────────────────────
+
+/// Parse a version string like "0.1.7" or "v0.1.7" into `(major, minor, patch)`.
+fn parse_version(v: &str) -> Option<(u32, u32, u32)> {
+    let v = v.strip_prefix('v').unwrap_or(v);
+    let parts: Vec<&str> = v.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    Some((
+        parts[0].parse().ok()?,
+        parts[1].parse().ok()?,
+        parts[2].parse().ok()?,
+    ))
+}
+
+/// Returns true if `remote` is strictly newer than `current`.
+fn is_newer(current: &str, remote: &str) -> bool {
+    match (parse_version(current), parse_version(remote)) {
+        (Some(c), Some(r)) => r > c,
+        _ => false,
+    }
+}
+
+// ── Platform detection ──────────────────────────────────────────────────────
+
+/// The release asset name for the current platform.
+///
+/// Matches the names published by `.github/workflows/release.yml`:
+///   - `nxv-x86_64-linux-musl`
+///   - `nxv-aarch64-linux-musl`
+///   - `nxv-x86_64-apple-darwin`
+///   - `nxv-aarch64-apple-darwin`
+fn detect_asset_name() -> Result<String> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    match (os, arch) {
+        ("linux", "x86_64") => Ok("nxv-x86_64-linux-musl".to_string()),
+        ("linux", "aarch64") => Ok("nxv-aarch64-linux-musl".to_string()),
+        ("macos", "x86_64") => Ok("nxv-x86_64-apple-darwin".to_string()),
+        ("macos", "aarch64") => Ok("nxv-aarch64-apple-darwin".to_string()),
+        _ => bail!("unsupported platform: {os}/{arch}"),
+    }
+}
+
+// ── SHA-256 checksum verification ───────────────────────────────────────────
+
+/// Parse a `SHA256SUMS.txt` file and verify the checksum for `asset_name` against `data`.
+fn verify_checksum(sums_content: &str, asset_name: &str, data: &[u8]) -> Result<()> {
+    let expected = sums_content
+        .lines()
+        .find_map(|line| {
+            // Standard `sha256sum` output: "<hash>  <filename>" (two-space sep).
+            let (hash, name) = line.split_once("  ")?;
+            if name.trim() == asset_name {
+                Some(hash.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .with_context(|| format!("asset {asset_name} not found in SHA256SUMS.txt"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let actual = format!("{:x}", hasher.finalize());
+
+    if actual != expected {
+        bail!(
+            "SHA-256 checksum mismatch for {asset_name}\n  expected: {expected}\n  actual:   {actual}"
+        );
+    }
+    Ok(())
+}
+
+// ── Binary self-replacement ─────────────────────────────────────────────────
+
+/// Replace the binary at `exe_path` with `new_binary`.
+///
+/// On Unix this is a three-step dance: rename the current binary aside, install
+/// the new one, and clean up the backup. If the install rename fails the
+/// backup is restored. We can rename across the same directory because we
+/// write the temp file next to the target.
+fn replace_binary(new_binary: &[u8], exe_path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let exe_dir = exe_path
+        .parent()
+        .context("cannot determine binary directory")?;
+
+    let pid = std::process::id();
+    let tmp_path = exe_dir.join(format!(".nxv-update-{pid}"));
+    let backup_path = exe_path.with_extension("old");
+
+    std::fs::write(&tmp_path, new_binary).context("failed to write new binary to temp file")?;
+    std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
+        .context("failed to set permissions on new binary")?;
+
+    std::fs::rename(exe_path, &backup_path).context("failed to move current binary to backup")?;
+
+    if let Err(e) = std::fs::rename(&tmp_path, exe_path) {
+        // Best-effort rollback.
+        let _ = std::fs::rename(&backup_path, exe_path);
+        let _ = std::fs::remove_file(&tmp_path);
+        bail!("failed to install new binary: {e}");
+    }
+
+    let _ = std::fs::remove_file(&backup_path);
+
+    // macOS: strip the quarantine attribute so Gatekeeper doesn't prompt.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("xattr")
+            .args(["-d", "com.apple.quarantine"])
+            .arg(exe_path)
+            .output();
+    }
+
+    Ok(())
+}
+
+// ── HTTP helpers ────────────────────────────────────────────────────────────
+
+fn build_client(timeout_secs: u64) -> Result<reqwest::blocking::Client> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github+json".parse().expect("valid header"),
+    );
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {token}")
+                .parse()
+                .context("invalid GITHUB_TOKEN")?,
+        );
+    }
+    reqwest::blocking::Client::builder()
+        .user_agent(format!("nxv/{}", version::PKG_VERSION))
+        .default_headers(headers)
+        .timeout(Duration::from_secs(timeout_secs))
+        .build()
+        .context("failed to build HTTP client")
+}
+
+fn fetch_latest_release(client: &reqwest::blocking::Client) -> Result<GitHubRelease> {
+    let url = format!("{GITHUB_API_BASE}/repos/{GITHUB_REPO}/releases/latest");
+    let resp = client
+        .get(&url)
+        .send()
+        .context("failed to connect to GitHub API")?;
+    handle_github_status(&resp)?;
+    resp.json()
+        .context("failed to parse GitHub release response")
+}
+
+fn fetch_release_by_tag(client: &reqwest::blocking::Client, tag: &str) -> Result<GitHubRelease> {
+    // Accept both "v0.1.7" and "0.1.7". nxv tags are v-prefixed.
+    let tag = if tag.starts_with('v') {
+        tag.to_string()
+    } else {
+        format!("v{tag}")
+    };
+    let url = format!("{GITHUB_API_BASE}/repos/{GITHUB_REPO}/releases/tags/{tag}");
+    let resp = client
+        .get(&url)
+        .send()
+        .context("failed to connect to GitHub API")?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        bail!("release {tag} not found on GitHub");
+    }
+    handle_github_status(&resp)?;
+    resp.json()
+        .context("failed to parse GitHub release response")
+}
+
+fn handle_github_status(resp: &reqwest::blocking::Response) -> Result<()> {
+    if resp.status() == reqwest::StatusCode::FORBIDDEN {
+        bail!(
+            "GitHub API rate limit exceeded. Set GITHUB_TOKEN to authenticate:\n  \
+             export GITHUB_TOKEN=$(gh auth token)"
+        );
+    }
+    if !resp.status().is_success() {
+        bail!("GitHub API returned {}", resp.status());
+    }
+    Ok(())
+}
+
+fn download_asset(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    size: u64,
+    show_progress: bool,
+) -> Result<Vec<u8>> {
+    let mut resp = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/octet-stream")
+        .send()
+        .context("failed to download release asset")?;
+    if !resp.status().is_success() {
+        bail!("download failed with HTTP {}", resp.status());
+    }
+
+    let pb = if show_progress {
+        let bar = ProgressBar::new(size);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "  Downloading [{bar:30.cyan/blue}] \
+                     {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+                )
+                .expect("valid template")
+                .progress_chars("=>-"),
+        );
+        Some(bar)
+    } else {
+        None
+    };
+
+    let mut data = Vec::with_capacity(size as usize);
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        use std::io::Read as _;
+        let n = resp
+            .read(&mut buf)
+            .context("error reading download stream")?;
+        if n == 0 {
+            break;
+        }
+        data.extend_from_slice(&buf[..n]);
+        if let Some(bar) = &pb {
+            bar.inc(n as u64);
+        }
+    }
+    if let Some(bar) = pb {
+        bar.finish_and_clear();
+    }
+    Ok(data)
+}
+
+// ── Main command ────────────────────────────────────────────────────────────
+
+/// Options passed in from the CLI layer.
+pub struct SelfUpdateOptions<'a> {
+    pub check: bool,
+    pub force: bool,
+    pub version: Option<&'a str>,
+    pub timeout_secs: u64,
+    pub show_progress: bool,
+    pub quiet: bool,
+}
+
+/// Execute `nxv self-update`. Returns `Ok(())` on success or a no-op
+/// "already up to date" / "managed install" outcome.
+pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
+    let current = version::PKG_VERSION;
+    if !opts.quiet {
+        eprintln!("Current version: {current}");
+        eprintln!("Checking for updates...");
+    }
+
+    let client = build_client(opts.timeout_secs)?;
+    let release = match opts.version {
+        Some(tag) => fetch_release_by_tag(&client, tag)?,
+        None => fetch_latest_release(&client)?,
+    };
+    let remote_version = release
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&release.tag_name);
+
+    // Version comparison (skipped under --force).
+    if !opts.force {
+        if remote_version == current {
+            if !opts.quiet {
+                eprintln!("Already up to date ({current}).");
+            }
+            return Ok(());
+        }
+        if opts.version.is_none() && !is_newer(current, remote_version) {
+            if !opts.quiet {
+                eprintln!(
+                    "Current version ({current}) is newer than latest release ({remote_version})."
+                );
+            }
+            return Ok(());
+        }
+    }
+
+    let action = if is_newer(current, remote_version) {
+        "Updating"
+    } else if remote_version == current {
+        "Reinstalling"
+    } else {
+        "Downgrading"
+    };
+
+    // `--check`: report availability and exit without touching disk.
+    if opts.check {
+        if !opts.quiet {
+            if is_newer(current, remote_version) {
+                eprintln!("New version available: {remote_version} (current: {current})");
+            } else {
+                eprintln!("Version {remote_version} is available (current: {current}).");
+            }
+        }
+        return Ok(());
+    }
+
+    // From here on we will write to disk — validate install location.
+    let exe_path = std::env::current_exe()
+        .context("failed to locate current executable")?
+        .canonicalize()
+        .context("failed to canonicalize current executable path")?;
+    let method = detect_install_method(&exe_path);
+
+    if method != InstallMethod::Local {
+        // Managed install: print the right hint and exit with a distinct status.
+        eprintln!();
+        eprintln!(
+            "nxv was installed via {} ({}).",
+            method.label(),
+            exe_path.display()
+        );
+        if is_newer(current, remote_version) {
+            eprintln!("A newer release is available: {remote_version} (current: {current}).");
+        } else if remote_version == current {
+            eprintln!("You are already on the latest release ({current}).");
+        } else {
+            eprintln!("Latest release is {remote_version}; you are on {current}.");
+        }
+        if let Some(hint) = method.update_hint() {
+            eprintln!();
+            eprintln!("To update, run:");
+            eprintln!("  {hint}");
+        }
+        // Non-zero exit so scripts can tell "did not update" apart from success.
+        std::process::exit(2);
+    }
+
+    // Local install — check we can actually write.
+    if let Some(exe_dir) = exe_path.parent() {
+        let test_path = exe_dir.join(format!(".nxv-update-test-{}", std::process::id()));
+        match std::fs::write(&test_path, b"") {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&test_path);
+            }
+            Err(_) => {
+                bail!(
+                    "no write permission to {}. Try running with sudo, \
+                     or reinstall to a writable location.",
+                    exe_dir.display()
+                );
+            }
+        }
+    }
+
+    if !opts.quiet {
+        eprintln!("{action}: {current} -> {remote_version}");
+    }
+
+    let asset_name = detect_asset_name()?;
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == asset_name)
+        .with_context(|| {
+            format!(
+                "release {} has no asset matching {asset_name}",
+                release.tag_name
+            )
+        })?;
+    let sums_asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == "SHA256SUMS.txt")
+        .context("release has no SHA256SUMS.txt file")?;
+
+    let binary_data = download_asset(
+        &client,
+        &asset.browser_download_url,
+        asset.size,
+        opts.show_progress,
+    )?;
+
+    let sums_resp = client
+        .get(&sums_asset.browser_download_url)
+        .send()
+        .context("failed to download SHA256SUMS.txt")?;
+    let sums_content = sums_resp.text().context("failed to read SHA256SUMS.txt")?;
+
+    verify_checksum(&sums_content, &asset.name, &binary_data)?;
+    if !opts.quiet {
+        eprintln!("Checksum verified (SHA-256).");
+    }
+
+    replace_binary(&binary_data, &exe_path)?;
+
+    if !opts.quiet {
+        eprintln!(
+            "{action} complete: nxv {remote_version} ({}).",
+            exe_path.display()
+        );
+    }
+    Ok(())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── Version comparison ──────────────────────────────────────────────
+    #[test]
+    fn parse_version_valid() {
+        assert_eq!(parse_version("0.1.7"), Some((0, 1, 7)));
+        assert_eq!(parse_version("v1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_version("10.20.30"), Some((10, 20, 30)));
+    }
+
+    #[test]
+    fn parse_version_invalid() {
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("1.2"), None);
+        assert_eq!(parse_version("1.2.3.4"), None);
+        assert_eq!(parse_version("abc"), None);
+        assert_eq!(parse_version("1.2.x"), None);
+    }
+
+    #[test]
+    fn is_newer_basic() {
+        assert!(is_newer("0.1.6", "0.1.7"));
+        assert!(is_newer("0.1.7", "0.2.0"));
+        assert!(!is_newer("0.1.7", "0.1.7"));
+        assert!(!is_newer("1.0.0", "0.1.7"));
+    }
+
+    #[test]
+    fn is_newer_with_v_prefix() {
+        assert!(is_newer("0.1.6", "v0.1.7"));
+        assert!(is_newer("v0.1.6", "0.1.7"));
+        assert!(!is_newer("v0.2.0", "v0.1.9"));
+    }
+
+    #[test]
+    fn is_newer_major_bump() {
+        assert!(is_newer("0.9.9", "1.0.0"));
+        assert!(!is_newer("1.0.0", "0.99.99"));
+    }
+
+    // ── Platform detection ──────────────────────────────────────────────
+    #[test]
+    fn detect_asset_name_current_platform() {
+        let name = detect_asset_name().expect("current platform should be supported");
+        assert!(name.starts_with("nxv-"));
+    }
+
+    // ── Install method detection ────────────────────────────────────────
+    #[test]
+    fn detect_nix_store() {
+        let p = PathBuf::from("/nix/store/abc123-nxv/bin/nxv");
+        assert_eq!(detect_install_method(&p), InstallMethod::Nix);
+    }
+
+    #[test]
+    fn detect_homebrew() {
+        let p = PathBuf::from("/opt/homebrew/Cellar/nxv/0.1.7/bin/nxv");
+        assert_eq!(detect_install_method(&p), InstallMethod::Homebrew);
+        let p2 = PathBuf::from("/usr/local/Cellar/nxv/0.1.7/bin/nxv");
+        assert_eq!(detect_install_method(&p2), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn detect_cargo_bin() {
+        let p = PathBuf::from("/Users/alice/.cargo/bin/nxv");
+        assert_eq!(detect_install_method(&p), InstallMethod::Cargo);
+        let p2 = PathBuf::from("/home/bob/.cargo/bin/nxv");
+        assert_eq!(detect_install_method(&p2), InstallMethod::Cargo);
+    }
+
+    #[test]
+    fn detect_local_bin() {
+        let p = PathBuf::from("/home/user/.local/bin/nxv");
+        assert_eq!(detect_install_method(&p), InstallMethod::Local);
+        let p2 = PathBuf::from("/usr/local/bin/nxv");
+        assert_eq!(detect_install_method(&p2), InstallMethod::Local);
+    }
+
+    #[test]
+    fn install_method_update_hint_is_set_for_managed() {
+        assert!(InstallMethod::Nix.update_hint().is_some());
+        assert!(InstallMethod::Cargo.update_hint().is_some());
+        assert!(InstallMethod::Homebrew.update_hint().is_some());
+        assert!(InstallMethod::Local.update_hint().is_none());
+    }
+
+    // ── Checksum verification ───────────────────────────────────────────
+    #[test]
+    fn verify_checksum_match() {
+        let data = b"hello nxv";
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let hash = format!("{:x}", hasher.finalize());
+        let sums = format!("{hash}  nxv-x86_64-linux-musl\n");
+        assert!(verify_checksum(&sums, "nxv-x86_64-linux-musl", data).is_ok());
+    }
+
+    #[test]
+    fn verify_checksum_mismatch() {
+        let sums = "0000000000000000000000000000000000000000000000000000000000000000  nxv-test\n";
+        let err = verify_checksum(sums, "nxv-test", b"anything").unwrap_err();
+        assert!(err.to_string().contains("checksum mismatch"));
+    }
+
+    #[test]
+    fn verify_checksum_missing_asset() {
+        let sums = "abcdef  other-file\n";
+        let err = verify_checksum(sums, "nxv-test", b"data").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn verify_checksum_multi_line() {
+        let a = b"file-a";
+        let b = b"file-b";
+        let ha = {
+            let mut h = Sha256::new();
+            h.update(a);
+            format!("{:x}", h.finalize())
+        };
+        let hb = {
+            let mut h = Sha256::new();
+            h.update(b);
+            format!("{:x}", h.finalize())
+        };
+        let sums = format!("{ha}  nxv-a\n{hb}  nxv-b\n");
+        assert!(verify_checksum(&sums, "nxv-a", a).is_ok());
+        assert!(verify_checksum(&sums, "nxv-b", b).is_ok());
+    }
+
+    // ── Binary replacement ──────────────────────────────────────────────
+    #[test]
+    fn replace_binary_roundtrip() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let exe_path = dir.path().join("nxv");
+        std::fs::write(&exe_path, b"old").unwrap();
+        std::fs::set_permissions(&exe_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        replace_binary(b"new-contents", &exe_path).unwrap();
+
+        assert_eq!(std::fs::read(&exe_path).unwrap(), b"new-contents");
+        let mode = std::fs::metadata(&exe_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755);
+        assert!(!exe_path.with_extension("old").exists());
+    }
+
+    #[test]
+    fn replace_binary_leaves_no_tmp() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe_path = dir.path().join("nxv");
+        std::fs::write(&exe_path, b"old").unwrap();
+
+        replace_binary(b"fresh", &exe_path).unwrap();
+
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".nxv-update-"))
+            .collect();
+        assert!(leftovers.is_empty(), "stray temp files: {leftovers:?}");
+    }
+}

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -233,18 +233,34 @@ fn replace_binary(new_binary: &[u8], exe_path: &Path) -> Result<()> {
 
     let pid = std::process::id();
     let tmp_path = exe_dir.join(format!(".nxv-update-{pid}"));
-    let backup_path = exe_path.with_extension("old");
+    // PID-suffixed backup so a crashed previous run or a concurrent update
+    // attempt doesn't block the rename. `exe_path.with_extension("old")`
+    // would always be `nxv.old`, which collides.
+    let backup_path = exe_dir.join(format!(".nxv-backup-{pid}.old"));
 
     std::fs::write(&tmp_path, new_binary).context("failed to write new binary to temp file")?;
     std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
         .context("failed to set permissions on new binary")?;
 
-    std::fs::rename(exe_path, &backup_path).context("failed to move current binary to backup")?;
+    std::fs::rename(exe_path, &backup_path).with_context(|| {
+        format!(
+            "failed to move current binary to backup at {}",
+            backup_path.display()
+        )
+    })?;
 
     if let Err(e) = std::fs::rename(&tmp_path, exe_path) {
-        // Best-effort rollback.
-        let _ = std::fs::rename(&backup_path, exe_path);
+        // Best-effort rollback. If it fails too, tell the user where the
+        // backup lives so they can restore by hand.
+        let rollback = std::fs::rename(&backup_path, exe_path);
         let _ = std::fs::remove_file(&tmp_path);
+        if let Err(rb) = rollback {
+            bail!(
+                "failed to install new binary: {e}; rollback also failed: {rb}. \
+                 Previous binary is preserved at {}",
+                backup_path.display()
+            );
+        }
         bail!("failed to install new binary: {e}");
     }
 
@@ -540,11 +556,16 @@ pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
         opts.show_progress,
     )?;
 
-    let sums_resp = client
+    let sums_content = client
         .get(&sums_asset.browser_download_url)
         .send()
-        .context("failed to download SHA256SUMS.txt")?;
-    let sums_content = sums_resp.text().context("failed to read SHA256SUMS.txt")?;
+        .context("failed to download SHA256SUMS.txt")?
+        // Fail loudly on a non-2xx — otherwise we'd feed an HTML error page
+        // into checksum parsing and surface a misleading "asset not found" error.
+        .error_for_status()
+        .context("failed to download SHA256SUMS.txt (non-success status)")?
+        .text()
+        .context("failed to read SHA256SUMS.txt")?;
 
     verify_checksum(&sums_content, &asset.name, &binary_data)?;
     if !opts.quiet {

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,8 +1,11 @@
-//! Self-update command — replaces the running `nxv` binary with the latest
-//! release from GitHub, or prints guidance when managed by a package manager.
+//! Self-update support for `nxv update`.
 //!
-//! The existing `nxv update` command continues to update the *index*; this
-//! is a separate, dedicated path for updating the *binary* itself.
+//! There is no standalone `self-update` subcommand — `nxv update` refreshes
+//! the package index first and then delegates to [`run`] here to check for
+//! a newer `nxv` release. For a local install the running binary is
+//! replaced in place; for a managed install (Nix / cargo / Homebrew) the
+//! binary is left untouched and the correct package-manager hint is
+//! printed instead.
 
 use std::path::Path;
 use std::time::Duration;
@@ -59,11 +62,11 @@ impl InstallMethod {
 
     /// Command (or instruction) the user should run to update a managed install.
     ///
-    /// `force` and `version` influence the generated hint so that, e.g.,
-    /// `nxv self-update --version v0.1.6` on a cargo install tells the user
-    /// to run `cargo install --locked --version 0.1.6 nxv`, not the generic
-    /// `cargo install --locked nxv` (which would silently install a different
-    /// version). Returns `None` for `Local` — callers do the work themselves.
+    /// `force` and `version` influence the generated hint. For example, on a
+    /// cargo install requesting a specific version, the hint becomes
+    /// `cargo install --locked --version 0.1.6 nxv` instead of the generic
+    /// upgrade command (which would silently install a different version).
+    /// Returns `None` for `Local` — callers do the work themselves.
     pub fn update_hint(self, force: bool, version: Option<&str>) -> Option<String> {
         match self {
             InstallMethod::Nix => {
@@ -138,18 +141,14 @@ pub fn detect_install_method(exe_path: &Path) -> InstallMethod {
 
 // ── Version comparison ──────────────────────────────────────────────────────
 
-/// Parse a version string like "0.1.7" or "v0.1.7" into `(major, minor, patch)`.
-fn parse_version(v: &str) -> Option<(u32, u32, u32)> {
+/// Parse a version string like "0.1.7" or "v0.1.7" into a `semver::Version`.
+///
+/// Uses the same `semver` crate already depended on by the search module
+/// (`src/search.rs`), so pre-release / build-metadata tags compare the way
+/// a Rust developer expects.
+fn parse_version(v: &str) -> Option<semver::Version> {
     let v = v.strip_prefix('v').unwrap_or(v);
-    let parts: Vec<&str> = v.split('.').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-    Some((
-        parts[0].parse().ok()?,
-        parts[1].parse().ok()?,
-        parts[2].parse().ok()?,
-    ))
+    semver::Version::parse(v).ok()
 }
 
 /// Returns true if `remote` is strictly newer than `current`.
@@ -239,15 +238,23 @@ fn replace_binary(new_binary: &[u8], exe_path: &Path) -> Result<()> {
     let backup_path = exe_dir.join(format!(".nxv-backup-{pid}.old"));
 
     std::fs::write(&tmp_path, new_binary).context("failed to write new binary to temp file")?;
-    std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755))
-        .context("failed to set permissions on new binary")?;
 
-    std::fs::rename(exe_path, &backup_path).with_context(|| {
-        format!(
-            "failed to move current binary to backup at {}",
-            backup_path.display()
-        )
-    })?;
+    // From here on, every early-error path must clean up `tmp_path` so
+    // repeated failed updates don't accumulate stray `.nxv-update-<pid>` files.
+    if let Err(e) = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o755)) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).context("failed to set permissions on new binary");
+    }
+
+    if let Err(e) = std::fs::rename(exe_path, &backup_path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| {
+            format!(
+                "failed to move current binary to backup at {}",
+                backup_path.display()
+            )
+        });
+    }
 
     if let Err(e) = std::fs::rename(&tmp_path, exe_path) {
         // Best-effort rollback. If it fails too, tell the user where the
@@ -489,24 +496,27 @@ pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
     let method = detect_install_method(&exe_path);
 
     if method != InstallMethod::Local {
-        // Managed install: print the right hint and return — never touch the binary.
-        eprintln!();
-        eprintln!(
-            "nxv was installed via {} ({}).",
-            method.label(),
-            exe_path.display()
-        );
-        if is_newer(current, remote_version) {
-            eprintln!("A newer release is available: {remote_version} (current: {current}).");
-        } else if remote_version == current {
-            eprintln!("You are already on the latest release ({current}).");
-        } else {
-            eprintln!("Latest release is {remote_version}; you are on {current}.");
-        }
-        if let Some(hint) = method.update_hint(opts.force, opts.version) {
+        // Managed install: never touch the binary. The hint is purely
+        // informational, so suppress it under --quiet.
+        if !opts.quiet {
             eprintln!();
-            eprintln!("To update, run:");
-            eprintln!("  {hint}");
+            eprintln!(
+                "nxv was installed via {} ({}).",
+                method.label(),
+                exe_path.display()
+            );
+            if is_newer(current, remote_version) {
+                eprintln!("A newer release is available: {remote_version} (current: {current}).");
+            } else if remote_version == current {
+                eprintln!("You are already on the latest release ({current}).");
+            } else {
+                eprintln!("Latest release is {remote_version}; you are on {current}.");
+            }
+            if let Some(hint) = method.update_hint(opts.force, opts.version) {
+                eprintln!();
+                eprintln!("To update, run:");
+                eprintln!("  {hint}");
+            }
         }
         return Ok(());
     }
@@ -593,18 +603,29 @@ mod tests {
     // ── Version comparison ──────────────────────────────────────────────
     #[test]
     fn parse_version_valid() {
-        assert_eq!(parse_version("0.1.7"), Some((0, 1, 7)));
-        assert_eq!(parse_version("v1.2.3"), Some((1, 2, 3)));
-        assert_eq!(parse_version("10.20.30"), Some((10, 20, 30)));
+        assert_eq!(parse_version("0.1.7"), Some(semver::Version::new(0, 1, 7)));
+        assert_eq!(parse_version("v1.2.3"), Some(semver::Version::new(1, 2, 3)));
+        assert_eq!(
+            parse_version("10.20.30"),
+            Some(semver::Version::new(10, 20, 30))
+        );
     }
 
     #[test]
     fn parse_version_invalid() {
         assert_eq!(parse_version(""), None);
+        // semver requires MAJOR.MINOR.PATCH — two-component versions are rejected.
         assert_eq!(parse_version("1.2"), None);
-        assert_eq!(parse_version("1.2.3.4"), None);
         assert_eq!(parse_version("abc"), None);
         assert_eq!(parse_version("1.2.x"), None);
+    }
+
+    #[test]
+    fn parse_version_handles_prerelease() {
+        // semver-aware: pre-release tags sort before the same base version.
+        let rc = parse_version("0.2.0-rc.1").expect("valid semver with prerelease");
+        let release = parse_version("0.2.0").expect("valid semver");
+        assert!(rc < release);
     }
 
     #[test]
@@ -631,8 +652,20 @@ mod tests {
     // ── Platform detection ──────────────────────────────────────────────
     #[test]
     fn detect_asset_name_current_platform() {
-        let name = detect_asset_name().expect("current platform should be supported");
-        assert!(name.starts_with("nxv-"));
+        // nxv publishes release binaries for Linux and macOS only; on other
+        // targets the module compiles but this function must return an error.
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            let name = detect_asset_name().expect("current platform should be supported");
+            assert!(name.starts_with("nxv-"));
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            assert!(
+                detect_asset_name().is_err(),
+                "unsupported platforms should return an error"
+            );
+        }
     }
 
     // ── Install method detection ────────────────────────────────────────
@@ -780,7 +813,14 @@ mod tests {
         assert_eq!(std::fs::read(&exe_path).unwrap(), b"new-contents");
         let mode = std::fs::metadata(&exe_path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o755);
-        assert!(!exe_path.with_extension("old").exists());
+        // Backup is PID-suffixed (`.nxv-backup-<pid>.old`), so scan for
+        // any leftover instead of checking the legacy `nxv.old` name.
+        let backups: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".nxv-backup-"))
+            .collect();
+        assert!(backups.is_empty(), "stray backup files: {backups:?}");
     }
 
     #[cfg(unix)]

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -57,12 +57,56 @@ impl InstallMethod {
         }
     }
 
-    /// Command the user should run to update a managed install, if any.
-    pub fn update_hint(self) -> Option<&'static str> {
+    /// Command (or instruction) the user should run to update a managed install.
+    ///
+    /// `force` and `version` influence the generated hint so that, e.g.,
+    /// `nxv self-update --version v0.1.6` on a cargo install tells the user
+    /// to run `cargo install --locked --version 0.1.6 nxv`, not the generic
+    /// `cargo install --locked nxv` (which would silently install a different
+    /// version). Returns `None` for `Local` — callers do the work themselves.
+    pub fn update_hint(self, force: bool, version: Option<&str>) -> Option<String> {
         match self {
-            InstallMethod::Nix => Some("nix profile upgrade nxv  # or update your flake input"),
-            InstallMethod::Cargo => Some("cargo install --locked nxv"),
-            InstallMethod::Homebrew => Some("brew upgrade nxv"),
+            InstallMethod::Nix => {
+                if let Some(v) = version {
+                    let tag = if v.starts_with('v') {
+                        v.to_string()
+                    } else {
+                        format!("v{v}")
+                    };
+                    Some(format!(
+                        "nix profile install --refresh github:utensils/nxv/{tag}  \
+                         # or pin the flake input to {tag}"
+                    ))
+                } else {
+                    Some("nix profile upgrade nxv  # or update your flake input".to_string())
+                }
+            }
+            InstallMethod::Cargo => {
+                let mut cmd = String::from("cargo install --locked");
+                if force {
+                    cmd.push_str(" --force");
+                }
+                if let Some(v) = version {
+                    let bare = v.strip_prefix('v').unwrap_or(v);
+                    cmd.push_str(" --version ");
+                    cmd.push_str(bare);
+                }
+                cmd.push_str(" nxv");
+                Some(cmd)
+            }
+            InstallMethod::Homebrew => {
+                if version.is_some() {
+                    // Homebrew tracks only the latest formula; pinning is not portable.
+                    Some(String::from(
+                        "# Homebrew tracks only the latest formula — use install.sh \
+                         with NXV_VERSION=<tag> to install a specific release.",
+                    ))
+                } else if force {
+                    Some(String::from("brew reinstall nxv"))
+                } else {
+                    Some(String::from("brew upgrade nxv"))
+                }
+            }
             InstallMethod::Local => None,
         }
     }
@@ -175,6 +219,11 @@ fn verify_checksum(sums_content: &str, asset_name: &str, data: &[u8]) -> Result<
 /// the new one, and clean up the backup. If the install rename fails the
 /// backup is restored. We can rename across the same directory because we
 /// write the temp file next to the target.
+///
+/// `detect_asset_name` already bails on non-Unix platforms, so the Windows
+/// stub below should never be reached at runtime — it exists purely to keep
+/// `cargo build` green on targets we don't ship binaries for.
+#[cfg(unix)]
 fn replace_binary(new_binary: &[u8], exe_path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -213,9 +262,20 @@ fn replace_binary(new_binary: &[u8], exe_path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(unix))]
+fn replace_binary(_new_binary: &[u8], _exe_path: &Path) -> Result<()> {
+    bail!("self-update is only supported on Unix platforms (Linux and macOS).")
+}
+
 // ── HTTP helpers ────────────────────────────────────────────────────────────
 
-fn build_client(timeout_secs: u64) -> Result<reqwest::blocking::Client> {
+/// Build the HTTP client used for both GitHub API calls *and* binary downloads.
+///
+/// `connect_timeout_secs` bounds only the TCP/TLS handshake so we fail fast
+/// on unreachable hosts. We intentionally do **not** set a total-request
+/// timeout: the same client is reused for multi-MB binary downloads, and
+/// the user can always Ctrl+C an unresponsive session.
+fn build_client(connect_timeout_secs: u64) -> Result<reqwest::blocking::Client> {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
         reqwest::header::ACCEPT,
@@ -232,7 +292,7 @@ fn build_client(timeout_secs: u64) -> Result<reqwest::blocking::Client> {
     reqwest::blocking::Client::builder()
         .user_agent(format!("nxv/{}", version::PKG_VERSION))
         .default_headers(headers)
-        .timeout(Duration::from_secs(timeout_secs))
+        .connect_timeout(Duration::from_secs(connect_timeout_secs))
         .build()
         .context("failed to build HTTP client")
 }
@@ -340,7 +400,8 @@ pub struct SelfUpdateOptions<'a> {
     pub check: bool,
     pub force: bool,
     pub version: Option<&'a str>,
-    pub timeout_secs: u64,
+    /// TCP/TLS connect timeout (seconds). Does **not** bound the download.
+    pub connect_timeout_secs: u64,
     pub show_progress: bool,
     pub quiet: bool,
 }
@@ -354,7 +415,7 @@ pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
         eprintln!("Checking for updates...");
     }
 
-    let client = build_client(opts.timeout_secs)?;
+    let client = build_client(opts.connect_timeout_secs)?;
     let release = match opts.version {
         Some(tag) => fetch_release_by_tag(&client, tag)?,
         None => fetch_latest_release(&client)?,
@@ -424,7 +485,7 @@ pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
         } else {
             eprintln!("Latest release is {remote_version}; you are on {current}.");
         }
-        if let Some(hint) = method.update_hint() {
+        if let Some(hint) = method.update_hint(opts.force, opts.version) {
             eprintln!();
             eprintln!("To update, run:");
             eprintln!("  {hint}");
@@ -585,10 +646,56 @@ mod tests {
 
     #[test]
     fn install_method_update_hint_is_set_for_managed() {
-        assert!(InstallMethod::Nix.update_hint().is_some());
-        assert!(InstallMethod::Cargo.update_hint().is_some());
-        assert!(InstallMethod::Homebrew.update_hint().is_some());
-        assert!(InstallMethod::Local.update_hint().is_none());
+        assert!(InstallMethod::Nix.update_hint(false, None).is_some());
+        assert!(InstallMethod::Cargo.update_hint(false, None).is_some());
+        assert!(InstallMethod::Homebrew.update_hint(false, None).is_some());
+        assert!(InstallMethod::Local.update_hint(false, None).is_none());
+    }
+
+    #[test]
+    fn cargo_hint_honors_version_and_force() {
+        let hint = InstallMethod::Cargo
+            .update_hint(true, Some("v0.1.6"))
+            .unwrap();
+        assert!(hint.contains("--force"), "hint missing --force: {hint}");
+        assert!(
+            hint.contains("--version 0.1.6"),
+            "hint missing pinned version (stripped of v): {hint}"
+        );
+        assert!(hint.ends_with(" nxv"), "hint must target nxv: {hint}");
+    }
+
+    #[test]
+    fn cargo_hint_plain() {
+        let hint = InstallMethod::Cargo.update_hint(false, None).unwrap();
+        assert_eq!(hint, "cargo install --locked nxv");
+    }
+
+    #[test]
+    fn homebrew_hint_force_vs_version_vs_default() {
+        let plain = InstallMethod::Homebrew.update_hint(false, None).unwrap();
+        assert_eq!(plain, "brew upgrade nxv");
+        let forced = InstallMethod::Homebrew.update_hint(true, None).unwrap();
+        assert_eq!(forced, "brew reinstall nxv");
+        // --version: Homebrew can't pin, so the hint becomes a guidance note.
+        let pinned = InstallMethod::Homebrew
+            .update_hint(false, Some("v0.1.6"))
+            .unwrap();
+        assert!(
+            pinned.contains("install.sh"),
+            "homebrew pin hint should redirect to install.sh: {pinned}"
+        );
+    }
+
+    #[test]
+    fn nix_hint_version_suggests_flake_ref() {
+        let hint = InstallMethod::Nix
+            .update_hint(false, Some("0.1.6"))
+            .unwrap();
+        assert!(
+            hint.contains("github:utensils/nxv/v0.1.6"),
+            "nix pin hint should include a flake ref: {hint}"
+        );
     }
 
     // ── Checksum verification ───────────────────────────────────────────
@@ -636,6 +743,7 @@ mod tests {
     }
 
     // ── Binary replacement ──────────────────────────────────────────────
+    #[cfg(unix)]
     #[test]
     fn replace_binary_roundtrip() {
         use std::os::unix::fs::PermissionsExt;
@@ -653,6 +761,7 @@ mod tests {
         assert!(!exe_path.with_extension("old").exists());
     }
 
+    #[cfg(unix)]
     #[test]
     fn replace_binary_leaves_no_tmp() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -406,13 +406,15 @@ pub struct SelfUpdateOptions<'a> {
     pub quiet: bool,
 }
 
-/// Execute `nxv self-update`. Returns `Ok(())` on success or a no-op
-/// "already up to date" / "managed install" outcome.
+/// Check for a newer nxv release and, on a local install, replace the
+/// running binary. On managed installs (Nix / cargo / Homebrew) this only
+/// prints a package-manager-appropriate upgrade hint — the binary is never
+/// touched. Returns `Ok(())` for all non-error outcomes (up-to-date,
+/// managed-install hint, successful replacement).
 pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
     let current = version::PKG_VERSION;
     if !opts.quiet {
-        eprintln!("Current version: {current}");
-        eprintln!("Checking for updates...");
+        eprintln!("Checking for a newer nxv release...");
     }
 
     let client = build_client(opts.connect_timeout_secs)?;
@@ -471,7 +473,7 @@ pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
     let method = detect_install_method(&exe_path);
 
     if method != InstallMethod::Local {
-        // Managed install: print the right hint and exit with a distinct status.
+        // Managed install: print the right hint and return — never touch the binary.
         eprintln!();
         eprintln!(
             "nxv was installed via {} ({}).",
@@ -490,8 +492,7 @@ pub fn run(opts: SelfUpdateOptions<'_>) -> Result<()> {
             eprintln!("To update, run:");
             eprintln!("  {hint}");
         }
-        // Non-zero exit so scripts can tell "did not update" apart from success.
-        std::process::exit(2);
+        return Ok(());
     }
 
     // Local install — check we can actually write.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -120,7 +120,20 @@ fn test_help_displays() {
         .stdout(predicate::str::contains("info"))
         .stdout(predicate::str::contains("stats"))
         .stdout(predicate::str::contains("history"))
-        .stdout(predicate::str::contains("completions"));
+        .stdout(predicate::str::contains("completions"))
+        .stdout(predicate::str::contains("self-update"));
+}
+
+#[test]
+fn test_self_update_help() {
+    nxv()
+        .args(["self-update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Update the nxv binary"))
+        .stdout(predicate::str::contains("--check"))
+        .stdout(predicate::str::contains("--force"))
+        .stdout(predicate::str::contains("--version"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -120,20 +120,19 @@ fn test_help_displays() {
         .stdout(predicate::str::contains("info"))
         .stdout(predicate::str::contains("stats"))
         .stdout(predicate::str::contains("history"))
-        .stdout(predicate::str::contains("completions"))
-        .stdout(predicate::str::contains("self-update"));
+        .stdout(predicate::str::contains("completions"));
 }
 
 #[test]
-fn test_self_update_help() {
+fn test_update_help_mentions_self_update() {
+    // `nxv update` is one command: it refreshes the index and then checks for
+    // a newer binary. Verify the help surface exposes the opt-out flag.
     nxv()
-        .args(["self-update", "--help"])
+        .args(["update", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Update the nxv binary"))
-        .stdout(predicate::str::contains("--check"))
-        .stdout(predicate::str::contains("--force"))
-        .stdout(predicate::str::contains("--version"));
+        .stdout(predicate::str::contains("--no-self-update"))
+        .stdout(predicate::str::contains("--force"));
 }
 
 #[test]

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -123,6 +123,49 @@ nxv update [options]
 | `--skip-verify`      | Skip manifest signature verification |
 | `--public-key <KEY>` | Custom public key for verification   |
 
+### self-update
+
+Update the nxv **binary** itself to the latest GitHub release. This is
+separate from `nxv update`, which updates the package _index_.
+
+```bash
+nxv self-update [options]
+```
+
+**Options:**
+
+| Flag                  | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `--check`             | Only report whether a newer release exists; no install    |
+| `--force`             | Reinstall even if the current version already matches     |
+| `--version <TAG>`     | Install a specific release tag (e.g. `v0.2.0`)            |
+
+**Behaviour by install method:**
+
+| Install method | Action                                                      |
+| -------------- | ----------------------------------------------------------- |
+| Nix            | Prints `nix profile upgrade nxv` / flake-update hint, exits |
+| `cargo install`| Prints `cargo install --locked nxv`, exits                  |
+| Homebrew       | Prints `brew upgrade nxv`, exits                            |
+| Local          | Downloads, verifies SHA-256, atomically swaps the binary    |
+
+Managed-install branches exit with status `2` so scripts can distinguish
+them from a successful in-place update. Set `GITHUB_TOKEN` to avoid
+unauthenticated rate limits when calling the GitHub API.
+
+**Examples:**
+
+```bash
+# Check if a new release is available
+nxv self-update --check
+
+# Update to latest
+nxv self-update
+
+# Pin to a specific version
+nxv self-update --version v0.2.0
+```
+
 ### serve
 
 Start the HTTP API server.

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -109,7 +109,8 @@ nxv history python311
 
 ### update
 
-Download or update the package index.
+Refresh the package index, then check for a newer nxv binary and update
+it (or print a hint for managed installs).
 
 ```bash
 nxv update [options]
@@ -117,53 +118,42 @@ nxv update [options]
 
 **Options:**
 
-| Flag                 | Description                          |
-| -------------------- | ------------------------------------ |
-| `-f, --force`        | Force full re-download               |
-| `--skip-verify`      | Skip manifest signature verification |
-| `--public-key <KEY>` | Custom public key for verification   |
+| Flag                 | Description                                                        |
+| -------------------- | ------------------------------------------------------------------ |
+| `-f, --force`        | Force full re-download of the index                                |
+| `--skip-verify`      | Skip manifest signature verification                               |
+| `--public-key <KEY>` | Custom public key for verification                                 |
+| `--no-self-update`   | Skip the binary self-update check; only refresh the index          |
 
-### self-update
+`--no-self-update` also honours the `NXV_NO_SELF_UPDATE` environment
+variable, which is useful for CI or systemd timer units that should
+only refresh the index.
 
-Update the nxv **binary** itself to the latest GitHub release. This is
-separate from `nxv update`, which updates the package _index_.
+**Binary-update behaviour by install method:**
 
-```bash
-nxv self-update [options]
-```
+| Install method | Action                                                         |
+| -------------- | -------------------------------------------------------------- |
+| Local          | Downloads, verifies SHA-256, atomically swaps the binary       |
+| Nix            | Leaves binary alone; prints `nix profile upgrade nxv` / flake hint |
+| `cargo install`| Leaves binary alone; prints `cargo install --locked nxv`       |
+| Homebrew       | Leaves binary alone; prints `brew upgrade nxv` (or reinstall)  |
 
-**Options:**
-
-| Flag                  | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| `--check`             | Only report whether a newer release exists; no install    |
-| `--force`             | Reinstall even if the current version already matches     |
-| `--version <TAG>`     | Install a specific release tag (e.g. `v0.2.0`)            |
-
-**Behaviour by install method:**
-
-| Install method | Action                                                      |
-| -------------- | ----------------------------------------------------------- |
-| Nix            | Prints `nix profile upgrade nxv` / flake-update hint, exits |
-| `cargo install`| Prints `cargo install --locked nxv`, exits                  |
-| Homebrew       | Prints `brew upgrade nxv`, exits                            |
-| Local          | Downloads, verifies SHA-256, atomically swaps the binary    |
-
-Managed-install branches exit with status `2` so scripts can distinguish
-them from a successful in-place update. Set `GITHUB_TOKEN` to avoid
-unauthenticated rate limits when calling the GitHub API.
+Set `GITHUB_TOKEN` to avoid unauthenticated rate limits when calling the
+GitHub API. If the binary check fails (e.g., network or rate limit),
+`nxv update` prints a warning but still reports the index update as
+successful.
 
 **Examples:**
 
 ```bash
-# Check if a new release is available
-nxv self-update --check
+# Refresh the index and update the binary (or print an upgrade hint)
+nxv update
 
-# Update to latest
-nxv self-update
+# Just refresh the index — don't touch the binary
+nxv update --no-self-update
 
-# Pin to a specific version
-nxv self-update --version v0.2.0
+# Force full re-download of the index
+nxv update --force
 ```
 
 ### serve


### PR DESCRIPTION
## Summary

- Teaches the existing `nxv update` command to also check GitHub for a newer nxv release after it finishes refreshing the index, so you stay current with one command instead of two.
- Detects how nxv was installed and does the right thing for each case:
  - **Local install** (from `install.sh` or a manual download): downloads the platform release binary, verifies its SHA-256 against `SHA256SUMS.txt`, and atomically swaps the running executable.
  - **Nix / cargo / Homebrew**: leaves the binary alone and prints the matching upgrade command (e.g. `brew upgrade nxv`, `cargo install --locked nxv`, `nix profile upgrade nxv`). Hints honour `--force`/`--version` where the underlying tool supports it.
- Adds `--no-self-update` (and `NXV_NO_SELF_UPDATE`) to opt out of the binary check — useful for CI, systemd timers, and the internal first-run prompt on a missing index.
- Binary check is best-effort: a GitHub outage or rate-limit is surfaced as a warning, not a failure, because the index refresh has already succeeded.
- Codex-reviewed; the three P2 findings (hint respects flags, no total-request timeout on the download, `cfg(unix)` gating for Windows builds) were fixed in the same branch.

Docs updated in `README.md` and `website/guide/cli-reference.md`.

## Behaviour reference

| Install method  | `nxv update` binary step                                         |
| --------------- | ---------------------------------------------------------------- |
| Local           | Downloads, verifies SHA-256, atomically swaps the binary         |
| Nix             | Leaves binary alone; prints `nix profile upgrade nxv` / flake hint |
| `cargo install` | Leaves binary alone; prints `cargo install --locked [--force] [--version X] nxv` |
| Homebrew        | Leaves binary alone; prints `brew upgrade` (or `reinstall`, or an install.sh note when `--version` is requested) |

`nxv update --no-self-update` skips the binary step entirely — the behaviour prior to this PR.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` — no new warnings from the added code
- [x] `cargo test` — 256 unit + 60 integration tests pass (new tests in `self_update` for version parsing, checksum verification, install-method detection, per-install-method hints, and Unix-gated binary replacement)
- [x] `nix flake check` passes (fmt, clippy, build, tests on aarch64-darwin)
- [x] `nxv update --help` lists `--no-self-update`; the first-run prompt for a missing index sets it so search/info never surprises a user with a binary replacement
- [ ] Manual smoke test against a real release >0.1.7 (deferred until one exists)

## Commits

- `feat(self-update)`: initial module + dedicated subcommand, pattern ported from `utensils/mold`.
- `fix(self-update)`: address three P2 findings from codex review.
- `refactor(update)`: fold self-update into a single `nxv update` per reviewer feedback and add `--no-self-update`.