### PR TITLE
fix(ci): remove nightly clippy formatting borrows

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -919,7 +919,7 @@ impl Indexer {
                 pb.set_message(format!(
                     "({}) {} ({}) | {} pkgs | {} ranges",
                     eta_tracker.eta_string(),
-                    &commit.short_hash,
+                    commit.short_hash,
                     commit.date.format("%Y-%m-%d"),
                     result.packages_found,
                     result.ranges_written
@@ -930,7 +930,7 @@ impl Indexer {
             if let Err(e) = repo.checkout_commit(&commit.hash) {
                 warn(
                     &progress_bar,
-                    format!("Failed to checkout {}: {}", &commit.short_hash, e),
+                    format!("Failed to checkout {}: {}", commit.short_hash, e),
                 );
                 prev_commit_hash = Some(commit.hash.clone());
                 prev_commit_date = Some(commit.date);
@@ -944,7 +944,7 @@ impl Indexer {
                 Err(e) => {
                     warn(
                         &progress_bar,
-                        format!("Failed to list changes for {}: {}", &commit.short_hash, e),
+                        format!("Failed to list changes for {}: {}", commit.short_hash, e),
                     );
                     prev_commit_hash = Some(commit.hash.clone());
                     prev_commit_date = Some(commit.date);
@@ -1031,7 +1031,7 @@ impl Indexer {
                                 &progress_bar,
                                 format!(
                                     "Extraction failed at {} ({}): {}",
-                                    &commit.short_hash, system, e
+                                    commit.short_hash, system, e
                                 ),
                             );
                             continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1430,7 +1430,7 @@ fn cmd_dedupe(cli: &Cli, args: &cli::DedupeArgs) -> Result<()> {
             } else {
                 "starting"
             },
-            &cli.db_path
+            cli.db_path
         );
     }
 


### PR DESCRIPTION
## Summary
- Fixes the Ubuntu nightly CI failure in the `Clippy (indexer feature)` step.
- Removes redundant `&` references passed to `format!`/`eprintln!` arguments in the indexer and dedupe command.

## Root cause
Nightly clippy now reports `clippy::useless_borrows_in_formatting` for redundant references in formatting macros. Because CI runs clippy with `-D warnings`, the Ubuntu nightly matrix job failed on five instances in `src/index/mod.rs` and `src/main.rs`.

## Validation
- `cargo fmt --check`
- `cargo clippy --features indexer -- -D warnings`
- `rustup run nightly cargo clippy --features indexer -- -D warnings`
- `cargo test --features indexer`
