### PR TITLE
ci: adopt release-plz; fix indexer sandbox failure

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,171 +1,67 @@
 ---
-description: Prepare and execute a release with pre-flight checks and user confirmation
+description: Review and merge the release-plz release PR with explicit user confirmation
 allowed-tools: Bash, Read, Grep, Edit, AskUserQuestion
 ---
 
 # Release
 
-Prepare and execute a release for nxv. Run pre-flight checks, generate release
-notes, and require explicit user confirmation before making any changes.
+Releases are driven by **release-plz** (`release-plz.toml` +
+`.github/workflows/release-plz.yml`). On every push to main it maintains a
+`chore: release vX.Y.Z` PR with the version bump and CHANGELOG update derived
+from conventional commits. **Merging that PR ships the release** — release-plz
+pushes the `vX.Y.Z` tag, which triggers `release.yml` (static binaries, GitHub
+release, crates.io, Docker) and `flakehub-publish-tagged.yml`.
 
-## Phase 1: Pre-flight Checks
+This command walks that flow safely. Never merge the release PR without
+explicit user confirmation — it is an outward-facing, hard-to-reverse action.
 
-Run these checks and stop immediately if any fail:
-
-```bash
-cargo fmt --check
-cargo clippy --features indexer -- -D warnings
-cargo test --features indexer
-markdownlint '**/*.md' --ignore node_modules
-nix flake check
-git status --porcelain
-```
-
-If `git status` shows uncommitted changes, stop and inform the user.
-
-## Phase 2: Gather Release Information
-
-1. Get the current version from `Cargo.toml`.
-2. Get the last tag with `git describe --tags --abbrev=0`.
-3. Get commits since last tag with `git log --oneline <last-tag>..HEAD`.
-4. Read current `CHANGELOG.md` to see unreleased section.
-
-## Phase 3: Determine Version
-
-Follow semantic versioning (`MAJOR.MINOR.PATCH`):
-
-- **MAJOR** - Breaking changes (API incompatibility, removed features)
-- **MINOR** - New features (backward compatible additions)
-- **PATCH** - Bug fixes (backward compatible fixes)
-
-Pre-release versions use hyphen suffix (e.g., `0.2.0-rc1`).
-
-Review the commits and suggest an appropriate version bump based on the changes.
-
-## Phase 4: Generate Release Notes
-
-Create markdown release notes with these sections:
-
-- **Features** - New functionality (commits starting with `feat:`)
-- **Fixes** - Bug fixes (commits starting with `fix:`)
-- **Other** - Everything else (refactor, chore, docs, etc.)
-
-## Phase 5: User Confirmation
-
-Present a summary and ask for confirmation before proceeding:
-
-```text
-=== RELEASE SUMMARY ===
-
-Current version: X.Y.Z
-Suggested version: A.B.C (reason: <major/minor/patch bump rationale>)
-
-Commits to be released:
-  <commit list>
-
-Release Notes:
-  <generated notes>
-
-Files to modify:
-  1. Cargo.toml - bump version to A.B.C
-  2. CHANGELOG.md - move Unreleased items to [A.B.C] section
-  3. Cargo.lock - updated automatically by cargo build
-
-Actions after verification:
-  4. Run cargo build/test/clippy to verify changes
-  5. Commit with message "chore: release A.B.C"
-  6. Run isolated Docker nix build (optional)
-  7. Create and push tag vA.B.C
-
-CI/CD will then:
-  - Build static binaries (Linux x86_64/aarch64, macOS x86_64/ARM64)
-  - Create GitHub Release with binaries and checksums
-  - Publish to crates.io
-  - Push Docker image to ghcr.io/utensils/nxv (timestamp derived from commit)
-  - Publish to FlakeHub
-
-Proceed? Enter version number to confirm, or "abort" to cancel.
-```
-
-Use `AskUserQuestion` to get confirmation. The user must provide the version
-number (e.g., `0.1.4` or `0.2.0`).
-
-## Phase 6: Execute Release
-
-Only proceed after explicit user confirmation with a version number.
-
-### Step 1: Update Cargo.toml
-
-Edit the `version` field to the new version.
-
-### Step 2: Update CHANGELOG.md
-
-Move the `[Unreleased]` section contents to a new version section:
-
-1. Create new section `## [A.B.C] - YYYY-MM-DD` below `[Unreleased]`.
-2. Move all content from `[Unreleased]` to the new section.
-3. Leave `[Unreleased]` empty (keep the heading).
-4. Update the comparison links at the bottom:
-   - Change `[unreleased]` link to compare against new tag.
-   - Add new version link.
-
-### Step 3: Verify changes
-
-Run a full build and test suite to ensure the version bump doesn't break anything
-and to regenerate Cargo.lock with the new version:
+## Phase 1: Locate the release PR
 
 ```bash
-cargo build --features indexer
-cargo test --features indexer
-cargo clippy --features indexer -- -D warnings
+gh pr list --repo utensils/nxv --search "chore: release in:title" --state open
 ```
 
