### PR TITLE
fix(index): recover scheduled publisher

### DIFF
--- a/.github/workflows/publish-index.yml
+++ b/.github/workflows/publish-index.yml
@@ -179,9 +179,12 @@ jobs:
           }
 
           echo "Uploading immutable index files to release..."
+          immutable_upload_dir="$(mktemp -d)"
+          cp publish/index.db.zst "${immutable_upload_dir}/${INDEX_ASSET_PREFIX}index.db.zst"
+          cp publish/bloom.bin "${immutable_upload_dir}/${INDEX_ASSET_PREFIX}bloom.bin"
           gh release upload "$INDEX_RELEASE_TAG" \
-            "publish/index.db.zst#${INDEX_ASSET_PREFIX}index.db.zst" \
-            "publish/bloom.bin#${INDEX_ASSET_PREFIX}bloom.bin"
+            "${immutable_upload_dir}/${INDEX_ASSET_PREFIX}index.db.zst" \
+            "${immutable_upload_dir}/${INDEX_ASSET_PREFIX}bloom.bin"
 
           echo "Verifying immutable assets are present before moving the manifest pointer..."
           gh release view "$INDEX_RELEASE_TAG" --json assets \

--- a/README.md
+++ b/README.md
@@ -420,9 +420,13 @@ gh release create index-latest \
   --notes "nxv package index" \
   --latest=false
 
+upload_dir="$(mktemp -d)"
+cp publish/index.db.zst "${upload_dir}/${RUN_ID}index.db.zst"
+cp publish/bloom.bin "${upload_dir}/${RUN_ID}bloom.bin"
+
 gh release upload index-latest \
-  "publish/index.db.zst#${RUN_ID}index.db.zst" \
-  "publish/bloom.bin#${RUN_ID}bloom.bin"
+  "${upload_dir}/${RUN_ID}index.db.zst" \
+  "${upload_dir}/${RUN_ID}bloom.bin"
 
 # Replace the stable pointer only after the payload assets are present.
 gh release upload index-latest publish/manifest.json.minisig --clobber

--- a/src/db/releases.rs
+++ b/src/db/releases.rs
@@ -222,6 +222,16 @@ impl Database {
         Ok(())
     }
 
+    /// Mark a release as terminally skipped without consuming retry attempts.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn mark_release_skipped(&self, id: i64, reason: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE releases SET status = 'skipped', error = ? WHERE id = ?",
+            rusqlite::params![reason, id],
+        )?;
+        Ok(())
+    }
+
     /// Atomically write a flush group: a batch of observations plus the
     /// `ingested` status for the releases they came from. Either everything
     /// commits or nothing does — a release can never be `ingested` without

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -55,6 +55,22 @@ const HEAD_EVAL_LAG_HOURS: i64 = 24;
 /// Environment override for the release bucket URL (tests, mirrors).
 const RELEASES_URL_ENV: &str = "NXV_RELEASES_URL";
 
+/// Upstream channel snapshots known to be malformed. They are kept out of
+/// ingestion permanently so data-quality gates can stay strict for every
+/// newly discovered anomaly without making the scheduled publisher red forever.
+const KNOWN_BAD_RELEASES: &[&str] = &[
+    "nixos-24.11pre657868.4a8e77c70685",
+    "nixpkgs-24.11pre657856.733453ac54a4",
+];
+
+fn known_bad_release_reason(release_name: &str) -> Option<&'static str> {
+    if KNOWN_BAD_RELEASES.contains(&release_name) {
+        Some("known malformed upstream snapshot: missing python*Packages.requests sentinel")
+    } else {
+        None
+    }
+}
+
 /// Entry point for `nxv index`.
 pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
     let mut db = Database::open(&cli.db_path)?;
@@ -142,8 +158,22 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         worklist.truncate(max);
     }
 
+    let mut skipped_known_bad = 0usize;
+    let mut filtered_worklist = Vec::with_capacity(worklist.len());
+    for release in worklist {
+        if let Some(reason) = known_bad_release_reason(&release.release_name) {
+            progress(&format!("  skipping {}: {reason}", release.release_name));
+            db.mark_release_skipped(release.id, reason)?;
+            skipped_known_bad += 1;
+        } else {
+            filtered_worklist.push(release);
+        }
+    }
+    let worklist = filtered_worklist;
+
     let mut report = RunReport {
         planned: worklist.len(),
+        skipped: skipped_known_bad,
         ..Default::default()
     };
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2897,6 +2897,77 @@ fn test_index_truncated_snapshot_fails_release_without_polluting() {
     assert!(error.is_some());
 }
 
