### PR TITLE
fix(publish): make index release uploads resilient

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -286,6 +286,7 @@ nxv dedupe                                           # Run
 # Publish distribution-ready compressed artifacts + manifest
 nxv publish --output ./publish --url-prefix https://your-server/nxv
 nxv publish --output ./publish --url-prefix https://... --sign --secret-key nxv.key
+nxv publish --output ./publish --url-prefix https://... --artifact-name-prefix run-123-
 
 # Generate a minisign keypair for signing manifests
 nxv keygen --secret-key ./nxv.key --public-key ./nxv.pub
@@ -295,7 +296,7 @@ Every recorded commit is a real, Hydra-built channel commit — `nix shell` comm
 
 Retired commands: `nxv backfill` and `nxv reset` are gone — snapshots carry complete metadata (source_path, homepage, known_vulnerabilities), and there is no checkout to reset.
 
-Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index.
+Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
 
 ## Key Environment Variables
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -286,6 +286,7 @@ nxv dedupe                                           # Run
 # Publish distribution-ready compressed artifacts + manifest
 nxv publish --output ./publish --url-prefix https://your-server/nxv
 nxv publish --output ./publish --url-prefix https://... --sign --secret-key nxv.key
+nxv publish --output ./publish --url-prefix https://... --artifact-name-prefix run-123-
 
 # Generate a minisign keypair for signing manifests
 nxv keygen --secret-key ./nxv.key --public-key ./nxv.pub
@@ -295,7 +296,7 @@ Every recorded commit is a real, Hydra-built channel commit — `nix shell` comm
 
 Retired commands: `nxv backfill` and `nxv reset` are gone — snapshots carry complete metadata (source_path, homepage, known_vulnerabilities), and there is no checkout to reset.
 
-Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index.
+Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
 
 ## Key Environment Variables
 

--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -191,8 +191,10 @@ jobs:
             --jq '.assets[].name' \
             | grep -Fx "${INDEX_ASSET_PREFIX}bloom.bin"
 
-          # Replace the signature first; the old manifest remains valid until
-          # manifest.json is replaced as the final step.
+          # GitHub release assets cannot replace manifest.json and its signature
+          # atomically. Payload assets are already present, and the restore logic
+          # keeps stable assets from staying missing; clients may see a brief
+          # signature mismatch until manifest.json is replaced as the final step.
           replace_stable_asset publish/manifest.json.minisig manifest.json.minisig
           replace_stable_asset publish/manifest.json manifest.json
 

--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -32,6 +32,7 @@ env:
   # Forks can override INDEX_URL_PREFIX via repository variable
   INDEX_RELEASE_TAG: index-latest
   INDEX_URL_PREFIX: ${{ vars.INDEX_URL_PREFIX || format('https://github.com/{0}/releases/download/index-latest', github.repository) }}
+  INDEX_ASSET_PREFIX: index-${{ github.run_id }}-${{ github.run_attempt }}-
 
 jobs:
   update-index:
@@ -72,11 +73,20 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.local/share/nxv
-          echo "Downloading existing index from ${INDEX_URL_PREFIX}..."
+          echo "Downloading existing manifest from ${INDEX_URL_PREFIX}..."
 
           # Incremental updates REQUIRE an existing index. The initial v4
           # full rebuild is run out-of-band and uploaded manually.
-          curl -sSfL "${INDEX_URL_PREFIX}/index.db.zst" -o ~/.local/share/nxv/index.db.zst
+          manifest_path="$(mktemp)"
+          curl -sSfL "${INDEX_URL_PREFIX}/manifest.json" -o "$manifest_path"
+          index_url="$(jq -r '.full_index.url // empty' "$manifest_path")"
+          if [ -z "$index_url" ]; then
+            echo "::error::Published manifest is missing full_index.url"
+            exit 1
+          fi
+
+          echo "Downloading existing index from ${index_url}..."
+          curl -sSfL "$index_url" -o ~/.local/share/nxv/index.db.zst
           zstd -d -f ~/.local/share/nxv/index.db.zst -o ~/.local/share/nxv/index.db
           rm ~/.local/share/nxv/index.db.zst
           echo "Index ready: $(du -h ~/.local/share/nxv/index.db | cut -f1)"