-If any verification fails, stop and inform the user before committing.
+If none exists, check whether main has unreleased conventional commits since
+the last tag (`git log $(git describe --tags --abbrev=0)..origin/main --oneline`).
+If there are releasable commits but no PR, check the latest `Release-plz`
+workflow run for errors (`gh run list --workflow release-plz.yml`).
 
-### Step 4: Commit changes
+## Phase 2: Review what will ship
 
-Include Cargo.lock to ensure reproducible builds:
+1. Show the PR's version bump (Cargo.toml diff) and CHANGELOG addition.
+2. Verify the version follows the project convention: `feat:` commits bump
+   the 0.x minor (`features_always_increment_minor = true`), fixes bump patch.
+3. If the version or changelog is wrong, edit the release PR directly
+   (it is a normal editable PR) — release-plz preserves manual edits unless
+   new commits land on main.
+
+## Phase 3: Pre-flight
+
+1. All CI checks on the release PR must be green. If checks show "Expected /
+   Waiting", the App token is misconfigured — see `release-plz.yml` comments.
+2. Confirm no other PR is about to land that should be in this release.
+
+## Phase 4: Confirm and merge
+
+Present a summary (version, commit list, changelog) and require the user to
+confirm with the explicit version number (AskUserQuestion). Then:
 
 ```bash
-git add Cargo.toml Cargo.lock CHANGELOG.md
-git commit -m "chore: release A.B.C"
+gh pr merge <PR> --repo utensils/nxv --squash
 ```
 
-### Step 5: Verify isolated nix build (optional but recommended)
+## Phase 5: Monitor
 
-Run the isolated Docker build to verify the flake builds correctly with no local
-state. This catches issues like missing Cargo.lock that would fail in CI:
+1. The `Release-plz` workflow on main pushes the tag.
+2. The `Release` workflow builds binaries and publishes — monitor with
+   `gh run list --workflow release.yml` / `gh run watch`.
+3. Verify the GitHub release has all four binaries + SHA256SUMS.txt,
+   crates.io has the new version, and ghcr.io has the version tag.
 
-```bash
-./scripts/verify-nix-build.sh
-```
+## Manual escape hatches
 
-If Docker is not available or the user wants to skip, proceed with caution.
-
-### Step 6: Create tag locally
-
-```bash
-git tag vA.B.C
-```
-
-### Step 7: Push commit and tag
-
-```bash
-git push origin main
-git push origin vA.B.C
-```
-
-### Step 8: Report completion
-
-Provide link to [GitHub Actions][actions] and remind user to monitor the
-release workflow.
-
-[actions]: https://github.com/utensils/nxv/actions
-
-## Important Notes
-
-- Never proceed past Phase 5 without explicit user confirmation.
-- Stop immediately if any pre-flight check fails.
-- The changelog must be updated as part of the release.
-- Version bumps must follow semver conventions.
-- Docker image timestamp is derived automatically from git commit date.
+- Tagging failed after the release PR merged: re-run the `Release-plz`
+  workflow on main (it is idempotent — existing tags are the gate).
+- The old fully-manual flow (bump Cargo.toml, edit CHANGELOG, tag by hand)
+  still works in emergencies but must match release-plz's expectations
+  (tag `vX.Y.Z`, CHANGELOG section `## [X.Y.Z] - YYYY-MM-DD`).

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,82 @@
+name: Release-plz
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  # Creates/updates the "chore: release vX.Y.Z" PR (version bump + CHANGELOG).
+  #
+  # Both jobs mint a GitHub App token instead of using GITHUB_TOKEN: events
+  # created with the default token never trigger other workflows (GitHub's
+  # recursion guard), so CI would not run on the release PR and the tag push
+  # would not trigger release.yml.
+  release-plz-pr:
+    name: Release PR
+    if: github.repository_owner == 'utensils'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  # After the release PR merges, creates and pushes the vX.Y.Z tag, which
+  # triggers release.yml (binaries, GitHub release, crates.io, Docker) and
+  # flakehub-publish-tagged.yml. publish + git_release are disabled in
+  # release-plz.toml, so this job only tags.
+  #
+  # Deliberately NO concurrency group: cancelling a release mid-flight can
+  # skip it entirely (release-plz docs).
+  release-plz-release:
+    name: Release (tag)
+    if: github.repository_owner == 'utensils'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,20 +204,24 @@ at `website/guide/skill.md`.
 
 ## Releasing
 
