### PR TITLE
Add Claude Code skill + fix #33 (JSON header pollution + broken-pipe panic)

### DIFF
--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: nxv
+description: Find any version of any Nix package across nixpkgs git history using the nxv CLI or HTTP API. Use when asked which nixpkgs commit shipped a specific package version (e.g. "python 2.7", "nodejs 15", "ruby 2.6"), when looking up package metadata/license/homepage, when generating a `nix shell nixpkgs/<commit>#pkg` invocation for an old version, or when querying the public/private nxv server.
+when_to_use: Trigger on requests like "find python 2.7 in nixpkgs", "which commit had nodejs 15.14", "when was foo added/removed", "give me the nix shell command for ruby 2.6", "search nixpkgs for X", or any question about historical Nix package versions.
+argument-hint: [subcommand or query]
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# nxv — Nix Version Index
+
+`nxv` is a Rust CLI + HTTP API that indexes the entire nixpkgs git history (2017+) into a local SQLite database with a bloom filter for fast lookups. It answers: *"which exact nixpkgs commit shipped version X of package Y?"* and produces the `nix shell nixpkgs/<commit>#pkg` command you need to actually use it.
+
+## Quick Reference
+
+```bash
+nxv search python                        # All python packages (most recent per version)
+nxv search python 2.7                    # Filter by version (prefix match)
+nxv search python --exact                # Exact attribute name only
+nxv search "json parser" --desc          # Full-text search package descriptions
+nxv info python311                       # Detailed info for current version
+nxv info python311 3.11.4                # Detailed info for specific version
+nxv history python311                    # Version timeline (first/last seen)
+nxv history python311 3.11.4             # When was 3.11.4 available?
+nxv stats                                # Index statistics
+nxv update                               # Refresh index + check for newer nxv binary
+nxv update --no-self-update              # Refresh index only (CI / systemd timers)
+nxv serve --host 0.0.0.0 --port 8080     # Start HTTP API + web UI
+nxv completions zsh                      # Generate shell completions
+```
+
+## How to Use This Skill
+
+Parse `$ARGUMENTS` to determine the action:
+
+- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `serve`, `completions`, and indexer-only `index`, `backfill`, `dedupe`, `publish`, `keygen`, `reset`), run that subcommand.
+- If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
+- If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
+- If no arguments, run `nxv stats` to give the user a quick health check of their index.
+
+**For agents**: always pass `--format json` (CLI) or hit the HTTP API and pipe to `jq`. The table format is human-only; column widths are terminal-dependent.
+
+## Global Options
+
+Every CLI invocation accepts:
+
+| Flag                   | Description                                                 |
+| ---------------------- | ----------------------------------------------------------- |
+| `--db-path <PATH>`     | Path to the index database (default: platform data dir)     |
+| `-v, --verbose`        | `-v` info, `-vv` debug (SQL queries, HTTP requests)         |
+| `-q, --quiet`          | Suppress all output except errors                           |
+| `--no-color`           | Disable colored output (also honors `NO_COLOR`)             |
+| `--api-timeout <SECS>` | API request timeout when using remote backend (default: 30) |
+
+## Local vs Remote Backend
+
+`nxv` transparently runs against either a local SQLite index or a remote `nxv serve` instance. Set `NXV_API_URL` to switch:
+
+```bash
+# Use the public hosted instance — no local index needed
+NXV_API_URL=https://nxv.urandom.io nxv search nodejs 15
+NXV_API_URL=https://nxv.urandom.io nxv info python311
+
+# Or your own private instance
+export NXV_API_URL=http://gpu-host:8080
+nxv search rust 1.70
+```
+
+If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv update` to download the latest published index on first use.
+
+## Search
+
+Find packages and the commits where each version existed:
+
+```bash
+nxv search python                                    # Recent per (pkg, version)
+nxv search python 3.11                               # Version prefix filter
+nxv search python --exact                            # Exact attribute name only
+nxv search python --license MIT                      # Filter by license
+nxv search python --sort date --reverse              # Oldest first
+nxv search "web server" --desc                       # FTS5 description search
+nxv search python --show-platforms                   # Add platforms column
+nxv search python --full                             # All commits (no dedup)
+nxv search python --limit 5                          # Cap at 5 results
+nxv search python --format json                      # Machine-readable JSON
+nxv search python --format plain                     # TSV for shell scripts
+```
+
+**JSON shape per row:**
+
+```json
+{
+  "attribute_path": "python311",
+  "version": "3.11.4",
+  "description": "A high-level dynamically-typed programming language",
+  "license": "Python-2.0",
+  "first_commit_hash": "abc123...",
+  "first_commit_date": "2023-06-15T00:00:00Z",
+  "last_commit_hash": "def456...",
+  "last_commit_date": "2023-12-01T00:00:00Z"
+}
+```
+
+## Info
+
+Detailed metadata for one package version (description, license, homepage, platforms, source path, known vulnerabilities):
+
+```bash
+nxv info python311                       # Latest known version
+nxv info python311 3.11.4                # Specific version (positional)
+nxv info python311 -V 3.11.4             # Specific version (flag form)
+nxv info python311 --format json
+```
+
+## History
+
+Version timeline — when each version first appeared and when it was last seen:
+
+```bash
+nxv history python311                    # All versions of python311
+nxv history python311 3.11.4             # Just one version's window
+nxv history python311 --full             # Add commits, license, homepage, etc.
+nxv history python311 --format json
+```
+
+**JSON shape per row:**
+
+```json
+{
+  "version": "3.11.4",
+  "first_seen": "2023-06-15T00:00:00Z",
+  "last_seen": "2023-12-01T00:00:00Z",
+  "is_insecure": false
+}
+```
+
+## Using a Found Version
+
+The whole point. Take a `first_commit_hash` (or `last_commit_hash`) from search/history output and feed it to Nix:
+
+```bash
+# Drop into a shell with that exact version
+nix shell nixpkgs/e4a45f9#python
+
+# Run it once
+nix run nixpkgs/e4a45f9#python
+
+# Add to a flake input
+inputs.nixpkgs-python27.url = "github:NixOS/nixpkgs/<commit>";
+```
+
+Pick `first_commit_hash` for the canonical "introduced in" commit; pick `last_commit_hash` if you want the most recent commit that still shipped that version.
+
+## Index Management
+
+```bash
+nxv update                               # Refresh index + check for newer nxv binary
+nxv update --force                       # Force full re-download of the index
+nxv update --no-self-update              # Only refresh the index, leave binary alone
+nxv update --skip-verify                 # Skip minisign signature check (INSECURE)
+nxv update --public-key /path/key.pub    # Use a custom public key (self-hosted index)
+nxv update --manifest-url <URL>          # Use a custom manifest (self-hosted index)
+nxv stats                                # Index size, commit range, last update
+```
+
+`nxv update` always refreshes the package index first. Then it checks GitHub for a newer nxv release:
+
+- **Local install** (install.sh / manual download): downloads the platform binary, verifies SHA-256, atomically swaps the running executable.
+- **Nix / cargo / Homebrew**: prints the matching upgrade hint (e.g. `brew upgrade nxv`) and exits successfully.
+
+Set `NXV_NO_SELF_UPDATE=1` for CI/systemd timers that should only refresh the index.
+
+## API Server
+
+```bash
+nxv serve                                            # 127.0.0.1:8080 (default)
+nxv serve --host 0.0.0.0 --port 3000                 # Public bind
+nxv serve --cors                                     # Enable CORS for all origins
+nxv serve --cors-origins https://app.example.com     # Restrict CORS
+nxv serve --rate-limit 10 --rate-limit-burst 20      # Per-IP rate limit
+```
+
+The server bundles:
+
+- **Web UI** at `/` (Tailwind v4 + vanilla JS, embedded at build time)
+- **OpenAPI docs** at `/docs` (Scalar UI)
+- **REST API** at `/api/v1/*` — see endpoints below
+- **Cache headers**: 1h on cacheable package routes; never on `/health`, `/metrics`
+
+### HTTP Endpoints
+
+All paths are under `/api/v1`. Wrap responses always look like `{ "data": ..., "meta": {...} }` for paginated lists, `{ "data": ... }` for single items.
+
+| Method | Path                                                | Purpose                              |
+| ------ | --------------------------------------------------- | ------------------------------------ |
+| `GET`  | `/search?q=<name>&limit=&offset=&sort=&exact=`      | Search packages                      |
+| `GET`  | `/search/description?q=<text>&limit=&offset=`       | Full-text search descriptions (FTS5) |
+| `GET`  | `/packages/{attr}`                                  | All version records for a package    |
+| `GET`  | `/packages/{attr}/history`                          | Version timeline (first/last seen)   |
+| `GET`  | `/packages/{attr}/versions/{version}`               | All records for one version          |
+| `GET`  | `/packages/{attr}/versions/{version}/first`         | First-seen commit                    |
+| `GET`  | `/packages/{attr}/versions/{version}/last`          | Last-seen commit                     |
+| `GET`  | `/stats`                                            | Index statistics                     |
+| `GET`  | `/health`                                           | Liveness probe (uncached)            |
+| `GET`  | `/metrics`                                          | Server metrics (uncached)            |
+
+**Search query parameters:**
+
+| Parameter | Type    | Description                          |
+| --------- | ------- | ------------------------------------ |
+| `q`       | string  | Search query (required)              |
+| `version` | string  | Version filter (prefix match)        |
+| `exact`   | boolean | Exact attribute name match           |
+| `license` | string  | License filter                       |
+| `sort`    | string  | `date`, `version`, or `name`         |
+| `reverse` | boolean | Reverse sort order                   |
+| `limit`   | integer | Max results (default 50)             |
+| `offset`  | integer | Results to skip (default 0)          |
+
+**Quick examples against the public instance:**
+
+```bash
+curl -s "https://nxv.urandom.io/api/v1/search?q=python&version=3.11&limit=5" | jq
+curl -s "https://nxv.urandom.io/api/v1/packages/python311/history" | jq '.data[0:3]'
+curl -s "https://nxv.urandom.io/api/v1/packages/nodejs_15/versions/15.14.0/first" | jq
+curl -s "https://nxv.urandom.io/api/v1/stats" | jq '.data'
+```
+
+## Indexer Commands (feature-gated)
+
+These require nxv built with `--features indexer` (`cargo build --features indexer` or `nix build .#nxv-indexer`) and a local nixpkgs git checkout:
+
+```bash
+# Build the index from a local nixpkgs clone
+nxv index --nixpkgs-path ./nixpkgs                   # Incremental from last commit
+nxv index --nixpkgs-path ./nixpkgs --full            # Full rebuild from scratch
+nxv index --nixpkgs-path ./nixpkgs --since 2023-01-01
+
+# Backfill missing metadata (source_path, homepage, known-vulnerabilities)
+nxv backfill --nixpkgs-path ./nixpkgs                # Fast: HEAD only
+nxv backfill --nixpkgs-path ./nixpkgs --history      # Slow: traverses git for accuracy
+
+# Repair pre-0.1.5 incremental indexer bug
+nxv dedupe --dry-run                                 # Preview
+nxv dedupe                                           # Run
+
+# Reset nixpkgs checkout to a known state
+nxv reset --nixpkgs-path ./nixpkgs --to origin/master --fetch
+
+# Publish distribution-ready compressed artifacts + manifest
+nxv publish --output ./publish --url-prefix https://your-server/nxv
+nxv publish --output ./publish --url-prefix https://... --sign --secret-key nxv.key
+
+# Generate a minisign keypair for signing manifests
+nxv keygen --secret-key ./nxv.key --public-key ./nxv.pub
+```
+
+Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index.
+
+## Key Environment Variables
+
+| Variable             | Purpose                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| `NXV_API_URL`        | Point CLI at a remote `nxv serve` instead of the local DB              |
+| `NXV_DB_PATH`        | Override local SQLite path                                             |
+| `NXV_API_TIMEOUT`    | HTTP client timeout in seconds (default 30)                            |
+| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv update`                         |
+| `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
+| `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
+| `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
+| `NXV_NO_SELF_UPDATE` | Skip the binary self-update check during `nxv update`                  |
+| `NXV_HOST`           | `nxv serve` bind host                                                  |
+| `NXV_PORT`           | `nxv serve` listen port                                                |
+| `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
+| `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
+| `NO_COLOR`           | Disable ANSI colors                                                    |
+
+## Data Paths
+
+The local index lives in platform data directories:
+
+- **macOS**: `~/Library/Application Support/nxv/`
+- **Linux**: `~/.local/share/nxv/`
+
+Files:
+
+- `index.db` — SQLite database with package versions
+- `bloom.bin` — Bloom filter sibling for fast negative lookups (loaded at search time)
+
+Safe to delete; `nxv update` will rebuild from the published manifest.
+
+## Agent Patterns
+
+**Find the commit that introduced a specific version (CLI):**
+
+```bash
+nxv search python 3.11.4 --exact --format json | \
+  jq '.[0] | {pkg: .attribute_path, version, commit: .first_commit_hash, date: .first_commit_date}'
+```
+
+**Generate the `nix shell` invocation directly (CLI):**
+
+```bash
+nxv search nodejs 15 --exact --format json | \
+  jq -r '.[0] | "nix shell nixpkgs/\(.first_commit_hash | .[0:7])#\(.attribute_path)"'
+```
+
+**Find a package version on the public API:**
+
+```bash
+curl -s "https://nxv.urandom.io/api/v1/packages/python27/versions/2.7.18/first" | \
+  jq -r '.data | "nix shell nixpkgs/\(.first_commit_hash | .[0:7])#\(.attribute_path)"'
+```
+
+**Check whether a version of a package was ever in nixpkgs (HTTP):**
+
+```bash
+curl -s "https://nxv.urandom.io/api/v1/packages/ruby/history" | \
+  jq '.data[] | select(.version | startswith("2.6"))'
+```
+
+**Get the index freshness (when was nixpkgs last walked):**
+
+```bash
+curl -s "https://nxv.urandom.io/api/v1/stats" | \
+  jq '.data | {commit: .last_indexed_commit, date: .last_indexed_date, packages: .unique_names}'
+```
+
+## Key Invariants for Agents
+
+- **Search is dedup-by-default**: by default, only the most recent record per `(attribute_path, version)` pair is returned. Pass `--full` (CLI) or use the `/packages/{attr}` HTTP endpoint to see every commit.
+- **Version filters are prefix matches**: `nxv search python 3.11` matches `3.11.0`, `3.11.4`, `3.11.10`, etc. Use `--exact` for whole-attribute matches, not for whole-version matches.
+- **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
+- **Coverage starts in 2017**: nixpkgs commits before 2017 are not indexed. Anything older needs raw git spelunking.
+- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump.
+- **`/api/v1` responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first.
+
+## Practical Tips
+
+- **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python27`.
+- **Use `--exact`** when the package name is unambiguous; otherwise `python` returns dozens of variants (`python27`, `python311`, `python311Packages.numpy`, etc.).
+- **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
+- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~100MB index download entirely if you only need occasional lookups.
+- **Update weekly**: the public index is republished on a weekly schedule (`publish-index.yml`).
+- **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
+
+## Updating This Skill
+
+This skill is maintained in the nxv repository on GitHub. To pull the latest version:
+
+```bash
+# Source repository
+https://github.com/utensils/nxv
+
+# Skill file location within the repo
+.claude/skills/nxv/SKILL.md
+
+# Fetch the latest skill directly
+curl -sL https://raw.githubusercontent.com/utensils/nxv/main/.claude/skills/nxv/SKILL.md \
+  -o ~/.claude/skills/nxv/SKILL.md
+```
+
+When copying this skill to other workspaces or agents, always pull from `main` to get the latest subcommands, flags, and JSON shapes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Claude Code skill at `.claude/skills/nxv/SKILL.md` so Claude (and any
+  agent that consumes the open Agent Skills standard, e.g. openclaw)
+  can drive the nxv CLI and HTTP API on the user's behalf without
+  extra setup. Documented at `website/guide/skill.md`.
+
+### Fixed
+
+- `--format json` and `--format plain` no longer emit human-readable
+  header lines (`Version history for: ...`, `Package: foo X.Y`, `To use
+  this version: ...`, `Package 'X' not found.`) before the machine
+  output. JSON output now parses cleanly with `jq` / `python -m json.tool`
+  / `dasel` etc., matching the documented contract. Empty / not-found
+  results emit `[]` instead of a prose line. Affects `nxv history` (all
+  modes) and `nxv info`. (#33)
+- Broken pipes (e.g. `nxv search ... --format json | head -1`,
+  `nxv history ... | jq`) no longer panic out of `println!` with a
+  spurious "failed printing to stdout: Broken pipe" backtrace and exit
+  code 5. nxv now resets `SIGPIPE` to its default disposition at startup
+  on Unix, matching ripgrep / fd / bat behavior, so the process exits
+  cleanly when a downstream consumer closes the pipe early. (#33)
+
 ## [0.2.0] - 2026-04-23
 
 _`nxv update` now also checks for a newer nxv binary release. Local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,15 @@ A NixOS module is provided for running nxv as a systemd service:
 }
 ```
 
+## Claude Code Skill
+
+The repo ships a Claude Code skill at `.claude/skills/nxv/SKILL.md` that
+teaches Claude (and any agent that consumes the open Agent Skills standard,
+e.g. openclaw) how to drive the nxv CLI and HTTP API. When changing CLI flags,
+adding/removing subcommands, or altering JSON / API response shapes, also
+update the SKILL.md so the skill stays accurate. The user-facing guide lives
+at `website/guide/skill.md`.
+
 ## Releasing
 
 **Use `/release` to prepare and execute a release.** This skill:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "git2",
  "http-body-util",
  "indicatif",
+ "libc",
  "minisign",
  "mockito",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,12 @@ semver = "1.0"
 # Temporary files
 tempfile = "3.24"
 
+# Reset SIGPIPE to default so broken pipes (e.g. `nxv ... | head`) exit cleanly
+# instead of panicking out of `println!`. Already in the dependency tree
+# transitively via reqwest/tokio/etc.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 assert_cmd = "2.1"
 predicates = "3.1"

--- a/README.md
+++ b/README.md
@@ -578,6 +578,25 @@ src/
     └── publisher.rs # Index publishing
 ```
 
+## Claude Code Skill
+
+nxv ships a [Claude Code skill](https://code.claude.com/docs/en/skills) at
+[`.claude/skills/nxv/SKILL.md`](.claude/skills/nxv/SKILL.md) so Claude — and
+agents like [openclaw](https://github.com/utensils/openclaw) — can run nxv
+commands and call the HTTP API on your behalf without extra setup.
+
+```bash
+# Install for all your projects
+mkdir -p ~/.claude/skills/nxv
+curl -sL https://raw.githubusercontent.com/utensils/nxv/main/.claude/skills/nxv/SKILL.md \
+  -o ~/.claude/skills/nxv/SKILL.md
+```
+
+Then ask Claude things like *"which nixpkgs commit shipped python 2.7?"* or
+*"give me the `nix shell` command for nodejs 15.14"*. See the
+[skill guide](https://utensils.io/nxv/guide/skill) for installation, agent
+patterns, and JSON shapes.
+
 ## Related Projects
 
 There are several other great tools in this space:

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,15 @@ use cli::{Cli, Commands};
 /// nxv::main();
 /// ```
 fn main() {
+    // Reset SIGPIPE to its default disposition so the process exits cleanly
+    // (with signal 13) when a downstream consumer like `head` or `jq` closes
+    // the pipe early, instead of panicking out of `println!`. Same approach
+    // as ripgrep, fd, bat, etc.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     let cli = Cli::parse();
 
     // Handle no-color flag
@@ -510,13 +519,19 @@ fn cmd_pkg_info(cli: &Cli, args: &cli::InfoArgs) -> Result<()> {
     let packages = backend.search_by_name_version(&args.package, version)?;
 
     if packages.is_empty() {
-        println!(
-            "Package '{}' not found{}.",
-            args.package,
-            version
-                .map(|v| format!(" version {}", v))
-                .unwrap_or_default()
-        );
+        match args.format {
+            cli::OutputFormatArg::Json => println!("[]"),
+            cli::OutputFormatArg::Plain => {} // empty stdout
+            cli::OutputFormatArg::Table => {
+                println!(
+                    "Package '{}' not found{}.",
+                    args.package,
+                    version
+                        .map(|v| format!(" version {}", v))
+                        .unwrap_or_default()
+                );
+            }
+        }
         return Ok(());
     }
 
@@ -907,53 +922,86 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
         let packages = backend.search_by_name_version(&args.package, Some(version.as_str()))?;
 
         if packages.is_empty() {
-            println!("Version {} of {} not found.", version, args.package);
-        } else {
-            // Use the first (most recent) match
-            let pkg = &packages[0];
-            println!("Package: {} {}", pkg.attribute_path, pkg.version);
-            println!();
-            println!(
-                "First appeared: {} ({})",
-                pkg.first_commit_short(),
-                pkg.first_commit_date.format("%Y-%m-%d")
-            );
-            println!(
-                "Last seen: {} ({})",
-                pkg.last_commit_short(),
-                pkg.last_commit_date.format("%Y-%m-%d")
-            );
-            println!();
-
-            // Show security warning if package has known vulnerabilities
-            if pkg.is_insecure() {
-                use owo_colors::OwoColorize;
-                println!("{}", "Security Warning".bold().underline().red());
-                println!(
-                    "  {}",
-                    "This package has known vulnerabilities!".red().bold()
-                );
-                let vulns = pkg.vulnerabilities();
-                for vuln in &vulns {
-                    println!("  {} {}", "•".red(), vuln);
+            match args.format {
+                cli::OutputFormatArg::Json => println!("[]"),
+                cli::OutputFormatArg::Plain => {} // empty stdout
+                cli::OutputFormatArg::Table => {
+                    println!("Version {} of {} not found.", version, args.package);
                 }
-                println!();
             }
+            return Ok(());
+        }
 
-            println!("To use this version:");
-            println!("  {}", pkg.nix_run_cmd());
+        // Use the first (most recent) match
+        let pkg = &packages[0];
+
+        match args.format {
+            cli::OutputFormatArg::Json => {
+                println!("{}", serde_json::to_string_pretty(&packages)?);
+            }
+            cli::OutputFormatArg::Plain => {
+                println!(
+                    "ATTR_PATH\tVERSION\tFIRST_COMMIT\tFIRST_DATE\tLAST_COMMIT\tLAST_DATE\tINSECURE"
+                );
+                println!(
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                    pkg.attribute_path,
+                    pkg.version,
+                    pkg.first_commit_short(),
+                    pkg.first_commit_date.format("%Y-%m-%d"),
+                    pkg.last_commit_short(),
+                    pkg.last_commit_date.format("%Y-%m-%d"),
+                    if pkg.is_insecure() { "yes" } else { "no" },
+                );
+            }
+            cli::OutputFormatArg::Table => {
+                println!("Package: {} {}", pkg.attribute_path, pkg.version);
+                println!();
+                println!(
+                    "First appeared: {} ({})",
+                    pkg.first_commit_short(),
+                    pkg.first_commit_date.format("%Y-%m-%d")
+                );
+                println!(
+                    "Last seen: {} ({})",
+                    pkg.last_commit_short(),
+                    pkg.last_commit_date.format("%Y-%m-%d")
+                );
+                println!();
+
+                // Show security warning if package has known vulnerabilities
+                if pkg.is_insecure() {
+                    use owo_colors::OwoColorize;
+                    println!("{}", "Security Warning".bold().underline().red());
+                    println!(
+                        "  {}",
+                        "This package has known vulnerabilities!".red().bold()
+                    );
+                    let vulns = pkg.vulnerabilities();
+                    for vuln in &vulns {
+                        println!("  {} {}", "•".red(), vuln);
+                    }
+                    println!();
+                }
+
+                println!("To use this version:");
+                println!("  {}", pkg.nix_run_cmd());
+            }
         }
     } else if args.full {
         // Show full details for all versions
         let packages = backend.search_by_name(&args.package, true)?;
 
         if packages.is_empty() {
-            println!("No history found for package '{}'", args.package);
+            match args.format {
+                cli::OutputFormatArg::Json => println!("[]"),
+                cli::OutputFormatArg::Plain => {} // empty stdout
+                cli::OutputFormatArg::Table => {
+                    println!("No history found for package '{}'", args.package);
+                }
+            }
             return Ok(());
         }
-
-        println!("Version history for: {}", args.package);
-        println!();
 
         match args.format {
             cli::OutputFormatArg::Json => {
@@ -982,6 +1030,9 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
                 use comfy_table::{
                     Cell, Color, ContentArrangement, Table, presets::ASCII_FULL, presets::UTF8_FULL,
                 };
+
+                println!("Version history for: {}", args.package);
+                println!();
 
                 let mut table = Table::new();
                 table
@@ -1035,12 +1086,15 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
         let history = backend.get_version_history(&args.package)?;
 
         if history.is_empty() {
-            println!("No history found for package '{}'", args.package);
+            match args.format {
+                cli::OutputFormatArg::Json => println!("[]"),
+                cli::OutputFormatArg::Plain => {} // empty stdout
+                cli::OutputFormatArg::Table => {
+                    println!("No history found for package '{}'", args.package);
+                }
+            }
             return Ok(());
         }
-
-        println!("Version history for: {}", args.package);
-        println!();
 
         match args.format {
             cli::OutputFormatArg::Json => {
@@ -1073,6 +1127,9 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
                 use comfy_table::{
                     Cell, Color, ContentArrangement, Table, presets::ASCII_FULL, presets::UTF8_FULL,
                 };
+
+                println!("Version history for: {}", args.package);
+                println!();
 
                 let mut table = Table::new();
                 table

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -457,6 +457,8 @@ fn test_history_json_format() {
     let db_path = dir.path().join("test.db");
     create_test_db(&db_path);
 
+    // Regression for #33: --format json must produce pure JSON on stdout
+    // (no human-readable "Version history for: ..." header).
     let output = nxv()
         .args([
             "--db-path",
@@ -470,11 +472,97 @@ fn test_history_json_format() {
         .success();
 
     let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
-    // Skip the header line and parse JSON
-    let json_part = stdout.lines().skip(2).collect::<Vec<_>>().join("\n");
     let parsed: serde_json::Value =
-        serde_json::from_str(&json_part).expect("Output should contain valid JSON");
+        serde_json::from_str(&stdout).expect("Output should be valid JSON with no header");
+    assert!(parsed.is_array(), "JSON output should be an array");
+    assert!(
+        !stdout.contains("Version history for:"),
+        "JSON output must not contain human-readable header"
+    );
+}
+
+#[test]
+fn test_history_full_json_format() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #33: --full --format json must also produce pure JSON.
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "history",
+            "python",
+            "--full",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--full --format json should be pure JSON");
     assert!(parsed.is_array());
+    assert!(!stdout.contains("Version history for:"));
+}
+
+#[test]
+fn test_history_specific_version_json() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #33: history with a specific version + --format json
+    // must produce pure JSON (was previously printing "Package: foo X.Y" first).
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "history",
+            "python",
+            "3.11.0",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("Specific-version JSON should parse cleanly");
+    assert!(parsed.is_array());
+    assert!(!stdout.contains("Package:"));
+    assert!(!stdout.contains("To use this version:"));
+}
+
+#[test]
+fn test_history_not_found_json() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #33: not-found path with --format json must still
+    // produce parseable JSON (an empty array), not the human-readable
+    // "No history found" message that breaks downstream `jq`.
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "history",
+            "nonexistent_package",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("Not-found JSON should be an empty array");
+    assert_eq!(parsed.as_array().map(|a| a.len()), Some(0));
+    assert!(!stdout.contains("No history found"));
 }
 
 #[test]
@@ -493,6 +581,109 @@ fn test_history_not_found() {
         .assert()
         .success()
         .stdout(predicate::str::contains("No history found"));
+}
+
+#[test]
+fn test_info_json_pure() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #33: `nxv info ... --format json` must be pure JSON.
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "info",
+            "python",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("info --format json should be pure JSON");
+    assert!(parsed.is_array());
+}
+
+#[test]
+fn test_info_not_found_json() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #33: not-found path on `info` with --format json must
+    // emit `[]`, not the human-readable "Package 'X' not found." message.
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "info",
+            "nonexistent_package_xyz",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("Not-found JSON should be an empty array");
+    assert_eq!(parsed.as_array().map(|a| a.len()), Some(0));
+    assert!(!stdout.contains("not found"));
+}
+
+#[test]
+#[cfg(unix)]
+fn test_broken_pipe_exits_cleanly() {
+    use std::io::Read;
+    use std::process::{Command as StdCommand, Stdio};
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #33: a downstream consumer closing stdin early must
+    // not cause nxv to panic from inside `println!`. Spawn nxv with stdout
+    // piped, drop the read end immediately, then assert nxv exits without
+    // a Rust panic backtrace.
+    let bin = assert_cmd::cargo::cargo_bin!("nxv");
+    let mut child = StdCommand::new(bin)
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "history",
+            "python",
+            "--full",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn nxv");
+
+    // Drop stdout immediately to close the pipe → next println! in nxv hits EPIPE.
+    drop(child.stdout.take());
+
+    let status = child.wait().expect("wait nxv");
+    let mut stderr = String::new();
+    if let Some(mut e) = child.stderr.take() {
+        let _ = e.read_to_string(&mut stderr);
+    }
+
+    assert!(
+        !stderr.contains("panicked at"),
+        "nxv panicked on broken pipe (regressed #33): {stderr}"
+    );
+    // SIGPIPE-terminated processes have status.code() == None on Unix, or
+    // 141 (128+13) when wrapped by a shell. A clean 0 is also acceptable
+    // if nxv finished writing before the pipe closed.
+    let code = status.code();
+    assert!(
+        code.is_none() || code == Some(0) || code == Some(141),
+        "unexpected exit on broken pipe: code={code:?}, stderr={stderr}"
+    );
 }
 
 // ============================================================================

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -63,6 +63,10 @@ export default defineConfig({
           text: 'Usage',
           items: [{ text: 'CLI Reference', link: '/guide/cli-reference' }],
         },
+        {
+          text: 'Integrations',
+          items: [{ text: 'Claude Code Skill', link: '/guide/skill' }],
+        },
       ],
       '/advanced/': [
         {

--- a/website/guide/skill.md
+++ b/website/guide/skill.md
@@ -1,0 +1,120 @@
+# Claude Code Skill
+
+nxv ships a [Claude Code skill](https://code.claude.com/docs/en/skills) that
+lets Claude — and agents like [openclaw](https://github.com/utensils/openclaw) —
+run nxv commands on your behalf without extra setup.
+
+## What is a skill?
+
+A Claude Code skill is a `SKILL.md` file (with optional supporting files) that
+teaches Claude how to use a tool. When the skill is loaded, Claude knows every
+subcommand, flag, JSON output shape, and HTTP endpoint for nxv. It can answer
+questions like "which nixpkgs commit shipped python 2.7?" or "give me the
+`nix shell` command for nodejs 15" by running the right `nxv` invocation (or
+hitting the public API) and interpreting the result.
+
+The skill follows the open [Agent Skills](https://agentskills.io) standard, so
+it works with Claude Code, the Claude Agent SDK, openclaw, and any other tool
+that consumes the same `SKILL.md` format.
+
+## Installing the skill
+
+### Personal skill (all your projects)
+
+```bash
+mkdir -p ~/.claude/skills/nxv
+curl -sL https://raw.githubusercontent.com/utensils/nxv/main/.claude/skills/nxv/SKILL.md \
+  -o ~/.claude/skills/nxv/SKILL.md
+```
+
+This makes the skill available in every Claude Code session on your machine.
+
+### Project-local skill
+
+```bash
+mkdir -p .claude/skills/nxv
+curl -sL https://raw.githubusercontent.com/utensils/nxv/main/.claude/skills/nxv/SKILL.md \
+  -o .claude/skills/nxv/SKILL.md
+```
+
+Only active when you're in that project's directory.
+
+### From this repo (if you cloned nxv)
+
+The skill is already at `.claude/skills/nxv/SKILL.md` in the repo root. Copy it
+wherever you need it:
+
+```bash
+cp .claude/skills/nxv/SKILL.md ~/.claude/skills/nxv/SKILL.md
+```
+
+## Using the skill
+
+Once installed, you can invoke it directly:
+
+```
+/nxv search python 2.7
+/nxv info python311 3.11.4
+/nxv history nodejs_15
+```
+
+Or just ask Claude naturally — it will load the skill automatically when your
+question matches the description:
+
+> "Which nixpkgs commit had python 2.7?"
+>
+> "Give me the `nix shell` command for nodejs 15.14."
+>
+> "When was ruby 2.6 last in nixpkgs?"
+
+You don't need a local index for the skill to be useful — Claude can hit the
+public API at `https://nxv.urandom.io` directly, or you can set
+`NXV_API_URL=https://nxv.urandom.io` in your environment so the CLI uses the
+hosted instance transparently.
+
+## For agents (openclaw and others)
+
+The skill is designed so autonomous agents can extract structured data reliably.
+Every CLI subcommand that produces output supports `--format json`, and every
+HTTP API response is wrapped in a stable `{ "data": ..., "meta": {...} }`
+envelope. Agents should:
+
+1. Run `nxv <subcommand> --format json` (CLI) or hit `/api/v1/...` (HTTP) for
+   machine-readable output.
+2. Pipe to `jq` (or parse in-process) for the specific field they need.
+3. Never rely on the human-readable table output — column widths and formatting
+   are terminal-dependent.
+
+Example agent pattern — generate a `nix shell` invocation for a specific version
+directly from the public API:
+
+```bash
+curl -s "https://nxv.urandom.io/api/v1/packages/python27/versions/2.7.18/first" | \
+  jq -r '.data | "nix shell nixpkgs/\(.first_commit_hash | .[0:7])#\(.attribute_path)"'
+```
+
+Or via the CLI against any backend:
+
+```bash
+nxv search nodejs 15 --exact --format json | \
+  jq -r '.[0] | "nix shell nixpkgs/\(.first_commit_hash | .[0:7])#\(.attribute_path)"'
+```
+
+## Keeping the skill up to date
+
+Pull the latest version any time nxv ships new subcommands, flags, or API
+endpoints:
+
+```bash
+curl -sL https://raw.githubusercontent.com/utensils/nxv/main/.claude/skills/nxv/SKILL.md \
+  -o ~/.claude/skills/nxv/SKILL.md
+```
+
+The skill file itself contains a self-update reminder at the bottom with this
+same command.
+
+## Skill source
+
+The canonical skill lives at
+[`.claude/skills/nxv/SKILL.md`](https://github.com/utensils/nxv/blob/main/.claude/skills/nxv/SKILL.md)
+in the repository.


### PR DESCRIPTION
## Summary

- **Adds an agent-facing Claude Code skill** at `.claude/skills/nxv/SKILL.md` so Claude (and any agent that consumes the open [Agent Skills](https://agentskills.io) standard, e.g. [openclaw](https://github.com/utensils/openclaw)) can drive the nxv CLI and HTTP API on the user's behalf without extra setup. Following the same pattern used in [`mold`](https://github.com/utensils/mold) and [`claudex`](https://github.com/utensils/claudex). Documents installation, usage, and agent-friendly JSON shapes in `website/guide/skill.md`; cross-links from `README.md` and `CLAUDE.md`.
- **Fixes #33** (surfaced while auditing the JSON contract for the skill):
  - `nxv history` (all modes) and `nxv info` no longer print human-readable header lines (`Version history for: ...`, `Package: foo X.Y`, `To use this version: ...`, `Package 'X' not found.`) before `--format json` / `--format plain` output. JSON now parses cleanly with `jq` / `python -m json.tool` / `dasel`, matching the documented contract. Empty / not-found results emit `[]` instead of a prose line.
  - `main()` resets `SIGPIPE` to its default disposition on Unix at startup, matching `ripgrep` / `fd` / `bat`. Piping nxv into a consumer that closes stdin early (`head -1`, `jq` parse-error, etc.) now exits cleanly instead of panicking out of `println!` with exit code 5.
- Adds regression tests covering pure-JSON output across `history` (specific version, `--full`, summary), `info`, the not-found path, and broken-pipe handling.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 66 pass, 0 fail (incl. 5 new regression tests for #33)
- [x] `nix flake check` — green (nxv build, clippy, test, fmt, treefmt, a11y)
- [x] `cd website && bun run build` — clean VitePress build with the new `/guide/skill` page
- [x] Manual smoke: `nxv history firefox --format json | jq 'length'` returns a number with no parse error and no panic
- [x] Manual smoke: `nxv search python --format json | head -1` exits cleanly