+/// Known malformed upstream snapshots are quarantined as skipped so scheduled
+/// publishing does not stay red forever, while unknown bad snapshots still hit
+/// the normal gate-failure path.
+#[test]
+#[cfg(feature = "indexer")]
+fn test_index_known_bad_snapshot_is_skipped_without_fetching_packages() {
+    let mut server = mockito::Server::new();
+    let release_name = "nixos-24.11pre657868.4a8e77c70685";
+    let short = "4a8e77c70685";
+    let commit = format!("{short}{}", "0".repeat(28));
+
+    let listing = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult>
+  <IsTruncated>false</IsTruncated>
+  <CommonPrefixes><Prefix>nixos/unstable-small/{release_name}/</Prefix></CommonPrefixes>
+</ListBucketResult>"#,
+    );
+    let _m1 = server
+        .mock("GET", "/")
+        .match_query(mockito::Matcher::Regex(
+            "prefix=nixos%2Funstable-small".to_string(),
+        ))
+        .with_body(listing)
+        .create();
+    let recent = (chrono::Utc::now() - chrono::Duration::days(1))
+        .format("%a, %d %b %Y %H:%M:%S GMT")
+        .to_string();
+    let _m2 = server
+        .mock(
+            "GET",
+            format!("/nixos/unstable-small/{release_name}/git-revision").as_str(),
+        )
+        .with_header("Last-Modified", recent.as_str())
+        .with_body(&commit)
+        .create();
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("index.db");
+
+    nxv()
+        .env("NXV_RELEASES_URL", server.url())
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "index",
+            "--channel",
+            "nixos-unstable-small",
+        ])
+        .timeout(std::time::Duration::from_secs(60))
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!(
+            "skipping {release_name}: known malformed upstream snapshot"
+        )))
+        .stderr(predicate::str::contains("status: healthy"));
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let (status, error): (String, Option<String>) = conn
+        .query_row("SELECT status, error FROM releases", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(status, "skipped");
+    assert!(
+        error
+            .as_deref()
+            .is_some_and(|msg| msg.contains("known malformed upstream snapshot"))
+    );
+}
+
 /// --strict turns failed releases into a non-zero exit.
 #[test]
 #[cfg(feature = "indexer")]
@@ -3176,8 +3247,21 @@ fn test_publish_index_workflow_keeps_manifest_as_stable_pointer() {
         "published manifests should point at run-scoped immutable assets"
     );
     assert!(
-        workflow.contains("\"publish/index.db.zst#${INDEX_ASSET_PREFIX}index.db.zst\""),
-        "index payload should upload under the run-scoped asset name"
+        workflow.contains(
+            "cp publish/index.db.zst \"${immutable_upload_dir}/${INDEX_ASSET_PREFIX}index.db.zst\""
+        ) && workflow.contains(
+            "cp publish/bloom.bin \"${immutable_upload_dir}/${INDEX_ASSET_PREFIX}bloom.bin\""
+        ),
+        "payload basenames should be staged with run-scoped asset names before upload"
+    );
+    assert!(
+        workflow.contains("\"${immutable_upload_dir}/${INDEX_ASSET_PREFIX}index.db.zst\"")
+            && workflow.contains("\"${immutable_upload_dir}/${INDEX_ASSET_PREFIX}bloom.bin\""),
+        "index payload should upload from paths whose basenames are the run-scoped asset names"
+    );
+    assert!(
+        !workflow.contains("\"publish/index.db.zst#${INDEX_ASSET_PREFIX}index.db.zst\""),
+        "gh release upload treats # suffixes as labels, not asset filenames"
     );
     assert!(
         workflow


### PR DESCRIPTION
## Summary
- stage run-scoped index payload copies before `gh release upload` so GitHub uses the intended immutable asset filenames
- quarantine two known malformed upstream 24.11pre snapshots as skipped instead of retrying them forever
- update the GitHub Releases hosting example and regression tests

## Root cause
The scheduled Publish Index run was red for two reasons: `gh release upload path#name` treats `#name` as a label rather than an asset filename, so the workflow still tried to upload `index.db.zst` and `bloom.bin` and collided with the stable assets; after that, the post-publish health alert stayed red because two exact upstream snapshots are malformed and keep failing the sentinel gate.

## Verification
- `env -u NO_COLOR nix develop -c cargo test --features indexer`
- `env -u NO_COLOR nix develop -c cargo clippy --features indexer -- -D warnings`