-**Use `/release` to prepare and execute a release.** This skill:
-
-1. Runs pre-flight checks (fmt, clippy, tests, nix flake check, clean git status)
-2. Generates release notes from git history
-3. Shows a complete summary of what will happen
-4. Asks for explicit confirmation with the version number
-5. Bumps version, updates Docker timestamp, commits, and tags
-6. CI/CD handles the rest (builds, GitHub release, crates.io, Docker, FlakeHub)
+Releases are automated with **release-plz** (`release-plz.toml` +
+`.github/workflows/release-plz.yml`). On every push to main it maintains a
+`chore: release vX.Y.Z` PR (version bump + CHANGELOG from conventional
+commits; `feat:` bumps the 0.x minor via `features_always_increment_minor`).
+**Merging that PR ships the release**: release-plz pushes the `vX.Y.Z` tag,
+which triggers `release.yml` and `flakehub-publish-tagged.yml`. Both
+release-plz jobs author with a GitHub App token (secrets
+`RELEASE_PLZ_APP_ID` / `RELEASE_PLZ_APP_PRIVATE_KEY`) — the default
+`GITHUB_TOKEN` would neither trigger CI on the release PR nor fire the
+tag-push workflows. Use `/release` to review and merge the release PR with
+confirmation; never merge it without explicit user approval.
 
 ## CI/CD & Index Publishing
 
 ### GitHub Actions Workflows
 
 - `ci.yml`: Runs on PRs and main - tests (cargo + nix), clippy, fmt, builds Docker latest on main
+- `release-plz.yml`: On pushes to main - maintains the release PR; tags `vX.Y.Z` when it merges (see Releasing)
 - `release.yml`: Triggered by `v*` tags - builds static binaries, publishes to crates.io, pushes versioned Docker images
 - `publish-index.yml`: Every 6 hours or manual - ingests new channel-release snapshots into the index and republishes to `index-latest` only when something was ingested and monitors are green (`--strict --head-eval --report`)
 - `pages.yml`: Deploys the VitePress docs site (`website/`) to GitHub Pages on pushes to main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.2.1] - 2026-04-24
 
 _Ships an agent-facing Claude Code skill so Claude / openclaw can drive
@@ -325,7 +323,6 @@ search-results view toggle._
 - Rust 2024 edition
 - 10 MB release binary size
 
-[unreleased]: https://github.com/utensils/nxv/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/utensils/nxv/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/utensils/nxv/compare/v0.1.7...v0.2.0
 [0.1.7]: https://github.com/utensils/nxv/compare/v0.1.6...v0.1.7