@@ -121,6 +131,7 @@ jobs:
           ./target/release/nxv publish \
             --output ./publish \
             --url-prefix "${INDEX_URL_PREFIX}" \
+            --artifact-name-prefix "${INDEX_ASSET_PREFIX}" \
             --min-version 4 \
             --sign
 
@@ -146,13 +157,53 @@ jobs:
               --latest=false
           fi
 
-          echo "Uploading index files to release..."
+          replace_stable_asset() {
+            local path="$1"
+            local name="$2"
+            local backup_dir
+            backup_dir="$(mktemp -d)"
+
+            if gh release view "$INDEX_RELEASE_TAG" --json assets --jq '.assets[].name' | grep -Fxq "$name"; then
+              gh release download "$INDEX_RELEASE_TAG" --pattern "$name" --dir "$backup_dir"
+            fi
+
+            if gh release upload "$INDEX_RELEASE_TAG" "${path}#${name}" --clobber; then
+              return 0
+            fi
+
+            echo "::error::Failed to replace ${name}; attempting to restore previous asset"
+            if [ -f "${backup_dir}/${name}" ]; then
+              gh release upload "$INDEX_RELEASE_TAG" "${backup_dir}/${name}#${name}" --clobber || true
+            fi
+            return 1
+          }
+
+          echo "Uploading immutable index files to release..."
           gh release upload "$INDEX_RELEASE_TAG" \
-            publish/index.db.zst \
-            publish/bloom.bin \
-            publish/manifest.json \
-            publish/manifest.json.minisig \
-            --clobber
+            "publish/index.db.zst#${INDEX_ASSET_PREFIX}index.db.zst" \
+            "publish/bloom.bin#${INDEX_ASSET_PREFIX}bloom.bin"
+
+          echo "Verifying immutable assets are present before moving the manifest pointer..."
+          gh release view "$INDEX_RELEASE_TAG" --json assets \
+            --jq '.assets[].name' \
+            | grep -Fx "${INDEX_ASSET_PREFIX}index.db.zst"
+          gh release view "$INDEX_RELEASE_TAG" --json assets \
+            --jq '.assets[].name' \
+            | grep -Fx "${INDEX_ASSET_PREFIX}bloom.bin"
+
+          # Replace the signature first; the old manifest remains valid until
+          # manifest.json is replaced as the final step.
+          replace_stable_asset publish/manifest.json.minisig manifest.json.minisig
+          replace_stable_asset publish/manifest.json manifest.json
+
+          echo "Verifying published manifest points at this run's immutable assets..."
+          published_manifest="$(mktemp)"
+          curl -sSfL "${INDEX_URL_PREFIX}/manifest.json" -o "$published_manifest"
+          jq -e \
+            --arg index_url "${INDEX_URL_PREFIX}/${INDEX_ASSET_PREFIX}index.db.zst" \
+            --arg bloom_url "${INDEX_URL_PREFIX}/${INDEX_ASSET_PREFIX}bloom.bin" \
+            '.full_index.url == $index_url and .bloom_filter.url == $bloom_url' \
+            "$published_manifest" >/dev/null
 
       # AFTER publishing: turn anomalies into a red workflow run so they
       # page the operator. Failed releases stay in the (published) ledger

--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ nxv publish --output ./publish --url-prefix https://your-server.com/nxv
 ```
 
 The `--url-prefix` sets the base URL that will appear in the manifest. This should match where you'll host the files.
+For GitHub Releases or other mutable asset stores, `--artifact-name-prefix` can
+put run-specific payload names in the manifest while keeping the local output
+files unchanged. Upload those payload assets first, then replace `manifest.json`
+last so clients keep using the old index until the new one is fully available.
 
 ### Integrity and Rollback
 
@@ -401,9 +405,14 @@ You can host the published artifacts anywhere that serves static files:
 <summary>GitHub Releases</summary>
 
 ```bash