--- a/flake.nix
+++ b/flake.nix
@@ -418,6 +418,12 @@
           checks = {
             inherit nxv;
 
+            # The indexer build runs its test suite inside the Nix sandbox
+            # (read-only HOME, loopback-only network) — an environment no
+            # other check exercises. Without this, sandbox-only failures
+            # surface first in the main-branch Docker image build.
+            inherit nxv-indexer;
+
             nxv-clippy = craneLib.cargoClippy (
               commonArgs
               // {

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,22 @@
+# release-plz drives the release PR (version bump + CHANGELOG) and the vX.Y.Z
+# tag ONLY. Everything downstream — GitHub release with binaries, crates.io,
+# Docker, FlakeHub — stays in the tag-triggered release.yml, so those two
+# features are deliberately disabled here.
+
+[workspace]
+# release.yml publishes to crates.io on tag push; release-plz still creates
+# the git tag with publishing disabled.
+publish = false
+
+# release.yml creates the GitHub release (softprops/action-gh-release) and
+# attaches the static binaries + SHA256SUMS.
+git_release_enable = false
+
+# On 0.x versions release-plz bumps only the patch for feat: commits by
+# default. This repo treats 0.x minors as feature releases (0.1 -> 0.2 were
+# feature bumps), so keep that convention.
+features_always_increment_minor = true
+
+# nxv is a CLI; the library target is an implementation detail, not a semver
+# contract worth a cargo-semver-checks baseline build on every release PR.
+semver_check = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1238,8 +1238,16 @@ fn cmd_index(cli: &Cli, args: &cli::IndexArgs) -> Result<()> {
         );
     }
 
-    // Ensure data directory exists before opening database
-    paths::ensure_data_dir()?;
+    // Ensure the database's parent directory exists before opening it. Use
+    // the resolved --db-path, NOT the default platform data dir: with an
+    // overridden path the default dir is never touched, which matters when
+    // HOME is read-only (Nix build sandbox, locked-down service accounts).
+    if let Some(parent) = cli.db_path.parent()
+        && !parent.as_os_str().is_empty()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
 
     Ok(crate::index::run_index(cli, args)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,13 @@ fn main() {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
 
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
+
+    // Shell tilde expansion doesn't happen for `--db-path=~/...` or
+    // NXV_DB_PATH=~/...; expand it once here so every command (and the
+    // parent-dir creation in cmd_index) sees a real path instead of a
+    // literal `~` directory.
+    cli.db_path = paths::expand_tilde(&cli.db_path);
 
     // Handle no-color flag
     if cli.no_color {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -66,7 +66,6 @@ pub fn get_bloom_path_for_db<P: AsRef<Path>>(db_path: P) -> PathBuf {
 /// let path = PathBuf::from("/tmp/foo");
 /// assert_eq!(expand_tilde(&path), path);
 /// ```
-#[cfg_attr(not(feature = "indexer"), allow(dead_code))]
 pub fn expand_tilde<P: AsRef<Path>>(path: P) -> PathBuf {
     let path = path.as_ref();
     if let Ok(stripped) = path.strip_prefix("~")

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -77,26 +77,6 @@ pub fn expand_tilde<P: AsRef<Path>>(path: P) -> PathBuf {
     path.to_path_buf()
 }
 
-/// Ensures the nxv data directory exists, creating it and any missing parents if necessary.
-///
-/// This creates the directory returned by `get_data_dir()` when it does not already exist.
-/// I/O errors from creating directories are returned to the caller.
-///
-/// # Examples
-///
-/// ```
-/// // Create the data directory if needed; propagate or assert success in tests.
-/// assert!(nxv::paths::ensure_data_dir().is_ok());
-/// ```
-#[cfg_attr(not(feature = "indexer"), allow(dead_code))]
-pub fn ensure_data_dir() -> std::io::Result<()> {
-    let data_dir = get_data_dir();
-    if !data_dir.exists() {
-        std::fs::create_dir_all(&data_dir)?;
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Two related changes that unblock the v0.3.0 release:

### 1. Fix the `nxv-indexer` sandbox failure that broke main's Docker build

`nxv index` unconditionally created the **default platform data directory** even when `--db-path` pointed elsewhere. Under a read-only `HOME` (Nix build sandbox sets `HOME=/homeless-shelter`; also any locked-down service account) this failed with `Permission denied (os error 13)` before any work started — the cause of the three e2e test failures in the `nxv-indexer` derivation inside the Docker image build on main ([run 27363749926](https://github.com/utensils/nxv/actions/runs/27363749926)).

Now the parent of the **resolved** db path is created instead; `paths::ensure_data_dir` is gone. Verified by running the failing e2e test under `HOME=/var/empty` (fails before, passes after) and a full local `nix build .#nxv-indexer`.

**CI gap closed:** `nxv-indexer` is now part of `nix flake check`, so PRs exercise the sandboxed indexer test suite — this class of failure can no longer ship to main unseen.

### 2. Adopt release-plz (replaces the manual /release flow)

- `release-plz.toml`: release PR + CHANGELOG + `vX.Y.Z` tag **only** — `publish = false`, `git_release_enable = false`. The proven tag-triggered `release.yml` pipeline (static binaries, GitHub release, crates.io, Docker) is untouched, as is `flakehub-publish-tagged.yml`.
- `features_always_increment_minor = true`: release-plz's default for 0.x crates bumps only the **patch** for `feat:` commits; this repo treats 0.x minors as feature releases, so the pending indexer rewrite correctly produces **0.3.0**, not 0.2.2.
- `.github/workflows/release-plz.yml`: two jobs per upstream quickstart (`release-pr` with concurrency guard; `release` deliberately without one). Both author via the `nxv-release-plz` GitHub App token — the default `GITHUB_TOKEN` would neither trigger CI on the release PR nor fire the tag-push workflows.
- CHANGELOG: dropped the manual `[Unreleased]` section (release-plz prepends generated sections under the header).
- Docs: AGENTS.md Releasing section + `.claude/commands/release.md` rewritten for the new flow.

## After merge

The `Release-plz` workflow opens `chore: release v0.3.0` covering the indexer rewrite (#36) and these fixes. Merging that PR tags v0.3.0 and ships through the existing pipeline.