+RUN_ID="$(date +%Y%m%d%H%M%S)-"
+
 # Generate artifacts
 nxv publish --output ./publish \
-  --url-prefix https://github.com/YOUR_USER/YOUR_REPO/releases/download/index-latest
+  --url-prefix https://github.com/YOUR_USER/YOUR_REPO/releases/download/index-latest \
+  --artifact-name-prefix "$RUN_ID" \
+  --sign \
+  --secret-key ./nxv.key
 
 # Create release and upload
 gh release create index-latest \
@@ -411,7 +420,13 @@ gh release create index-latest \
   --notes "nxv package index" \
   --latest=false
 
-gh release upload index-latest publish/* --clobber
+gh release upload index-latest \
+  "publish/index.db.zst#${RUN_ID}index.db.zst" \
+  "publish/bloom.bin#${RUN_ID}bloom.bin"
+
+# Replace the stable pointer only after the payload assets are present.
+gh release upload index-latest publish/manifest.json.minisig --clobber
+gh release upload index-latest publish/manifest.json --clobber
 ```
 
 </details>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -527,6 +527,14 @@ pub struct PublishArgs {
     #[arg(long)]
     pub url_prefix: Option<String>,
 
+    /// Prefix to add to index and bloom artifact names in the manifest.
+    ///
+    /// This is useful for GitHub release publishing: payload artifacts can be
+    /// uploaded under immutable run-specific names while manifest.json remains
+    /// the stable pointer clients fetch.
+    #[arg(long)]
+    pub artifact_name_prefix: Option<String>,
+
     /// Sign the manifest with a minisign secret key.
     #[arg(long)]
     pub sign: bool,

--- a/src/index/publisher.rs
+++ b/src/index/publisher.rs
@@ -25,6 +25,22 @@ pub const BLOOM_FILTER_NAME: &str = "bloom.bin";
 pub const MANIFEST_NAME: &str = "manifest.json";
 pub const MANIFEST_SIG_NAME: &str = "manifest.json.minisig";
 
+fn published_artifact_name(base_name: &str, artifact_name_prefix: Option<&str>) -> String {
+    format!("{}{}", artifact_name_prefix.unwrap_or_default(), base_name)
+}
+
+fn published_artifact_url(
+    base_name: &str,
+    url_prefix: Option<&str>,
+    artifact_name_prefix: Option<&str>,
+) -> String {
+    let name = published_artifact_name(base_name, artifact_name_prefix);
+    match url_prefix {
+        Some(prefix) => format!("{}/{}", prefix.trim_end_matches('/'), name),
+        None => name,
+    }
+}
+
 /// Replace the untrusted comment line in a minisign key string.
 ///
 /// Minisign keys have the format:
@@ -383,6 +399,7 @@ pub fn generate_full_index<P: AsRef<Path>, Q: AsRef<Path>>(
     db_path: P,
     output_dir: Q,
     url_prefix: Option<&str>,
+    artifact_name_prefix: Option<&str>,
     show_progress: bool,
     min_version: Option<u32>,
 ) -> Result<(IndexFile, String, u32)> {
@@ -457,13 +474,8 @@ pub fn generate_full_index<P: AsRef<Path>, Q: AsRef<Path>>(
         );
     }
 
-    let url = match url_prefix {
-        Some(prefix) => format!("{}/{}", prefix.trim_end_matches('/'), INDEX_DB_NAME),
-        None => INDEX_DB_NAME.to_string(),
-    };
-
     let index_file = IndexFile {
-        url,
+        url: published_artifact_url(INDEX_DB_NAME, url_prefix, artifact_name_prefix),
         size_bytes: size,
         sha256,
     };
@@ -511,6 +523,7 @@ pub fn generate_bloom_filter<P: AsRef<Path>, Q: AsRef<Path>>(
     db_path: P,
     output_dir: Q,
     url_prefix: Option<&str>,
+    artifact_name_prefix: Option<&str>,
     show_progress: bool,
 ) -> Result<IndexFile> {
     let db_path = db_path.as_ref();
@@ -568,13 +581,8 @@ pub fn generate_bloom_filter<P: AsRef<Path>, Q: AsRef<Path>>(
         eprintln!("  Bloom filter: {}", format_bytes(size));
     }
 
-    let url = match url_prefix {
-        Some(prefix) => format!("{}/{}", prefix.trim_end_matches('/'), BLOOM_FILTER_NAME),
-        None => BLOOM_FILTER_NAME.to_string(),
-    };
-
     Ok(IndexFile {
-        url,
+        url: published_artifact_url(BLOOM_FILTER_NAME, url_prefix, artifact_name_prefix),
         size_bytes: size,
         sha256,
     })
@@ -593,6 +601,7 @@ pub fn publish_index<P: AsRef<Path>, Q: AsRef<Path>>(
     db_path: P,
     output_dir: Q,
     url_prefix: Option<&str>,
+    artifact_name_prefix: Option<&str>,
     show_progress: bool,
     secret_key: Option<&str>,
     min_version: Option<u32>,
@@ -605,14 +614,26 @@ pub fn publish_index<P: AsRef<Path>, Q: AsRef<Path>>(
     if show_progress {
         eprintln!("Generating compressed index...");
     }
-    let (full_index, last_commit, resolved_min_version) =
-        generate_full_index(db_path, output_dir, url_prefix, show_progress, min_version)?;
+    let (full_index, last_commit, resolved_min_version) = generate_full_index(
+        db_path,
+        output_dir,
+        url_prefix,
+        artifact_name_prefix,
+        show_progress,
+        min_version,
+    )?;
 
     if show_progress {
         eprintln!();
         eprintln!("Generating bloom filter...");
     }
-    let bloom_filter = generate_bloom_filter(db_path, output_dir, url_prefix, show_progress)?;
+    let bloom_filter = generate_bloom_filter(
+        db_path,
+        output_dir,
+        url_prefix,
+        artifact_name_prefix,
+        show_progress,
+    )?;
 
     if show_progress {
         eprintln!();
@@ -721,7 +742,7 @@ mod tests {
         create_test_db(&db_path);
 
         let (index_file, last_commit, resolved_min) =
-            generate_full_index(&db_path, &output_dir, None, false, None).unwrap();
+            generate_full_index(&db_path, &output_dir, None, None, false, None).unwrap();
 
         assert!(!index_file.sha256.is_empty());
         assert!(index_file.size_bytes > 0);
@@ -748,9 +769,39 @@ mod tests {
 
         let url_prefix = "https://example.com/releases";
         let (index_file, _, _) =
-            generate_full_index(&db_path, &output_dir, Some(url_prefix), false, None).unwrap();
+            generate_full_index(&db_path, &output_dir, Some(url_prefix), None, false, None)
+                .unwrap();
 
         assert_eq!(index_file.url, format!("{}/{}", url_prefix, INDEX_DB_NAME));
+    }
+
+    #[test]
+    fn test_generate_full_index_with_artifact_name_prefix() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let output_dir = dir.path().join("output");
+
+        create_test_db(&db_path);
+
+        let url_prefix = "https://example.com/releases";
+        let (index_file, _, _) = generate_full_index(
+            &db_path,
+            &output_dir,
+            Some(url_prefix),
+            Some("run-123-"),
+            false,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            index_file.url,
+            format!("{}/run-123-{}", url_prefix, INDEX_DB_NAME)
+        );
+        assert!(
+            output_dir.join(INDEX_DB_NAME).exists(),
+            "artifact prefix should affect manifest URLs, not local output names"
+        );
     }
 
     #[test]
@@ -765,7 +816,7 @@ mod tests {
 
         // min_version omitted: must default to the schema version and be
         // written into the published DB (the pre-download gate depends on it).
-        generate_full_index(&db_path, &output_dir, None, false, None).unwrap();
+        generate_full_index(&db_path, &output_dir, None, None, false, None).unwrap();
 
         let compressed_path = output_dir.join(INDEX_DB_NAME);
         let decompressed_path = dir.path().join("decompressed.db");
@@ -786,7 +837,8 @@ mod tests {
 
         // Publishing a schema-4 index readable-gated below 4 would let old
         // clients overwrite their working index with one they can't open.
-        let err = generate_full_index(&db_path, &output_dir, None, false, Some(3)).unwrap_err();
+        let err =
+            generate_full_index(&db_path, &output_dir, None, None, false, Some(3)).unwrap_err();
         assert!(err.to_string().contains("refusing to publish"));
     }
 
@@ -798,7 +850,7 @@ mod tests {
 
         create_test_db(&db_path);
 
-        let bloom_file = generate_bloom_filter(&db_path, &output_dir, None, false).unwrap();
+        let bloom_file = generate_bloom_filter(&db_path, &output_dir, None, None, false).unwrap();
 
         assert_eq!(bloom_file.url, BLOOM_FILTER_NAME);
         assert!(!bloom_file.sha256.is_empty());
@@ -1041,7 +1093,7 @@ mod tests {
         create_test_db(&db_path);
 
         // Publish without signing
-        publish_index(&db_path, &output_dir, None, false, None, None).unwrap();
+        publish_index(&db_path, &output_dir, None, None, false, None, None).unwrap();
 
         // Verify all artifacts except signature
         assert!(output_dir.join(INDEX_DB_NAME).exists());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1389,6 +1389,7 @@ fn cmd_publish(cli: &Cli, args: &cli::PublishArgs) -> Result<()> {
         &cli.db_path,
         &output,
         args.url_prefix.as_deref(),
+        args.artifact_name_prefix.as_deref(),
         !cli.quiet,
         args.secret_key.as_deref(),
         args.min_version,

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -286,6 +286,7 @@ nxv dedupe                                           # Run
 # Publish distribution-ready compressed artifacts + manifest
 nxv publish --output ./publish --url-prefix https://your-server/nxv
 nxv publish --output ./publish --url-prefix https://... --sign --secret-key nxv.key
+nxv publish --output ./publish --url-prefix https://... --artifact-name-prefix run-123-
 
 # Generate a minisign keypair for signing manifests
 nxv keygen --secret-key ./nxv.key --public-key ./nxv.pub
@@ -295,7 +296,7 @@ Every recorded commit is a real, Hydra-built channel commit — `nix shell` comm
 
 Retired commands: `nxv backfill` and `nxv reset` are gone — snapshots carry complete metadata (source_path, homepage, known_vulnerabilities), and there is no checkout to reset.
 
-Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index.
+Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
 
 ## Key Environment Variables
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3157,7 +3157,15 @@ fn test_publish_with_signing() {
 
 #[test]
 fn test_publish_index_workflow_keeps_manifest_as_stable_pointer() {
-    let workflow = include_str!("../.github/workflows/publish-index.yml");
+    let workflow_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(".github/workflows/publish-index.yml");
+    let Ok(workflow) = std::fs::read_to_string(&workflow_path) else {
+        eprintln!(
+            "skipping workflow assertion because {} is absent from this source tree",
+            workflow_path.display()
+        );
+        return;
+    };
 
     assert!(
         workflow.contains("curl -sSfL \"${INDEX_URL_PREFIX}/manifest.json\""),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3181,6 +3181,11 @@ fn test_publish_index_workflow_keeps_manifest_as_stable_pointer() {
         "manifest.json should be the final stable pointer replacement"
     );
     assert!(
+        workflow.contains("clients may see a brief")
+            && workflow.contains("signature mismatch until manifest.json is replaced"),
+        "workflow should document the non-atomic manifest/signature replacement window"
+    );
+    assert!(
         workflow.find("replace_stable_asset publish/manifest.json.minisig manifest.json.minisig")
             < workflow.find("replace_stable_asset publish/manifest.json manifest.json"),
         "manifest.json must be replaced after its signature"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3110,6 +3110,10 @@ fn test_publish_with_signing() {
             "publish",
             "--output",
             output_dir.to_str().unwrap(),
+            "--url-prefix",
+            "https://example.com/releases",
+            "--artifact-name-prefix",
+            "run-123-",
             "--sign",
             "--secret-key",
             sk_path.to_str().unwrap(),
@@ -3137,6 +3141,49 @@ fn test_publish_with_signing() {
     assert!(
         sig_content.contains("trusted comment:"),
         "Signature should have trusted comment"
+    );
+
+    let manifest_content = std::fs::read_to_string(output_dir.join("manifest.json")).unwrap();
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_content).unwrap();
+    assert_eq!(
+        manifest["full_index"]["url"],
+        "https://example.com/releases/run-123-index.db.zst"
+    );
+    assert_eq!(
+        manifest["bloom_filter"]["url"],
+        "https://example.com/releases/run-123-bloom.bin"
+    );
+}
+
+#[test]
+fn test_publish_index_workflow_keeps_manifest_as_stable_pointer() {
+    let workflow = include_str!("../.github/workflows/publish-index.yml");
+
+    assert!(
+        workflow.contains("curl -sSfL \"${INDEX_URL_PREFIX}/manifest.json\""),
+        "publish-index should discover the current index from the manifest"
+    );
+    assert!(
+        workflow.contains("--artifact-name-prefix \"${INDEX_ASSET_PREFIX}\""),
+        "published manifests should point at run-scoped immutable assets"
+    );
+    assert!(
+        workflow.contains("\"publish/index.db.zst#${INDEX_ASSET_PREFIX}index.db.zst\""),
+        "index payload should upload under the run-scoped asset name"
+    );
+    assert!(
+        workflow
+            .contains("replace_stable_asset publish/manifest.json.minisig manifest.json.minisig"),
+        "signature should be replaced before manifest.json"
+    );
+    assert!(
+        workflow.contains("replace_stable_asset publish/manifest.json manifest.json"),
+        "manifest.json should be the final stable pointer replacement"
+    );
+    assert!(
+        workflow.find("replace_stable_asset publish/manifest.json.minisig manifest.json.minisig")
+            < workflow.find("replace_stable_asset publish/manifest.json manifest.json"),
+        "manifest.json must be replaced after its signature"
     );
 }
 


### PR DESCRIPTION
## Summary

- add `nxv publish --artifact-name-prefix` so generated manifests can point at immutable, run-scoped index and bloom assets while local output names stay stable
- update `publish-index.yml` to read the existing index URL from the current manifest, upload immutable payload assets first, and replace the stable `manifest.json` pointer last
- document the safer GitHub Releases flow and regenerate the checked-in nxv skill copies

## Root Cause

`nxv update` failed because the default manifest URL returned `HTTP 404 Not Found`. The `index-latest` release had been left with only `bloom.bin` and `manifest.json.minisig`; both `manifest.json` and `index.db.zst` were missing.

The failing June 12 publish run generated all artifacts, then used one multi-file `gh release upload ... --clobber`. GitHub returned an HTTP 502 during the clobber/upload sequence, leaving the release partially updated and deleting the stable assets clients need. Later scheduled runs then failed earlier because they could no longer download the existing `index.db.zst`.

## Operational Repair Already Done

I restored the live `index-latest` release from the retained `nxv-index` workflow artifact from run `27390580479`, uploading only the missing `index.db.zst` and `manifest.json`. The default manifest URL now returns 200 and an isolated temp-path update succeeds.

## Validation

- `env -u NO_COLOR nix develop -c cargo test --features indexer artifact_name_prefix`
- `env -u NO_COLOR nix develop -c cargo test --features indexer test_publish_index_workflow_keeps_manifest_as_stable_pointer`
- `env -u NO_COLOR nix develop -c cargo test --features indexer test_publish_with_signing`
- `env -u NO_COLOR nix develop -c cargo test --features indexer test_checked_in_skill_copies_match_template`
- `env -u NO_COLOR nix develop -c cargo clippy --features indexer -- -D warnings`
- `env -u NO_COLOR nix develop -c cargo test`
- `env -u NO_COLOR NXV_DB_PATH=/tmp/nxv-update-proof/index.db target/debug/nxv update --no-self-update`
