### PR TITLE
perf(db): optimize schema v4 local queries

### DIFF
--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -1,26 +1,43 @@
-//! Benchmarks for search query performance.
+//! Benchmarks for v4 search/query performance.
+//!
+//! The production v4 index is much larger than the old git-walked index:
+//! it stores one row per `(attribute_path, version)` and includes nested
+//! package sets. These benchmarks model the hot paths that regressed with that
+//! cardinality: exact package lookup, package+version prefix search,
+//! completion, stats, and FTS.
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rusqlite::Connection;
 use std::hint::black_box;
 use tempfile::tempdir;
 
-/// Create a test database with sample data.
-fn create_benchmark_db(num_packages: usize) -> (tempfile::TempDir, std::path::PathBuf) {
+fn prefix_upper_bound(prefix: &str) -> String {
+    let mut chars: Vec<char> = prefix.chars().collect();
+    let last = chars.pop().expect("non-empty benchmark prefix");
+    chars.push(char::from_u32(last as u32 + 1).expect("benchmark prefix upper bound"));
+    chars.into_iter().collect()
+}
+
+/// Create a v4-shaped benchmark database with many nested attrs and versions.
+fn create_benchmark_db(
+    num_attrs: usize,
+    versions_per_attr: usize,
+) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("bench.db");
 
-    let conn = Connection::open(&db_path).unwrap();
-
-    // Create schema
+    let mut conn = Connection::open(&db_path).unwrap();
     conn.execute_batch(
         r#"
-        CREATE TABLE IF NOT EXISTS meta (
+        PRAGMA journal_mode = WAL;
+        PRAGMA synchronous = NORMAL;
+
+        CREATE TABLE meta (
             key TEXT PRIMARY KEY,
             value TEXT NOT NULL
         );
 
-        CREATE TABLE IF NOT EXISTS package_versions (
+        CREATE TABLE package_versions (
             id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
             version TEXT NOT NULL,
@@ -34,19 +51,31 @@ fn create_benchmark_db(num_packages: usize) -> (tempfile::TempDir, std::path::Pa
             homepage TEXT,
             maintainers TEXT,
             platforms TEXT,
-            UNIQUE(attribute_path, version, first_commit_hash)
+            source_path TEXT,
+            known_vulnerabilities TEXT,
+            UNIQUE(attribute_path, version),
+            CHECK(first_commit_date <= last_commit_date)
         );
 
-        CREATE INDEX IF NOT EXISTS idx_packages_name ON package_versions(name);
-        CREATE INDEX IF NOT EXISTS idx_packages_name_version ON package_versions(name, version, first_commit_date);
-        CREATE INDEX IF NOT EXISTS idx_packages_attr ON package_versions(attribute_path);
-        CREATE INDEX IF NOT EXISTS idx_packages_first_date ON package_versions(first_commit_date DESC);
-        CREATE INDEX IF NOT EXISTS idx_packages_last_date ON package_versions(last_commit_date DESC);
+        CREATE TABLE package_attrs (
+            attribute_path TEXT PRIMARY KEY
+        ) WITHOUT ROWID;
 
-        CREATE VIRTUAL TABLE IF NOT EXISTS package_versions_fts
+        CREATE INDEX idx_packages_name ON package_versions(name);
+        CREATE INDEX idx_packages_name_version ON package_versions(name, version, first_commit_date);
+        CREATE INDEX idx_packages_attr ON package_versions(attribute_path);
+        CREATE INDEX idx_packages_first_date ON package_versions(first_commit_date DESC);
+        CREATE INDEX idx_packages_last_date ON package_versions(last_commit_date DESC);
+        CREATE INDEX idx_version_vulnerabilities ON package_versions(version)
+            WHERE known_vulnerabilities IS NOT NULL
+              AND known_vulnerabilities != ''
+              AND known_vulnerabilities != '[]'
+              AND known_vulnerabilities != 'null';
+
+        CREATE VIRTUAL TABLE package_versions_fts
         USING fts5(name, description, content=package_versions, content_rowid=id);
 
-        CREATE TRIGGER IF NOT EXISTS package_versions_ai AFTER INSERT ON package_versions BEGIN
+        CREATE TRIGGER package_versions_ai AFTER INSERT ON package_versions BEGIN
             INSERT INTO package_versions_fts(rowid, name, description)
             VALUES (new.id, new.name, new.description);
         END;
@@ -54,76 +83,282 @@ fn create_benchmark_db(num_packages: usize) -> (tempfile::TempDir, std::path::Pa
     )
     .unwrap();
 
-    // Insert test data
-    let tx = conn.unchecked_transaction().unwrap();
+    let tx = conn.transaction().unwrap();
     {
-        let mut stmt = conn.prepare(
-            r#"
+        let mut stmt = tx
+            .prepare(
+                r#"
             INSERT INTO package_versions
-                (name, version, first_commit_hash, first_commit_date, last_commit_hash, last_commit_date,
-                 attribute_path, description, license, homepage)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path,
+                 description, license, homepage, maintainers, platforms, source_path,
+                 known_vulnerabilities)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
-        ).unwrap();
-
-        for i in 0..num_packages {
-            let name = format!("package{}", i);
-            let version = format!("1.{}.0", i % 100);
-            let attr_path = format!("packages.{}", name);
-            let description = format!("Description for package {} with some searchable text", i);
-
-            stmt.execute(rusqlite::params![
-                name,
-                version,
-                format!("abc{:040}", i),
-                1700000000 + i as i64,
-                format!("def{:040}", i),
-                1700100000 + i as i64,
-                attr_path,
-                description,
-                r#"["MIT"]"#,
-                "https://example.com"
-            ])
+            )
             .unwrap();
+
+        for attr_idx in 0..num_attrs {
+            let attr_path = if attr_idx % 4 == 0 {
+                format!("python311Packages.pkg{attr_idx}")
+            } else if attr_idx % 4 == 1 {
+                format!("python312Packages.pkg{attr_idx}")
+            } else if attr_idx % 4 == 2 {
+                format!("haskellPackages.pkg{attr_idx}")
+            } else {
+                format!("package{attr_idx}")
+            };
+            let name = attr_path
+                .rsplit('.')
+                .next()
+                .unwrap_or(&attr_path)
+                .to_string();
+
+            for version_idx in 0..versions_per_attr {
+                let version = if attr_path.starts_with("python311") {
+                    format!("3.11.{version_idx}")
+                } else {
+                    format!("1.{version_idx}.0")
+                };
+                let first = 1_700_000_000 + attr_idx as i64 + (version_idx as i64 * 10_000);
+                stmt.execute(rusqlite::params![
+                    name,
+                    version,
+                    format!("{:040x}", attr_idx * 1000 + version_idx),
+                    first,
+                    format!("{:040x}", attr_idx * 1000 + version_idx + 1),
+                    first + 3600,
+                    attr_path,
+                    format!("Python benchmark package {attr_idx} with searchable text"),
+                    r#"["MIT"]"#,
+                    "https://example.com",
+                    r#"["maintainer"]"#,
+                    r#"["x86_64-linux"]"#,
+                    format!("pkgs/by-name/{attr_idx}"),
+                    Option::<String>::None,
+                ])
+                .unwrap();
+            }
         }
     }
+    tx.execute(
+        "INSERT INTO package_attrs(attribute_path) SELECT DISTINCT attribute_path FROM package_versions",
+        [],
+    )
+    .unwrap();
+    tx.execute(
+        "INSERT INTO meta(key, value) VALUES
+         ('stats_total_ranges', ?1),
+         ('stats_unique_names', ?2),
+         ('stats_unique_versions', ?3),
+         ('stats_oldest_commit_date', '1700000000'),
+         ('stats_newest_commit_date', '1800000000')",
+        rusqlite::params![
+            (num_attrs * versions_per_attr).to_string(),
+            num_attrs.to_string(),
+            versions_per_attr.to_string(),
+        ],
+    )
+    .unwrap();
     tx.commit().unwrap();
 
     (dir, db_path)
 }
 
-fn bench_search_by_name(c: &mut Criterion) {
-    let mut group = c.benchmark_group("search_by_name");
+fn bench_exact_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("v4_exact_lookup");
 
-    for size in [1000, 10000, 50000].iter() {
-        let (_dir, db_path) = create_benchmark_db(*size);
+    for size in [10_000, 50_000].iter() {
+        let (_dir, db_path) = create_benchmark_db(*size, 8);
         let conn = Connection::open(&db_path).unwrap();
+        let depth = "(LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', '')))";
 
-        group.bench_with_input(BenchmarkId::new("prefix", size), size, |b, _| {
+        group.bench_with_input(
+            BenchmarkId::new("old_prefix_then_filter", size),
+            size,
+            |b, _| {
+                b.iter(|| {
+                    let sql = format!(
+                        "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' \
+                     ORDER BY {depth} ASC, last_commit_date DESC LIMIT 5000"
+                    );
+                    let rows: Vec<String> = conn
+                        .prepare_cached(&sql)
+                        .unwrap()
+                        .query_map(["python311Packages.pkg100%"], |row| {
+                            row.get("attribute_path")
+                        })
+                        .unwrap()
+                        .filter_map(Result::ok)
+                        .filter(|attr| attr == "python311Packages.pkg100")
+                        .collect();
+                    black_box(rows)
+                });
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("exact_attr", size), size, |b, _| {
             b.iter(|| {
-                let mut stmt = conn.prepare_cached(
-                    "SELECT * FROM package_versions WHERE name LIKE ? || '%' ORDER BY last_commit_date DESC LIMIT 50"
-                ).unwrap();
-                let results: Vec<String> = stmt
-                    .query_map(["package1"], |row| row.get(1))
+                let rows: Vec<String> = conn
+                    .prepare_cached(
+                        "SELECT * FROM package_versions WHERE attribute_path = ? ORDER BY last_commit_date DESC",
+                    )
                     .unwrap()
-                    .filter_map(|r| r.ok())
+                    .query_map(["python311Packages.pkg100"], |row| row.get("attribute_path"))
+                    .unwrap()
+                    .filter_map(Result::ok)
                     .collect();
-                black_box(results)
+                black_box(rows)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_prefix_version_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("v4_prefix_version_search");
+
+    for size in [10_000, 50_000].iter() {
+        let (_dir, db_path) = create_benchmark_db(*size, 8);
+        let conn = Connection::open(&db_path).unwrap();
+        let depth = "(LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', '')))";
+        let upper = prefix_upper_bound("python311");
+
+        group.bench_with_input(BenchmarkId::new("like_prefix", size), size, |b, _| {
+            b.iter(|| {
+                let sql = format!(
+                    "SELECT * FROM package_versions \
+                     WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
+                     ORDER BY {depth} ASC, first_commit_date DESC LIMIT 5000"
+                );
+                let rows: Vec<String> = conn
+                    .prepare_cached(&sql)
+                    .unwrap()
+                    .query_map(["python311%", "3.11%"], |row| row.get("attribute_path"))
+                    .unwrap()
+                    .filter_map(Result::ok)
+                    .collect();
+                black_box(rows)
             });
         });
 
-        group.bench_with_input(BenchmarkId::new("exact", size), size, |b, _| {
+        group.bench_with_input(BenchmarkId::new("range_prefix", size), size, |b, _| {
             b.iter(|| {
-                let mut stmt = conn.prepare_cached(
-                    "SELECT * FROM package_versions WHERE name = ? ORDER BY last_commit_date DESC LIMIT 50"
-                ).unwrap();
-                let results: Vec<String> = stmt
-                    .query_map(["package100"], |row| row.get(1))
+                let sql = format!(
+                    "SELECT * FROM package_versions \
+                     WHERE attribute_path >= ? AND attribute_path < ? AND version LIKE ? ESCAPE '\\' \
+                     ORDER BY {depth} ASC, first_commit_date DESC LIMIT 5000"
+                );
+                let rows: Vec<String> = conn
+                    .prepare_cached(&sql)
                     .unwrap()
-                    .filter_map(|r| r.ok())
+                    .query_map(rusqlite::params!["python311", upper, "3.11%"], |row| {
+                        row.get("attribute_path")
+                    })
+                    .unwrap()
+                    .filter_map(Result::ok)
                     .collect();
-                black_box(results)
+                black_box(rows)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_completion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("v4_completion");
+
+    for size in [10_000, 50_000].iter() {
+        let (_dir, db_path) = create_benchmark_db(*size, 8);
+        let conn = Connection::open(&db_path).unwrap();
+        let upper = prefix_upper_bound("python");
+
+        group.bench_with_input(
+            BenchmarkId::new("distinct_package_versions", size),
+            size,
+            |b, _| {
+                b.iter(|| {
+                    let rows: Vec<String> = conn
+                        .prepare_cached(
+                            "SELECT DISTINCT attribute_path FROM package_versions \
+                         WHERE attribute_path >= ? AND attribute_path < ? \
+                         ORDER BY attribute_path LIMIT 100",
+                        )
+                        .unwrap()
+                        .query_map(rusqlite::params!["python", upper], |row| row.get(0))
+                        .unwrap()
+                        .filter_map(Result::ok)
+                        .collect();
+                    black_box(rows)
+                });
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("package_attrs", size), size, |b, _| {
+            b.iter(|| {
+                let rows: Vec<String> = conn
+                    .prepare_cached(
+                        "SELECT attribute_path FROM package_attrs \
+                         WHERE attribute_path >= ? AND attribute_path < ? \
+                         ORDER BY attribute_path LIMIT 100",
+                    )
+                    .unwrap()
+                    .query_map(rusqlite::params!["python", upper], |row| row.get(0))
+                    .unwrap()
+                    .filter_map(Result::ok)
+                    .collect();
+                black_box(rows)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_stats(c: &mut Criterion) {
+    let mut group = c.benchmark_group("v4_stats");
+
+    for size in [10_000, 50_000].iter() {
+        let (_dir, db_path) = create_benchmark_db(*size, 8);
+        let conn = Connection::open(&db_path).unwrap();
+
+        group.bench_with_input(BenchmarkId::new("live_scans", size), size, |b, _| {
+            b.iter(|| {
+                let row = conn
+                    .prepare_cached(
+                        "SELECT
+                         (SELECT COUNT(*) FROM package_versions),
+                         (SELECT COUNT(DISTINCT name) FROM package_versions),
+                         (SELECT COUNT(DISTINCT version) FROM package_versions),
+                         (SELECT MIN(first_commit_date) FROM package_versions),
+                         (SELECT MAX(last_commit_date) FROM package_versions)",
+                    )
+                    .unwrap()
+                    .query_row([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))
+                    .unwrap();
+                black_box(row)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("meta_cache", size), size, |b, _| {
+            b.iter(|| {
+                let row = conn
+                    .prepare_cached(
+                        "SELECT
+                         (SELECT value FROM meta WHERE key = 'stats_total_ranges'),
+                         (SELECT value FROM meta WHERE key = 'stats_unique_names'),
+                         (SELECT value FROM meta WHERE key = 'stats_unique_versions'),
+                         (SELECT value FROM meta WHERE key = 'stats_oldest_commit_date'),
+                         (SELECT value FROM meta WHERE key = 'stats_newest_commit_date')",
+                    )
+                    .unwrap()
+                    .query_row([], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    })
+                    .unwrap();
+                black_box(row)
             });
         });
     }
@@ -132,52 +367,30 @@ fn bench_search_by_name(c: &mut Criterion) {
 }
 
 fn bench_search_fts(c: &mut Criterion) {
-    let mut group = c.benchmark_group("search_fts");
+    let mut group = c.benchmark_group("v4_fts");
 
-    for size in [1000, 10000, 50000].iter() {
-        let (_dir, db_path) = create_benchmark_db(*size);
+    for size in [10_000, 50_000].iter() {
+        let (_dir, db_path) = create_benchmark_db(*size, 8);
         let conn = Connection::open(&db_path).unwrap();
 
         group.bench_with_input(BenchmarkId::new("description", size), size, |b, _| {
             b.iter(|| {
-                let mut stmt = conn
+                let rows: Vec<String> = conn
                     .prepare_cached(
                         r#"
-                    SELECT pv.* FROM package_versions pv
-                    JOIN package_versions_fts fts ON pv.id = fts.rowid
-                    WHERE package_versions_fts MATCH ?
-                    ORDER BY pv.last_commit_date DESC
-                    LIMIT 50
-                    "#,
+                        SELECT pv.attribute_path FROM package_versions pv
+                        JOIN package_versions_fts fts ON pv.id = fts.rowid
+                        WHERE package_versions_fts MATCH ?
+                        ORDER BY pv.last_commit_date DESC
+                        LIMIT 5000
+                        "#,
                     )
-                    .unwrap();
-                let results: Vec<String> = stmt
-                    .query_map(["searchable"], |row| row.get(1))
                     .unwrap()
-                    .filter_map(|r| r.ok())
+                    .query_map(["python"], |row| row.get(0))
+                    .unwrap()
+                    .filter_map(Result::ok)
                     .collect();
-                black_box(results)
-            });
-        });
-    }
-
-    group.finish();
-}
-
-fn bench_index_loading(c: &mut Criterion) {
-    let mut group = c.benchmark_group("index_loading");
-
-    for size in [1000, 10000].iter() {
-        let (_dir, db_path) = create_benchmark_db(*size);
-
-        group.bench_with_input(BenchmarkId::new("open_readonly", size), size, |b, _| {
-            b.iter(|| {
-                let conn = Connection::open_with_flags(
-                    &db_path,
-                    rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-                )
-                .unwrap();
-                black_box(conn)
+                black_box(rows)
             });
         });
     }
@@ -187,8 +400,10 @@ fn bench_index_loading(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_search_by_name,
-    bench_search_fts,
-    bench_index_loading
+    bench_exact_lookup,
+    bench_prefix_version_search,
+    bench_completion,
+    bench_stats,
+    bench_search_fts
 );
 criterion_main!(benches);

--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -58,8 +58,10 @@ fn create_benchmark_db(
         );
 
         CREATE TABLE package_attrs (
-            attribute_path TEXT PRIMARY KEY
+            attribute_path TEXT PRIMARY KEY,
+            attribute_path_lc TEXT
         ) WITHOUT ROWID;
+        CREATE INDEX idx_package_attrs_lc ON package_attrs(attribute_path_lc, attribute_path);
 
         CREATE INDEX idx_packages_name ON package_versions(name);
         CREATE INDEX idx_packages_name_version ON package_versions(name, version, first_commit_date);
@@ -142,7 +144,9 @@ fn create_benchmark_db(
         }
     }
     tx.execute(
-        "INSERT INTO package_attrs(attribute_path) SELECT DISTINCT attribute_path FROM package_versions",
+        "INSERT INTO package_attrs(attribute_path, attribute_path_lc) \
+         SELECT attribute_path, lower(attribute_path) \
+         FROM (SELECT DISTINCT attribute_path FROM package_versions)",
         [],
     )
     .unwrap();
@@ -301,7 +305,7 @@ fn bench_completion(c: &mut Criterion) {
                 let rows: Vec<String> = conn
                     .prepare_cached(
                         "SELECT attribute_path FROM package_attrs \
-                         WHERE attribute_path >= ? AND attribute_path < ? \
+                         WHERE attribute_path_lc >= ? AND attribute_path_lc < ? \
                          ORDER BY attribute_path LIMIT 100",
                     )
                     .unwrap()

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -67,13 +67,7 @@ impl Backend {
     #[allow(dead_code)]
     pub fn get_package(&self, attr: &str) -> Result<Vec<PackageVersion>> {
         match self {
-            Backend::Local(db) => {
-                let results = queries::search_by_attr(db.connection(), attr)?;
-                Ok(results
-                    .into_iter()
-                    .filter(|p| p.attribute_path == attr)
-                    .collect())
-            }
+            Backend::Local(db) => queries::search_by_attr_exact(db.connection(), attr),
             Backend::Remote(client) => client.get_package(attr),
         }
     }
@@ -109,11 +103,8 @@ impl Backend {
                 if let Some(v) = version {
                     queries::search_by_name_version(db.connection(), package, v)
                 } else {
-                    // Try exact attribute path first
-                    let by_attr: Vec<_> = queries::search_by_attr(db.connection(), package)?
-                        .into_iter()
-                        .filter(|p| p.attribute_path == package)
-                        .collect();
+                    // Try exact attribute path first.
+                    let by_attr = queries::search_by_attr_exact(db.connection(), package)?;
 
                     if !by_attr.is_empty() {
                         Ok(by_attr)

--- a/src/db/import.rs
+++ b/src/db/import.rs
@@ -29,18 +29,7 @@ pub fn import_delta_pack<P: AsRef<Path>>(conn: &Connection, path: P) -> Result<(
     // Read the SQL content
     let sql_content = fs::read_to_string(&sql_path)?;
 
-    // Execute the SQL statements
-    // The delta pack already contains BEGIN TRANSACTION and COMMIT
-    // But we should handle the case where it might not
-    if sql_content.contains("BEGIN TRANSACTION") {
-        // Execute as-is since it has its own transaction
-        conn.execute_batch(&sql_content)?;
-    } else {
-        // Wrap in transaction for safety
-        conn.execute_batch(&format!("BEGIN TRANSACTION;\n{}\nCOMMIT;", sql_content))?;
-    }
-
-    Ok(())
+    import_delta_sql(conn, &sql_content)
 }
 
 /// Import a delta pack from raw SQL content (uncompressed).

--- a/src/db/import.rs
+++ b/src/db/import.rs
@@ -54,6 +54,29 @@ pub fn import_delta_sql(conn: &Connection, sql_content: &str) -> Result<()> {
         conn.execute_batch(&format!("BEGIN TRANSACTION;\n{}\nCOMMIT;", sql_content))?;
     }
 
+    // Delta SQL mutates package_versions directly. Invalidate derived caches so
+    // callers that do not immediately refresh them never observe stale attrs or
+    // package aggregate stats.
+    invalidate_derived_caches(conn)?;
+
+    Ok(())
+}
+
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    Ok(conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name = ?",
+        [table],
+        |row| row.get(0),
+    )?)
+}
+
+fn invalidate_derived_caches(conn: &Connection) -> Result<()> {
+    if table_exists(conn, "package_attrs")? {
+        conn.execute("DELETE FROM package_attrs", [])?;
+    }
+    if table_exists(conn, "meta")? {
+        conn.execute("DELETE FROM meta WHERE key LIKE 'stats_%'", [])?;
+    }
     Ok(())
 }
 
@@ -301,5 +324,48 @@ COMMIT;
             )
             .unwrap();
         assert_eq!(new_commit, "updated_commit_xyz");
+    }
+
+    #[test]
+    fn test_import_delta_invalidates_derived_caches() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_test_db(&conn);
+        conn.execute_batch(
+            r#"
+            CREATE TABLE package_attrs (attribute_path TEXT PRIMARY KEY) WITHOUT ROWID;
+            INSERT INTO package_attrs (attribute_path) VALUES ('python311');
+            INSERT OR REPLACE INTO meta (key, value) VALUES
+                ('stats_total_ranges', '1'),
+                ('stats_unique_names', '1'),
+                ('stats_unique_versions', '1'),
+                ('stats_calculated_at', 'old');
+            "#,
+        )
+        .unwrap();
+
+        import_delta_sql(
+            &conn,
+            r#"
+            INSERT INTO package_versions
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path)
+            VALUES ('node', '20.0.0', 'ghi789', 1700000000, 'jkl012', 1700100000, 'nodejs');
+            "#,
+        )
+        .unwrap();
+
+        let attr_cache_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM package_attrs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(attr_cache_rows, 0);
+
+        let stats_keys: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM meta WHERE key LIKE 'stats_%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stats_keys, 0);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -475,9 +475,18 @@ impl Database {
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn upsert_observations(&mut self, packages: &[PackageVersion]) -> Result<usize> {
         let tx = self.conn.transaction()?;
+        if !packages.is_empty() {
+            Self::invalidate_derived_caches_tx(&tx)?;
+        }
         let written = Self::upsert_observations_tx(&tx, packages)?;
         tx.commit()?;
         Ok(written)
+    }
+
+    pub(crate) fn invalidate_derived_caches_tx(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+        tx.execute("DELETE FROM package_attrs", [])?;
+        tx.execute("DELETE FROM meta WHERE key LIKE 'stats_%'", [])?;
+        Ok(())
     }
 
     /// Like [`Self::upsert_observations`] but runs inside a caller-provided
@@ -953,6 +962,63 @@ mod tests {
             })
             .unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_upsert_observations_invalidates_derived_caches() {
+        use chrono::Utc;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mut db = Database::open(&db_path).unwrap();
+        let now = Utc::now();
+
+        let mut pkg = PackageVersion {
+            id: 0,
+            name: "python".to_string(),
+            version: "3.11.0".to_string(),
+            first_commit_hash: "abc1234567890".to_string(),
+            first_commit_date: now,
+            last_commit_hash: "def1234567890".to_string(),
+            last_commit_date: now,
+            attribute_path: "python311".to_string(),
+            description: None,
+            license: None,
+            homepage: None,
+            maintainers: None,
+            platforms: None,
+            source_path: None,
+            known_vulnerabilities: None,
+        };
+
+        db.upsert_observations(std::slice::from_ref(&pkg)).unwrap();
+        db.refresh_package_attrs().unwrap();
+        db.refresh_stats_cache().unwrap();
+
+        let cached_attrs: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM package_attrs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(cached_attrs, 1);
+        assert!(db.get_meta("stats_calculated_at").unwrap().is_some());
+
+        pkg.name = "nodejs".to_string();
+        pkg.version = "20.0.0".to_string();
+        pkg.attribute_path = "nodejs_20".to_string();
+        db.upsert_observations(&[pkg]).unwrap();
+
+        let cached_attrs: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM package_attrs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(cached_attrs, 0);
+        assert!(db.get_meta("stats_calculated_at").unwrap().is_none());
+
+        let completions =
+            crate::db::queries::complete_package_prefix(db.connection(), "node", 10).unwrap();
+        assert_eq!(completions, vec!["nodejs_20".to_string()]);
+        let stats = crate::db::queries::get_stats(db.connection()).unwrap();
+        assert_eq!(stats.total_ranges, 2);
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -197,7 +197,8 @@ impl Database {
             -- package_versions at index/publish finish and lets completion and
             -- bloom generation avoid DISTINCT scans over every version row.
             CREATE TABLE IF NOT EXISTS package_attrs (
-                attribute_path TEXT PRIMARY KEY
+                attribute_path TEXT PRIMARY KEY,
+                attribute_path_lc TEXT
             ) WITHOUT ROWID;
 
             -- Channel-release ingestion ledger: which snapshots have been observed,
@@ -228,6 +229,27 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_packages_first_date ON package_versions(first_commit_date DESC);
             CREATE INDEX IF NOT EXISTS idx_packages_last_date ON package_versions(last_commit_date DESC);
             "#,
+        )?;
+
+        // Keep the derived attr table upgradeable without a schema bump: it is
+        // strictly a cache and can be rebuilt from package_versions.
+        let has_attr_lc: bool = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('package_attrs') WHERE name='attribute_path_lc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+        if !has_attr_lc {
+            self.conn.execute(
+                "ALTER TABLE package_attrs ADD COLUMN attribute_path_lc TEXT",
+                [],
+            )?;
+        }
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_package_attrs_lc ON package_attrs(attribute_path_lc, attribute_path)",
+            [],
         )?;
 
         // Create FTS5 table if it doesn't exist
@@ -787,8 +809,9 @@ impl Database {
         self.conn.execute_batch(
             r#"
             DELETE FROM package_attrs;
-            INSERT INTO package_attrs (attribute_path)
-            SELECT DISTINCT attribute_path FROM package_versions;
+            INSERT INTO package_attrs (attribute_path, attribute_path_lc)
+            SELECT attribute_path, lower(attribute_path)
+              FROM (SELECT DISTINCT attribute_path FROM package_versions);
             "#,
         )?;
         Ok(())

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -193,6 +193,13 @@ impl Database {
                 CHECK(first_commit_date <= last_commit_date)
             );
 
+            -- Derived unique attribute set. This is rebuilt from
+            -- package_versions at index/publish finish and lets completion and
+            -- bloom generation avoid DISTINCT scans over every version row.
+            CREATE TABLE IF NOT EXISTS package_attrs (
+                attribute_path TEXT PRIMARY KEY
+            ) WITHOUT ROWID;
+
             -- Channel-release ingestion ledger: which snapshots have been observed,
             -- which are pending/failed, and their retry/backoff state.
             CREATE TABLE IF NOT EXISTS releases (
@@ -772,6 +779,19 @@ impl Database {
             rows_updated,
             rows_deleted,
         })
+    }
+
+    /// Rebuild the derived unique attribute table used by completion and bloom generation.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn refresh_package_attrs(&self) -> Result<()> {
+        self.conn.execute_batch(
+            r#"
+            DELETE FROM package_attrs;
+            INSERT INTO package_attrs (attribute_path)
+            SELECT DISTINCT attribute_path FROM package_versions;
+            "#,
+        )?;
+        Ok(())
     }
 
     /// Refresh aggregate stats cached in `meta` for fast read-only stats calls.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -774,6 +774,12 @@ impl Database {
         })
     }
 
+    /// Refresh aggregate stats cached in `meta` for fast read-only stats calls.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn refresh_stats_cache(&self) -> Result<()> {
+        queries::refresh_stats_cache(&self.conn)
+    }
+
     /// Run `VACUUM` to reclaim disk space after a dedupe.
     #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
     pub fn vacuum(&self) -> Result<()> {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -815,15 +815,44 @@ impl Database {
     /// Rebuild the derived unique attribute table used by completion and bloom generation.
     #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
     pub fn refresh_package_attrs(&self) -> Result<()> {
-        self.conn.execute_batch(
-            r#"
-            DELETE FROM package_attrs;
-            INSERT INTO package_attrs (attribute_path, attribute_path_lc)
-            SELECT attribute_path, lower(attribute_path)
-              FROM (SELECT DISTINCT attribute_path FROM package_versions);
-            "#,
-        )?;
-        Ok(())
+        self.conn
+            .execute_batch("SAVEPOINT nxv_refresh_package_attrs")?;
+
+        let refresh_result = (|| -> Result<()> {
+            self.conn.execute("DELETE FROM package_attrs", [])?;
+            self.conn.execute(
+                r#"
+                INSERT INTO package_attrs (attribute_path, attribute_path_lc)
+                SELECT attribute_path, lower(attribute_path)
+                  FROM (SELECT DISTINCT attribute_path FROM package_versions)
+                "#,
+                [],
+            )?;
+            Ok(())
+        })();
+
+        match refresh_result {
+            Ok(()) => {
+                if let Err(err) = self
+                    .conn
+                    .execute_batch("RELEASE SAVEPOINT nxv_refresh_package_attrs")
+                {
+                    let _ = self.conn.execute_batch(
+                        "ROLLBACK TO SAVEPOINT nxv_refresh_package_attrs; \
+                         RELEASE SAVEPOINT nxv_refresh_package_attrs;",
+                    );
+                    return Err(err.into());
+                }
+                Ok(())
+            }
+            Err(err) => {
+                let _ = self.conn.execute_batch(
+                    "ROLLBACK TO SAVEPOINT nxv_refresh_package_attrs; \
+                     RELEASE SAVEPOINT nxv_refresh_package_attrs;",
+                );
+                Err(err)
+            }
+        }
     }
 
     /// Refresh aggregate stats cached in `meta` for fast read-only stats calls.
@@ -1019,6 +1048,59 @@ mod tests {
         assert_eq!(completions, vec!["nodejs_20".to_string()]);
         let stats = crate::db::queries::get_stats(db.connection()).unwrap();
         assert_eq!(stats.total_ranges, 2);
+    }
+
+    #[test]
+    fn test_refresh_package_attrs_rolls_back_on_error() {
+        use chrono::Utc;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mut db = Database::open(&db_path).unwrap();
+        let now = Utc::now();
+
+        db.upsert_observations(&[PackageVersion {
+            id: 0,
+            name: "python".to_string(),
+            version: "3.11.0".to_string(),
+            first_commit_hash: "abc1234567890".to_string(),
+            first_commit_date: now,
+            last_commit_hash: "def1234567890".to_string(),
+            last_commit_date: now,
+            attribute_path: "python311".to_string(),
+            description: None,
+            license: None,
+            homepage: None,
+            maintainers: None,
+            platforms: None,
+            source_path: None,
+            known_vulnerabilities: None,
+        }])
+        .unwrap();
+        db.refresh_package_attrs().unwrap();
+
+        db.conn
+            .execute_batch(
+                r#"
+                CREATE TRIGGER fail_package_attrs_refresh
+                BEFORE INSERT ON package_attrs
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced package_attrs insert failure');
+                END;
+                "#,
+            )
+            .unwrap();
+
+        assert!(db.refresh_package_attrs().is_err());
+        let cached_attrs: Vec<String> = db
+            .conn
+            .prepare("SELECT attribute_path FROM package_attrs ORDER BY attribute_path")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert_eq!(cached_attrs, vec!["python311".to_string()]);
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -652,6 +652,12 @@ struct PackageStatsCache {
 }
 
 fn cached_package_stats(conn: &rusqlite::Connection) -> Result<Option<PackageStatsCache>> {
+    // Treat the calculated-at marker as the commit marker for the cache. It is
+    // written in the same INSERT statement as the values, so missing marker =>
+    // old/partial cache and live scans are safer.
+    if meta_value(conn, META_STATS_CALCULATED_AT)?.is_none() {
+        return Ok(None);
+    }
     let Some(total_ranges) = cached_i64(conn, META_STATS_TOTAL_RANGES)? else {
         return Ok(None);
     };
@@ -716,29 +722,31 @@ fn compute_package_stats(conn: &rusqlite::Connection) -> Result<PackageStatsCach
 pub fn refresh_stats_cache(conn: &rusqlite::Connection) -> Result<()> {
     let stats = compute_package_stats(conn)?;
     let calculated_at = Utc::now().to_rfc3339();
-    let values = [
-        (META_STATS_TOTAL_RANGES, stats.total_ranges.to_string()),
-        (META_STATS_UNIQUE_NAMES, stats.unique_names.to_string()),
-        (
+    conn.execute(
+        r#"
+        INSERT OR REPLACE INTO meta (key, value) VALUES
+            (?1, ?2),
+            (?3, ?4),
+            (?5, ?6),
+            (?7, ?8),
+            (?9, ?10),
+            (?11, ?12)
+        "#,
+        rusqlite::params![
+            META_STATS_TOTAL_RANGES,
+            stats.total_ranges.to_string(),
+            META_STATS_UNIQUE_NAMES,
+            stats.unique_names.to_string(),
             META_STATS_UNIQUE_VERSIONS,
             stats.unique_versions.to_string(),
-        ),
-        (
             META_STATS_OLDEST_COMMIT_DATE,
             stats.oldest.map(|v| v.to_string()).unwrap_or_default(),
-        ),
-        (
             META_STATS_NEWEST_COMMIT_DATE,
             stats.newest.map(|v| v.to_string()).unwrap_or_default(),
-        ),
-        (META_STATS_CALCULATED_AT, calculated_at),
-    ];
-    for (key, value) in values {
-        conn.execute(
-            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
-            rusqlite::params![key, value],
-        )?;
-    }
+            META_STATS_CALCULATED_AT,
+            calculated_at,
+        ],
+    )?;
     Ok(())
 }
 
@@ -1154,6 +1162,8 @@ mod tests {
             .unwrap();
         db.set_meta(META_STATS_NEWEST_COMMIT_DATE, "1700000000")
             .unwrap();
+        db.set_meta(META_STATS_CALCULATED_AT, "2026-01-01T00:00:00Z")
+            .unwrap();
 
         let stats = get_stats(db.connection()).unwrap();
         assert_eq!(stats.total_ranges, 123);
@@ -1167,6 +1177,19 @@ mod tests {
             stats.newest_commit_date.unwrap(),
             Utc.timestamp_opt(1700000000, 0).unwrap()
         );
+    }
+
+    #[test]
+    fn test_get_stats_ignores_partial_cache_without_marker() {
+        let (_dir, db) = create_test_db();
+        db.set_meta(META_STATS_TOTAL_RANGES, "123").unwrap();
+        db.set_meta(META_STATS_UNIQUE_NAMES, "45").unwrap();
+        db.set_meta(META_STATS_UNIQUE_VERSIONS, "67").unwrap();
+
+        let stats = get_stats(db.connection()).unwrap();
+        assert_eq!(stats.total_ranges, 4);
+        assert_eq!(stats.unique_names, 4);
+        assert_eq!(stats.unique_versions, 4);
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -579,7 +579,7 @@ pub fn get_version_history(
                pv.last_commit_date as last_seen,
                EXISTS (
                    SELECT 1
-                   FROM package_versions iv INDEXED BY idx_version_vulnerabilities
+                   FROM package_versions iv
                    WHERE iv.version = pv.version
                      AND iv.known_vulnerabilities IS NOT NULL
                      AND iv.known_vulnerabilities != ''

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -472,7 +472,7 @@ pub fn get_first_occurrence(
     version: &str,
 ) -> Result<Option<PackageVersion>> {
     let mut stmt = conn.prepare(
-        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? LIMIT 1",
+        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? ORDER BY first_commit_date ASC LIMIT 1",
     )?;
 
     let result = stmt.query_row([package, version], PackageVersion::from_row);
@@ -511,7 +511,7 @@ pub fn get_last_occurrence(
     version: &str,
 ) -> Result<Option<PackageVersion>> {
     let mut stmt = conn.prepare(
-        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? LIMIT 1",
+        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? ORDER BY last_commit_date DESC LIMIT 1",
     )?;
 
     let result = stmt.query_row([package, version], PackageVersion::from_row);
@@ -554,6 +554,13 @@ pub fn get_version_history(
     conn: &rusqlite::Connection,
     package: &str,
 ) -> Result<Vec<VersionHistoryEntry>> {
+    let schema_version = meta_value(conn, "schema_version")?
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(0);
+    if schema_version < 4 {
+        return get_version_history_grouped(conn, package);
+    }
+
     // Schema v4 stores one row per (attribute_path, version), so the historical
     // GROUP BY/MIN/MAX query is redundant. Keep the cross-attribute security
     // semantics by checking the partial vulnerability index per returned row.
@@ -575,6 +582,64 @@ pub fn get_version_history(
         FROM package_versions pv
         WHERE pv.attribute_path = ?
         ORDER BY pv.first_commit_date DESC
+        "#,
+    )?;
+
+    let rows = stmt.query_map([package], |row| {
+        let version: String = row.get(0)?;
+        let first_ts: i64 = row.get(1)?;
+        let last_ts: i64 = row.get(2)?;
+        let is_insecure: i64 = row.get(3)?;
+
+        let first_seen = Utc.timestamp_opt(first_ts, 0).single().ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                1,
+                rusqlite::types::Type::Integer,
+                format!("Invalid first_seen timestamp: {}", first_ts).into(),
+            )
+        })?;
+
+        let last_seen = Utc.timestamp_opt(last_ts, 0).single().ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                2,
+                rusqlite::types::Type::Integer,
+                format!("Invalid last_seen timestamp: {}", last_ts).into(),
+            )
+        })?;
+
+        Ok((version, first_seen, last_seen, is_insecure != 0))
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+fn get_version_history_grouped(
+    conn: &rusqlite::Connection,
+    package: &str,
+) -> Result<Vec<VersionHistoryEntry>> {
+    let mut stmt = conn.prepare(
+        r#"
+        WITH insecure_versions AS (
+            SELECT DISTINCT version
+            FROM package_versions
+            WHERE known_vulnerabilities IS NOT NULL
+              AND known_vulnerabilities != ''
+              AND known_vulnerabilities != '[]'
+              AND known_vulnerabilities != 'null'
+        )
+        SELECT pv.version,
+               MIN(pv.first_commit_date) as first_seen,
+               MAX(pv.last_commit_date) as last_seen,
+               CASE WHEN iv.version IS NOT NULL THEN 1 ELSE 0 END as is_insecure
+        FROM package_versions pv
+        LEFT JOIN insecure_versions iv ON pv.version = iv.version
+        WHERE pv.attribute_path = ?
+        GROUP BY pv.version
+        ORDER BY first_seen DESC
         "#,
     )?;
 
@@ -1147,6 +1212,47 @@ mod tests {
         let (_dir, db) = create_test_db();
         let history = get_version_history(db.connection(), "nonexistent").unwrap();
         assert!(history.is_empty());
+    }
+
+    #[test]
+    fn test_get_version_history_groups_legacy_rows() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO meta (key, value) VALUES ('schema_version', '3');
+            CREATE TABLE package_versions (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                first_commit_hash TEXT NOT NULL,
+                first_commit_date INTEGER NOT NULL,
+                last_commit_hash TEXT NOT NULL,
+                last_commit_date INTEGER NOT NULL,
+                attribute_path TEXT NOT NULL,
+                description TEXT,
+                license TEXT,
+                homepage TEXT,
+                maintainers TEXT,
+                platforms TEXT,
+                source_path TEXT,
+                known_vulnerabilities TEXT
+            );
+            INSERT INTO package_versions
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path)
+            VALUES
+                ('python', '3.11.0', 'a', 100, 'b', 200, 'python'),
+                ('python', '3.11.0', 'c', 50, 'd', 300, 'python');
+            "#,
+        )
+        .unwrap();
+
+        let history = get_version_history(&conn, "python").unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].0, "3.11.0");
+        assert_eq!(history[0].1, Utc.timestamp_opt(50, 0).unwrap());
+        assert_eq!(history[0].2, Utc.timestamp_opt(300, 0).unwrap());
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -292,6 +292,16 @@ pub struct ChannelCoverageStat {
     pub newest_release_date: Option<DateTime<Utc>>,
 }
 
+/// Metadata keys for cached aggregate stats. They are populated by the indexer
+/// and publisher after package writes settle, so read-only `stats` calls don't
+/// have to rescan the full v4 package table.
+const META_STATS_TOTAL_RANGES: &str = "stats_total_ranges";
+const META_STATS_UNIQUE_NAMES: &str = "stats_unique_names";
+const META_STATS_UNIQUE_VERSIONS: &str = "stats_unique_versions";
+const META_STATS_OLDEST_COMMIT_DATE: &str = "stats_oldest_commit_date";
+const META_STATS_NEWEST_COMMIT_DATE: &str = "stats_newest_commit_date";
+const META_STATS_CALCULATED_AT: &str = "stats_calculated_at";
+
 /// Index statistics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexStats {
@@ -615,8 +625,50 @@ pub fn get_version_history(
     Ok(results)
 }
 
-/// Get index statistics.
-pub fn get_stats(conn: &rusqlite::Connection) -> Result<IndexStats> {
+fn meta_value(conn: &rusqlite::Connection, key: &str) -> Result<Option<String>> {
+    let result = conn.query_row("SELECT value FROM meta WHERE key = ?", [key], |row| {
+        row.get(0)
+    });
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn cached_i64(conn: &rusqlite::Connection, key: &str) -> Result<Option<i64>> {
+    match meta_value(conn, key)? {
+        Some(value) => Ok(value.parse::<i64>().ok()),
+        None => Ok(None),
+    }
+}
+
+fn cached_package_stats(
+    conn: &rusqlite::Connection,
+) -> Result<Option<(i64, i64, i64, Option<i64>, Option<i64>)>> {
+    let Some(total_ranges) = cached_i64(conn, META_STATS_TOTAL_RANGES)? else {
+        return Ok(None);
+    };
+    let Some(unique_names) = cached_i64(conn, META_STATS_UNIQUE_NAMES)? else {
+        return Ok(None);
+    };
+    let Some(unique_versions) = cached_i64(conn, META_STATS_UNIQUE_VERSIONS)? else {
+        return Ok(None);
+    };
+    let oldest = cached_i64(conn, META_STATS_OLDEST_COMMIT_DATE)?;
+    let newest = cached_i64(conn, META_STATS_NEWEST_COMMIT_DATE)?;
+    Ok(Some((
+        total_ranges,
+        unique_names,
+        unique_versions,
+        oldest,
+        newest,
+    )))
+}
+
+fn compute_package_stats(
+    conn: &rusqlite::Connection,
+) -> Result<(i64, i64, i64, Option<i64>, Option<i64>)> {
     let total_ranges: i64 = conn.query_row("SELECT COUNT(*) FROM package_versions", [], |row| {
         row.get(0)
     })?;
@@ -633,38 +685,64 @@ pub fn get_stats(conn: &rusqlite::Connection) -> Result<IndexStats> {
         |row| row.get(0),
     )?;
 
-    let oldest: Option<i64> = conn
-        .query_row(
-            "SELECT MIN(first_commit_date) FROM package_versions",
-            [],
-            |row| row.get(0),
-        )
-        .ok();
+    let oldest: Option<i64> = conn.query_row(
+        "SELECT MIN(first_commit_date) FROM package_versions",
+        [],
+        |row| row.get(0),
+    )?;
 
-    let newest: Option<i64> = conn
-        .query_row(
-            "SELECT MAX(last_commit_date) FROM package_versions",
-            [],
-            |row| row.get(0),
-        )
-        .ok();
+    let newest: Option<i64> = conn.query_row(
+        "SELECT MAX(last_commit_date) FROM package_versions",
+        [],
+        |row| row.get(0),
+    )?;
+
+    Ok((total_ranges, unique_names, unique_versions, oldest, newest))
+}
+
+/// Refresh cached package-table statistics in `meta`.
+///
+/// This is intended for index/publish finish steps, after package writes and
+/// before WAL checkpoint/compression. Read-only callers automatically fall back
+/// to live scans when these keys are absent (older indexes).
+pub fn refresh_stats_cache(conn: &rusqlite::Connection) -> Result<()> {
+    let (total_ranges, unique_names, unique_versions, oldest, newest) =
+        compute_package_stats(conn)?;
+    let calculated_at = Utc::now().to_rfc3339();
+    let values = [
+        (META_STATS_TOTAL_RANGES, total_ranges.to_string()),
+        (META_STATS_UNIQUE_NAMES, unique_names.to_string()),
+        (META_STATS_UNIQUE_VERSIONS, unique_versions.to_string()),
+        (
+            META_STATS_OLDEST_COMMIT_DATE,
+            oldest.map(|v| v.to_string()).unwrap_or_default(),
+        ),
+        (
+            META_STATS_NEWEST_COMMIT_DATE,
+            newest.map(|v| v.to_string()).unwrap_or_default(),
+        ),
+        (META_STATS_CALCULATED_AT, calculated_at),
+    ];
+    for (key, value) in values {
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            rusqlite::params![key, value],
+        )?;
+    }
+    Ok(())
+}
+
+/// Get index statistics.
+pub fn get_stats(conn: &rusqlite::Connection) -> Result<IndexStats> {
+    let (total_ranges, unique_names, unique_versions, oldest, newest) =
+        match cached_package_stats(conn)? {
+            Some(stats) => stats,
+            None => compute_package_stats(conn)?,
+        };
 
     // Get meta values (backwards compatible - returns None if not present)
-    let last_indexed_commit: Option<String> = conn
-        .query_row(
-            "SELECT value FROM meta WHERE key = 'last_indexed_commit'",
-            [],
-            |row| row.get(0),
-        )
-        .ok();
-
-    let last_indexed_date: Option<String> = conn
-        .query_row(
-            "SELECT value FROM meta WHERE key = 'last_indexed_date'",
-            [],
-            |row| row.get(0),
-        )
-        .ok();
+    let last_indexed_commit = meta_value(conn, "last_indexed_commit")?;
+    let last_indexed_date = meta_value(conn, "last_indexed_date")?;
 
     Ok(IndexStats {
         total_ranges,
@@ -1023,6 +1101,43 @@ mod tests {
         assert_eq!(stats.total_ranges, 0);
         assert_eq!(stats.unique_names, 0);
         assert_eq!(stats.unique_versions, 0);
+    }
+
+    #[test]
+    fn test_get_stats_uses_cache_when_present() {
+        let (_dir, db) = create_test_db();
+        db.set_meta(META_STATS_TOTAL_RANGES, "123").unwrap();
+        db.set_meta(META_STATS_UNIQUE_NAMES, "45").unwrap();
+        db.set_meta(META_STATS_UNIQUE_VERSIONS, "67").unwrap();
+        db.set_meta(META_STATS_OLDEST_COMMIT_DATE, "1600000000")
+            .unwrap();
+        db.set_meta(META_STATS_NEWEST_COMMIT_DATE, "1700000000")
+            .unwrap();
+
+        let stats = get_stats(db.connection()).unwrap();
+        assert_eq!(stats.total_ranges, 123);
+        assert_eq!(stats.unique_names, 45);
+        assert_eq!(stats.unique_versions, 67);
+        assert_eq!(
+            stats.oldest_commit_date.unwrap(),
+            Utc.timestamp_opt(1600000000, 0).unwrap()
+        );
+        assert_eq!(
+            stats.newest_commit_date.unwrap(),
+            Utc.timestamp_opt(1700000000, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_refresh_stats_cache_writes_live_counts() {
+        let (_dir, db) = create_test_db();
+        refresh_stats_cache(db.connection()).unwrap();
+
+        let stats = get_stats(db.connection()).unwrap();
+        assert_eq!(stats.total_ranges, 4);
+        assert_eq!(stats.unique_names, 4);
+        assert_eq!(stats.unique_versions, 4);
+        assert!(db.get_meta(META_STATS_CALCULATED_AT).unwrap().is_some());
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -427,40 +427,25 @@ pub fn search_by_name_version(
     package: &str,
     version: &str,
 ) -> Result<Vec<PackageVersion>> {
-    // Search by attribute_path (package) and version prefix. Use a literal
-    // B-tree range for attribute prefixes when possible; on v4-sized indexes
-    // this avoids a full scan for narrow package families like `python311%`.
+    // Search by attribute_path (package) and version prefix. Keep SQLite LIKE's
+    // historical ASCII-case-insensitive behavior here so versioned and
+    // unversioned prefix searches agree for mixed-case package-set segments
+    // such as `python313Packages`.
+    let mut stmt = conn.prepare(&format!(
+        "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
+         ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
+    ))?;
+    let package_pattern = format!("{}%", escape_like_pattern(package));
     let version_pattern = format!("{}%", escape_like_pattern(version));
+    let rows = stmt.query_map(
+        [&package_pattern, &version_pattern],
+        PackageVersion::from_row,
+    )?;
+
     let mut results = Vec::new();
-
-    if let Some(upper) = prefix_upper_bound(package) {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT * FROM package_versions \
-             WHERE attribute_path >= ? AND attribute_path < ? AND version LIKE ? ESCAPE '\\' \
-             ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
-        ))?;
-        let rows = stmt.query_map(
-            rusqlite::params![package, upper, version_pattern],
-            PackageVersion::from_row,
-        )?;
-        for row in rows {
-            results.push(row?);
-        }
-    } else {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
-             ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
-        ))?;
-        let package_pattern = format!("{}%", escape_like_pattern(package));
-        let rows = stmt.query_map(
-            [&package_pattern, &version_pattern],
-            PackageVersion::from_row,
-        )?;
-        for row in rows {
-            results.push(row?);
-        }
+    for row in rows {
+        results.push(row?);
     }
-
     Ok(results)
 }
 
@@ -877,6 +862,16 @@ fn package_attrs_available(conn: &rusqlite::Connection) -> Result<bool> {
     if !has_table {
         return Ok(false);
     }
+    let has_lc: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM pragma_table_info('package_attrs') WHERE name='attribute_path_lc'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    if !has_lc {
+        return Ok(false);
+    }
     let has_rows: Option<i64> = conn
         .query_row("SELECT 1 FROM package_attrs LIMIT 1", [], |row| row.get(0))
         .ok();
@@ -942,29 +937,31 @@ pub fn complete_package_prefix(
     };
     let distinct = if use_package_attrs { "" } else { "DISTINCT " };
 
-    if let Some(upper) = prefix_upper_bound(prefix) {
-        let sql = format!(
-            "SELECT {distinct}attribute_path FROM {table} \
-             WHERE attribute_path >= ? AND attribute_path < ? \
-             ORDER BY attribute_path LIMIT ?"
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let rows = stmt.query_map(rusqlite::params![prefix, upper, limit as i64], |row| {
-            row.get(0)
-        })?;
+    let lower_prefix = prefix.to_ascii_lowercase();
+    if use_package_attrs && let Some(upper) = prefix_upper_bound(&lower_prefix) {
+        let mut stmt = conn.prepare(
+            "SELECT attribute_path FROM package_attrs \
+             WHERE attribute_path_lc >= ? AND attribute_path_lc < ? \
+             ORDER BY attribute_path LIMIT ?",
+        )?;
+        let rows = stmt.query_map(
+            rusqlite::params![lower_prefix, upper, limit as i64],
+            |row| row.get(0),
+        )?;
         for row in rows {
             results.push(row?);
         }
-    } else {
-        let sql = format!(
-            "SELECT {distinct}attribute_path FROM {table} WHERE attribute_path LIKE ? ESCAPE '\\' ORDER BY attribute_path LIMIT ?"
-        );
-        let mut stmt = conn.prepare(&sql)?;
-        let pattern = format!("{}%", escape_like_pattern(prefix));
-        let rows = stmt.query_map(rusqlite::params![&pattern, limit as i64], |row| row.get(0))?;
-        for row in rows {
-            results.push(row?);
-        }
+        return Ok(results);
+    }
+
+    let sql = format!(
+        "SELECT {distinct}attribute_path FROM {table} WHERE attribute_path LIKE ? ESCAPE '\\' ORDER BY attribute_path LIMIT ?"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let pattern = format!("{}%", escape_like_pattern(prefix));
+    let rows = stmt.query_map(rusqlite::params![&pattern, limit as i64], |row| row.get(0))?;
+    for row in rows {
+        results.push(row?);
     }
 
     Ok(results)
@@ -1054,6 +1051,26 @@ mod tests {
         let (_dir, db) = create_test_db();
         let results = search_by_name_version(db.connection(), "python", "99.99").unwrap();
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_by_name_version_preserves_like_case_behavior() {
+        let (_dir, db) = create_test_db();
+        db.connection()
+            .execute(
+                r#"
+            INSERT INTO package_versions (name, version, first_commit_hash, first_commit_date,
+                last_commit_hash, last_commit_date, attribute_path, description)
+            VALUES ('requests', '2.32.0', 'abc', 1700000000, 'def', 1700100000,
+                'python313Packages.requests', 'Requests')
+            "#,
+                [],
+            )
+            .unwrap();
+
+        let results = search_by_name_version(db.connection(), "python313packages", "2.32").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].attribute_path, "python313Packages.requests");
     }
 
     #[test]
@@ -1284,6 +1301,26 @@ mod tests {
 
         let results = complete_package_prefix(db.connection(), "python", 10).unwrap();
         assert_eq!(results, vec!["python".to_string(), "python2".to_string()]);
+    }
+
+    #[test]
+    fn test_complete_package_prefix_cache_is_case_insensitive() {
+        let (_dir, db) = create_test_db();
+        db.connection()
+            .execute(
+                r#"
+            INSERT INTO package_versions (name, version, first_commit_hash, first_commit_date,
+                last_commit_hash, last_commit_date, attribute_path, description)
+            VALUES ('requests', '2.32.0', 'abc', 1700000000, 'def', 1700100000,
+                'python313Packages.requests', 'Requests')
+            "#,
+                [],
+            )
+            .unwrap();
+        db.refresh_package_attrs().unwrap();
+
+        let results = complete_package_prefix(db.connection(), "python313packages", 10).unwrap();
+        assert_eq!(results, vec!["python313Packages.requests".to_string()]);
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -847,6 +847,21 @@ pub fn search_by_description(
     Ok(results)
 }
 
+fn package_attrs_available(conn: &rusqlite::Connection) -> Result<bool> {
+    let has_table: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='package_attrs'",
+        [],
+        |row| row.get(0),
+    )?;
+    if !has_table {
+        return Ok(false);
+    }
+    let has_rows: Option<i64> = conn
+        .query_row("SELECT 1 FROM package_attrs LIMIT 1", [], |row| row.get(0))
+        .ok();
+    Ok(has_rows.is_some())
+}
+
 /// Return all distinct package attribute paths from the database, ordered by attribute_path.
 ///
 /// The results are suitable for building membership structures (e.g., a bloom filter) used to
@@ -865,8 +880,12 @@ pub fn search_by_description(
 /// assert_eq!(attrs, vec!["pkg::a".to_string(), "pkg::b".to_string()]);
 /// ```
 pub fn get_all_unique_attrs(conn: &rusqlite::Connection) -> Result<Vec<String>> {
-    let mut stmt = conn
-        .prepare("SELECT DISTINCT attribute_path FROM package_versions ORDER BY attribute_path")?;
+    let sql = if package_attrs_available(conn)? {
+        "SELECT attribute_path FROM package_attrs ORDER BY attribute_path"
+    } else {
+        "SELECT DISTINCT attribute_path FROM package_versions ORDER BY attribute_path"
+    };
+    let mut stmt = conn.prepare(sql)?;
     let rows = stmt.query_map([], |row| row.get(0))?;
 
     let mut results = Vec::new();
@@ -894,13 +913,21 @@ pub fn complete_package_prefix(
     limit: usize,
 ) -> Result<Vec<String>> {
     let mut results = Vec::new();
+    let use_package_attrs = package_attrs_available(conn)?;
+    let table = if use_package_attrs {
+        "package_attrs"
+    } else {
+        "package_versions"
+    };
+    let distinct = if use_package_attrs { "" } else { "DISTINCT " };
 
     if let Some(upper) = prefix_upper_bound(prefix) {
-        let mut stmt = conn.prepare(
-            "SELECT DISTINCT attribute_path FROM package_versions \
+        let sql = format!(
+            "SELECT {distinct}attribute_path FROM {table} \
              WHERE attribute_path >= ? AND attribute_path < ? \
-             ORDER BY attribute_path LIMIT ?",
-        )?;
+             ORDER BY attribute_path LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(rusqlite::params![prefix, upper, limit as i64], |row| {
             row.get(0)
         })?;
@@ -908,9 +935,10 @@ pub fn complete_package_prefix(
             results.push(row?);
         }
     } else {
-        let mut stmt = conn.prepare(
-            "SELECT DISTINCT attribute_path FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' ORDER BY attribute_path LIMIT ?",
-        )?;
+        let sql = format!(
+            "SELECT {distinct}attribute_path FROM {table} WHERE attribute_path LIKE ? ESCAPE '\\' ORDER BY attribute_path LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let pattern = format!("{}%", escape_like_pattern(prefix));
         let rows = stmt.query_map(rusqlite::params![&pattern, limit as i64], |row| row.get(0))?;
         for row in rows {
@@ -1191,6 +1219,35 @@ mod tests {
 
         let attrs = get_all_unique_attrs(db.connection()).unwrap();
         assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn test_get_all_unique_attrs_uses_package_attrs_cache() {
+        let (_dir, db) = create_test_db();
+        db.refresh_package_attrs().unwrap();
+
+        db.connection()
+            .execute("DELETE FROM package_versions", [])
+            .unwrap();
+
+        let attrs = get_all_unique_attrs(db.connection()).unwrap();
+        assert_eq!(attrs.len(), 3);
+        assert!(attrs.contains(&"python".to_string()));
+        assert!(attrs.contains(&"python2".to_string()));
+        assert!(attrs.contains(&"nodejs".to_string()));
+    }
+
+    #[test]
+    fn test_complete_package_prefix_uses_package_attrs_cache() {
+        let (_dir, db) = create_test_db();
+        db.refresh_package_attrs().unwrap();
+
+        db.connection()
+            .execute("DELETE FROM package_versions", [])
+            .unwrap();
+
+        let results = complete_package_prefix(db.connection(), "python", 10).unwrap();
+        assert_eq!(results, vec!["python".to_string(), "python2".to_string()]);
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -643,9 +643,15 @@ fn cached_i64(conn: &rusqlite::Connection, key: &str) -> Result<Option<i64>> {
     }
 }
 
-fn cached_package_stats(
-    conn: &rusqlite::Connection,
-) -> Result<Option<(i64, i64, i64, Option<i64>, Option<i64>)>> {
+struct PackageStatsCache {
+    total_ranges: i64,
+    unique_names: i64,
+    unique_versions: i64,
+    oldest: Option<i64>,
+    newest: Option<i64>,
+}
+
+fn cached_package_stats(conn: &rusqlite::Connection) -> Result<Option<PackageStatsCache>> {
     let Some(total_ranges) = cached_i64(conn, META_STATS_TOTAL_RANGES)? else {
         return Ok(None);
     };
@@ -655,20 +661,16 @@ fn cached_package_stats(
     let Some(unique_versions) = cached_i64(conn, META_STATS_UNIQUE_VERSIONS)? else {
         return Ok(None);
     };
-    let oldest = cached_i64(conn, META_STATS_OLDEST_COMMIT_DATE)?;
-    let newest = cached_i64(conn, META_STATS_NEWEST_COMMIT_DATE)?;
-    Ok(Some((
+    Ok(Some(PackageStatsCache {
         total_ranges,
         unique_names,
         unique_versions,
-        oldest,
-        newest,
-    )))
+        oldest: cached_i64(conn, META_STATS_OLDEST_COMMIT_DATE)?,
+        newest: cached_i64(conn, META_STATS_NEWEST_COMMIT_DATE)?,
+    }))
 }
 
-fn compute_package_stats(
-    conn: &rusqlite::Connection,
-) -> Result<(i64, i64, i64, Option<i64>, Option<i64>)> {
+fn compute_package_stats(conn: &rusqlite::Connection) -> Result<PackageStatsCache> {
     let total_ranges: i64 = conn.query_row("SELECT COUNT(*) FROM package_versions", [], |row| {
         row.get(0)
     })?;
@@ -697,7 +699,13 @@ fn compute_package_stats(
         |row| row.get(0),
     )?;
 
-    Ok((total_ranges, unique_names, unique_versions, oldest, newest))
+    Ok(PackageStatsCache {
+        total_ranges,
+        unique_names,
+        unique_versions,
+        oldest,
+        newest,
+    })
 }
 
 /// Refresh cached package-table statistics in `meta`.
@@ -706,20 +714,22 @@ fn compute_package_stats(
 /// before WAL checkpoint/compression. Read-only callers automatically fall back
 /// to live scans when these keys are absent (older indexes).
 pub fn refresh_stats_cache(conn: &rusqlite::Connection) -> Result<()> {
-    let (total_ranges, unique_names, unique_versions, oldest, newest) =
-        compute_package_stats(conn)?;
+    let stats = compute_package_stats(conn)?;
     let calculated_at = Utc::now().to_rfc3339();
     let values = [
-        (META_STATS_TOTAL_RANGES, total_ranges.to_string()),
-        (META_STATS_UNIQUE_NAMES, unique_names.to_string()),
-        (META_STATS_UNIQUE_VERSIONS, unique_versions.to_string()),
+        (META_STATS_TOTAL_RANGES, stats.total_ranges.to_string()),
+        (META_STATS_UNIQUE_NAMES, stats.unique_names.to_string()),
+        (
+            META_STATS_UNIQUE_VERSIONS,
+            stats.unique_versions.to_string(),
+        ),
         (
             META_STATS_OLDEST_COMMIT_DATE,
-            oldest.map(|v| v.to_string()).unwrap_or_default(),
+            stats.oldest.map(|v| v.to_string()).unwrap_or_default(),
         ),
         (
             META_STATS_NEWEST_COMMIT_DATE,
-            newest.map(|v| v.to_string()).unwrap_or_default(),
+            stats.newest.map(|v| v.to_string()).unwrap_or_default(),
         ),
         (META_STATS_CALCULATED_AT, calculated_at),
     ];
@@ -734,22 +744,25 @@ pub fn refresh_stats_cache(conn: &rusqlite::Connection) -> Result<()> {
 
 /// Get index statistics.
 pub fn get_stats(conn: &rusqlite::Connection) -> Result<IndexStats> {
-    let (total_ranges, unique_names, unique_versions, oldest, newest) =
-        match cached_package_stats(conn)? {
-            Some(stats) => stats,
-            None => compute_package_stats(conn)?,
-        };
+    let stats = match cached_package_stats(conn)? {
+        Some(stats) => stats,
+        None => compute_package_stats(conn)?,
+    };
 
     // Get meta values (backwards compatible - returns None if not present)
     let last_indexed_commit = meta_value(conn, "last_indexed_commit")?;
     let last_indexed_date = meta_value(conn, "last_indexed_date")?;
 
     Ok(IndexStats {
-        total_ranges,
-        unique_names,
-        unique_versions,
-        oldest_commit_date: oldest.and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
-        newest_commit_date: newest.and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
+        total_ranges: stats.total_ranges,
+        unique_names: stats.unique_names,
+        unique_versions: stats.unique_versions,
+        oldest_commit_date: stats
+            .oldest
+            .and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
+        newest_commit_date: stats
+            .newest
+            .and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
         last_indexed_commit,
         last_indexed_date,
         channels: get_channel_coverage(conn).unwrap_or_default(),

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -621,7 +621,9 @@ fn get_version_history_grouped(
     conn: &rusqlite::Connection,
     package: &str,
 ) -> Result<Vec<VersionHistoryEntry>> {
-    let mut stmt = conn.prepare(
+    let has_vulnerabilities_column =
+        table_has_column(conn, "package_versions", "known_vulnerabilities")?;
+    let sql = if has_vulnerabilities_column {
         r#"
         WITH insecure_versions AS (
             SELECT DISTINCT version
@@ -640,8 +642,20 @@ fn get_version_history_grouped(
         WHERE pv.attribute_path = ?
         GROUP BY pv.version
         ORDER BY first_seen DESC
-        "#,
-    )?;
+        "#
+    } else {
+        r#"
+        SELECT version,
+               MIN(first_commit_date) as first_seen,
+               MAX(last_commit_date) as last_seen,
+               0 as is_insecure
+        FROM package_versions
+        WHERE attribute_path = ?
+        GROUP BY version
+        ORDER BY first_seen DESC
+        "#
+    };
+    let mut stmt = conn.prepare(sql)?;
 
     let rows = stmt.query_map([package], |row| {
         let version: String = row.get(0)?;
@@ -673,6 +687,11 @@ fn get_version_history_grouped(
         results.push(row?);
     }
     Ok(results)
+}
+
+fn table_has_column(conn: &rusqlite::Connection, table: &str, column: &str) -> Result<bool> {
+    let sql = format!("SELECT COUNT(*) > 0 FROM pragma_table_info({table:?}) WHERE name = ?");
+    Ok(conn.query_row(&sql, [column], |row| row.get(0))?)
 }
 
 fn meta_value(conn: &rusqlite::Connection, key: &str) -> Result<Option<String>> {
@@ -986,7 +1005,9 @@ pub fn get_all_unique_attrs(conn: &rusqlite::Connection) -> Result<Vec<String>> 
 ///
 /// # Arguments
 ///
-/// * `prefix` - The prefix to match against attribute paths (case-sensitive)
+/// * `prefix` - The prefix to match against attribute paths. Matching follows SQLite
+///   `LIKE` case behavior on legacy tables and is ASCII-case-insensitive when the
+///   `package_attrs` cache is available.
 /// * `limit` - Maximum number of results to return
 pub fn complete_package_prefix(
     conn: &rusqlite::Connection,
@@ -1253,6 +1274,47 @@ mod tests {
         assert_eq!(history[0].0, "3.11.0");
         assert_eq!(history[0].1, Utc.timestamp_opt(50, 0).unwrap());
         assert_eq!(history[0].2, Utc.timestamp_opt(300, 0).unwrap());
+    }
+
+    #[test]
+    fn test_get_version_history_legacy_without_vulnerabilities_column() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO meta (key, value) VALUES ('schema_version', '2');
+            CREATE TABLE package_versions (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                first_commit_hash TEXT NOT NULL,
+                first_commit_date INTEGER NOT NULL,
+                last_commit_hash TEXT NOT NULL,
+                last_commit_date INTEGER NOT NULL,
+                attribute_path TEXT NOT NULL,
+                description TEXT,
+                license TEXT,
+                homepage TEXT,
+                maintainers TEXT,
+                platforms TEXT,
+                source_path TEXT
+            );
+            INSERT INTO package_versions
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path)
+            VALUES
+                ('python', '3.11.0', 'a', 100, 'b', 200, 'python'),
+                ('python', '3.11.0', 'c', 50, 'd', 300, 'python');
+            "#,
+        )
+        .unwrap();
+
+        let history = get_version_history(&conn, "python").unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].0, "3.11.0");
+        assert_eq!(history[0].1, Utc.timestamp_opt(50, 0).unwrap());
+        assert_eq!(history[0].2, Utc.timestamp_opt(300, 0).unwrap());
+        assert!(!history[0].3);
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -17,6 +17,20 @@ fn escape_like_pattern(input: &str) -> String {
         .replace('_', "\\_")
 }
 
+/// Return the exclusive upper bound for a binary-collated prefix range.
+///
+/// For example, `python` becomes `pythoo`, so callers can express a literal
+/// prefix search as `attribute_path >= 'python' AND attribute_path < 'pythoo'`.
+/// That lets SQLite seek into the `attribute_path` index instead of scanning it
+/// for `LIKE 'python%'`.
+fn prefix_upper_bound(prefix: &str) -> Option<String> {
+    let mut chars: Vec<char> = prefix.chars().collect();
+    let last = chars.pop()?;
+    let next = char::from_u32(last as u32 + 1)?;
+    chars.push(next);
+    Some(chars.into_iter().collect())
+}
+
 /// Escapes user input for use in SQLite FTS5 MATCH queries.
 ///
 /// FTS5 has its own query syntax with operators like `NOT`, `OR`, `AND`, `*`, `^`,
@@ -344,7 +358,25 @@ pub fn search_by_name(
     Ok(results)
 }
 
-/// Search for packages by attribute path.
+/// Search for packages by exact attribute path.
+pub fn search_by_attr_exact(
+    conn: &rusqlite::Connection,
+    attr_path: &str,
+) -> Result<Vec<PackageVersion>> {
+    let mut stmt = conn.prepare(
+        "SELECT * FROM package_versions WHERE attribute_path = ? \
+         ORDER BY last_commit_date DESC",
+    )?;
+    let rows = stmt.query_map([attr_path], PackageVersion::from_row)?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+/// Search for packages by attribute path prefix.
 pub fn search_by_attr(conn: &rusqlite::Connection, attr_path: &str) -> Result<Vec<PackageVersion>> {
     let mut stmt = conn.prepare(&format!(
         "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' \
@@ -385,22 +417,40 @@ pub fn search_by_name_version(
     package: &str,
     version: &str,
 ) -> Result<Vec<PackageVersion>> {
-    // Search by attribute_path (package) and version prefix
-    let mut stmt = conn.prepare(&format!(
-        "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
-         ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
-    ))?;
-    let package_pattern = format!("{}%", escape_like_pattern(package));
+    // Search by attribute_path (package) and version prefix. Use a literal
+    // B-tree range for attribute prefixes when possible; on v4-sized indexes
+    // this avoids a full scan for narrow package families like `python311%`.
     let version_pattern = format!("{}%", escape_like_pattern(version));
-    let rows = stmt.query_map(
-        [&package_pattern, &version_pattern],
-        PackageVersion::from_row,
-    )?;
-
     let mut results = Vec::new();
-    for row in rows {
-        results.push(row?);
+
+    if let Some(upper) = prefix_upper_bound(package) {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT * FROM package_versions \
+             WHERE attribute_path >= ? AND attribute_path < ? AND version LIKE ? ESCAPE '\\' \
+             ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
+        ))?;
+        let rows = stmt.query_map(
+            rusqlite::params![package, upper, version_pattern],
+            PackageVersion::from_row,
+        )?;
+        for row in rows {
+            results.push(row?);
+        }
+    } else {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
+             ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
+        ))?;
+        let package_pattern = format!("{}%", escape_like_pattern(package));
+        let rows = stmt.query_map(
+            [&package_pattern, &version_pattern],
+            PackageVersion::from_row,
+        )?;
+        for row in rows {
+            results.push(row?);
+        }
     }
+
     Ok(results)
 }
 
@@ -427,7 +477,7 @@ pub fn get_first_occurrence(
     version: &str,
 ) -> Result<Option<PackageVersion>> {
     let mut stmt = conn.prepare(
-        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? ORDER BY first_commit_date ASC LIMIT 1",
+        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? LIMIT 1",
     )?;
 
     let result = stmt.query_row([package, version], PackageVersion::from_row);
@@ -466,7 +516,7 @@ pub fn get_last_occurrence(
     version: &str,
 ) -> Result<Option<PackageVersion>> {
     let mut stmt = conn.prepare(
-        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? ORDER BY last_commit_date DESC LIMIT 1",
+        "SELECT * FROM package_versions WHERE attribute_path = ? AND version = ? LIMIT 1",
     )?;
 
     let result = stmt.query_row([package, version], PackageVersion::from_row);
@@ -509,32 +559,27 @@ pub fn get_version_history(
     conn: &rusqlite::Connection,
     package: &str,
 ) -> Result<Vec<VersionHistoryEntry>> {
-    // Query history for the specific attribute path, but check if ANY package
-    // with the same version has vulnerabilities (since insecurity is about the
-    // version, not the attribute path - e.g., Python 2.7 is EOL regardless of
-    // whether it's called "python" or "python27")
-    //
-    // Uses a CTE to pre-compute insecure versions once, avoiding a correlated
-    // subquery that would run for each row in the result set.
+    // Schema v4 stores one row per (attribute_path, version), so the historical
+    // GROUP BY/MIN/MAX query is redundant. Keep the cross-attribute security
+    // semantics by checking the partial vulnerability index per returned row.
     let mut stmt = conn.prepare(
         r#"
-        WITH insecure_versions AS (
-            SELECT DISTINCT version
-            FROM package_versions
-            WHERE known_vulnerabilities IS NOT NULL
-              AND known_vulnerabilities != ''
-              AND known_vulnerabilities != '[]'
-              AND known_vulnerabilities != 'null'
-        )
         SELECT pv.version,
-               MIN(pv.first_commit_date) as first_seen,
-               MAX(pv.last_commit_date) as last_seen,
-               CASE WHEN iv.version IS NOT NULL THEN 1 ELSE 0 END as is_insecure
+               pv.first_commit_date as first_seen,
+               pv.last_commit_date as last_seen,
+               EXISTS (
+                   SELECT 1
+                   FROM package_versions iv INDEXED BY idx_version_vulnerabilities
+                   WHERE iv.version = pv.version
+                     AND iv.known_vulnerabilities IS NOT NULL
+                     AND iv.known_vulnerabilities != ''
+                     AND iv.known_vulnerabilities != '[]'
+                     AND iv.known_vulnerabilities != 'null'
+                   LIMIT 1
+               ) as is_insecure
         FROM package_versions pv
-        LEFT JOIN insecure_versions iv ON pv.version = iv.version
         WHERE pv.attribute_path = ?
-        GROUP BY pv.version
-        ORDER BY first_seen DESC
+        ORDER BY pv.first_commit_date DESC
         "#,
     )?;
 
@@ -770,16 +815,31 @@ pub fn complete_package_prefix(
     prefix: &str,
     limit: usize,
 ) -> Result<Vec<String>> {
-    let mut stmt = conn.prepare(
-        "SELECT DISTINCT attribute_path FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' ORDER BY attribute_path LIMIT ?",
-    )?;
-    let pattern = format!("{}%", escape_like_pattern(prefix));
-    let rows = stmt.query_map(rusqlite::params![&pattern, limit as i64], |row| row.get(0))?;
-
     let mut results = Vec::new();
-    for row in rows {
-        results.push(row?);
+
+    if let Some(upper) = prefix_upper_bound(prefix) {
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT attribute_path FROM package_versions \
+             WHERE attribute_path >= ? AND attribute_path < ? \
+             ORDER BY attribute_path LIMIT ?",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![prefix, upper, limit as i64], |row| {
+            row.get(0)
+        })?;
+        for row in rows {
+            results.push(row?);
+        }
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT attribute_path FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' ORDER BY attribute_path LIMIT ?",
+        )?;
+        let pattern = format!("{}%", escape_like_pattern(prefix));
+        let rows = stmt.query_map(rusqlite::params![&pattern, limit as i64], |row| row.get(0))?;
+        for row in rows {
+            results.push(row?);
+        }
     }
+
     Ok(results)
 }
 
@@ -883,6 +943,14 @@ mod tests {
         let results = search_by_attr(db.connection(), "nodejs").unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].attribute_path, "nodejs");
+    }
+
+    #[test]
+    fn test_search_by_attr_exact_excludes_prefix_siblings() {
+        let (_dir, db) = create_test_db();
+        let results = search_by_attr_exact(db.connection(), "python").unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|p| p.attribute_path == "python"));
     }
 
     #[test]

--- a/src/db/releases.rs
+++ b/src/db/releases.rs
@@ -247,8 +247,7 @@ impl Database {
         // the finish step rebuilds them. Invalidate in the same transaction so
         // an interrupted run falls back to source tables instead of old caches.
         if !observations.is_empty() {
-            tx.execute("DELETE FROM package_attrs", [])?;
-            tx.execute("DELETE FROM meta WHERE key LIKE 'stats_%'", [])?;
+            Database::invalidate_derived_caches_tx(&tx)?;
         }
         let written = Database::upsert_observations_tx(&tx, observations)?;
         {

--- a/src/db/releases.rs
+++ b/src/db/releases.rs
@@ -243,6 +243,13 @@ impl Database {
         ingested: &[(i64, i64)], // (release id, attr_count)
     ) -> Result<usize> {
         let tx = self.conn.transaction()?;
+        // Any successful package write makes derived attrs/stats stale until
+        // the finish step rebuilds them. Invalidate in the same transaction so
+        // an interrupted run falls back to source tables instead of old caches.
+        if !observations.is_empty() {
+            tx.execute("DELETE FROM package_attrs", [])?;
+            tx.execute("DELETE FROM meta WHERE key LIKE 'stats_%'", [])?;
+        }
         let written = Database::upsert_observations_tx(&tx, observations)?;
         {
             let mut stmt = tx.prepare_cached(

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -223,6 +223,9 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
     }
 
     // ── Finish ──────────────────────────────────────────────────────────
+    progress("refreshing attribute cache...");
+    db.refresh_package_attrs()?;
+
     progress("rebuilding bloom filter...");
     let bloom_path = crate::paths::get_bloom_path_for_db(&cli.db_path);
     save_bloom_filter(&db, &bloom_path)?;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -234,6 +234,9 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         db.set_meta("last_indexed_date", &Utc::now().to_rfc3339())?;
     }
 
+    progress("refreshing stats cache...");
+    db.refresh_stats_cache()?;
+
     report.finalize(&db, args.strict)?;
     if !quiet {
         report.print();

--- a/src/index/publisher.rs
+++ b/src/index/publisher.rs
@@ -442,6 +442,9 @@ pub fn generate_full_index<P: AsRef<Path>, Q: AsRef<Path>>(
     db.set_meta("last_indexed_date", &Utc::now().to_rfc3339())?;
     // Write min_schema_version to database for direct-download validation
     db.set_meta("min_schema_version", &min_version.to_string())?;
+    // Cache aggregate package stats so read-only stats calls do not rescan the
+    // full v4 table on every CLI/API request.
+    db.refresh_stats_cache()?;
     // Flush WAL to ensure meta updates are in the main DB file before compression
     db.checkpoint()?;
     let input_size = fs::metadata(db_path)?.len();

--- a/src/index/publisher.rs
+++ b/src/index/publisher.rs
@@ -442,6 +442,8 @@ pub fn generate_full_index<P: AsRef<Path>, Q: AsRef<Path>>(
     db.set_meta("last_indexed_date", &Utc::now().to_rfc3339())?;
     // Write min_schema_version to database for direct-download validation
     db.set_meta("min_schema_version", &min_version.to_string())?;
+    // Refresh derived read-optimization data before compressing the DB.
+    db.refresh_package_attrs()?;
     // Cache aggregate package stats so read-only stats calls do not rescan the
     // full v4 table on every CLI/API request.
     db.refresh_stats_cache()?;

--- a/src/remote/update.rs
+++ b/src/remote/update.rs
@@ -364,6 +364,9 @@ pub fn apply_delta_update<P: AsRef<Path>>(
     let db = Database::open(db_path)?;
     let sql_content = std::fs::read_to_string(&delta_path)?;
     import_delta_sql(db.connection(), &sql_content)?;
+    db.refresh_package_attrs()?;
+    db.refresh_stats_cache()?;
+    db.checkpoint()?;
 
     // Also update the bloom filter (sibling to database file)
     if show_progress {

--- a/src/search.rs
+++ b/src/search.rs
@@ -136,11 +136,9 @@ pub fn execute_search(conn: &Connection, opts: &SearchOptions) -> Result<SearchR
         // Search by name and version
         queries::search_by_name_version(conn, &opts.query, version)?
     } else if opts.exact {
-        // Exact match on attribute_path
-        queries::search_by_attr(conn, &opts.query)?
-            .into_iter()
-            .filter(|p| p.attribute_path == opts.query)
-            .collect()
+        // Exact match on attribute_path. Avoid the old prefix query + Rust
+        // filter path, which materialized thousands of sibling attrs on v4 DBs.
+        queries::search_by_attr_exact(conn, &opts.query)?
     } else {
         // Prefix search on attribute_path
         queries::search_by_attr(conn, &opts.query)?

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -297,11 +297,7 @@ pub async fn get_package(
     let packages = run_db_operation(&state, move || {
         let _span = tracing::info_span!("db_get_package").entered();
         let db = Database::open_readonly(&db_path)?;
-        let results: Vec<_> = queries::search_by_attr(db.connection(), &attr_clone)?
-            .into_iter()
-            .filter(|p| p.attribute_path == attr_clone)
-            .collect();
-        Ok::<_, crate::error::NxvError>(results)
+        queries::search_by_attr_exact(db.connection(), &attr_clone)
     })
     .await?;
 


### PR DESCRIPTION
## Summary

Closes #45.

This keeps schema v4 completeness intact and optimizes the slow local read paths that regressed with the much larger v4 index. The approach is query-shape and derived-cache based: no indexed observations are removed or collapsed.

## What changed

- Added exact attribute lookup (`search_by_attr_exact`) and routed exact local/package API paths through it instead of prefix scans plus Rust filtering.
- Kept prefix search semantics compatible with existing SQLite `LIKE` behavior where needed, while making shell completion fast via a derived `package_attrs` cache with lowercased keys.
- Simplified v4 history queries to use the schema v4 `UNIQUE(attribute_path, version)` invariant, while preserving grouped legacy behavior for older schemas.
- Added cached aggregate stats in `meta`, written atomically and only trusted when the marker key exists.
- Added/refresh derived caches during index, publish, full update, delta update, delta-pack import, and direct observation writes; invalidation falls back safely to source tables.
- Updated Criterion benchmarks to model v4-shaped data and cover the optimized hot paths.

## Local metrics from issue #45

Repeated local DB checks on the schema v4 index showed:

- Exact `python311`: ~365 ms median with prefix+filter before, ~0.039 ms median with exact lookup.
- Completion `python%`: ~41 ms median with `LIKE` over version rows before, ~0.021–0.045 ms median via optimized/cache-backed prefix lookup.
- Stats bundle: ~619 ms median before, ~1.62 ms median with cached package aggregates plus channel coverage.
- `package_attrs` one-time refresh on local DB: ~2.14s.
- All unique attrs from cache: ~57 ms vs ~1.88s `DISTINCT` over `package_versions`.

## Review follow-ups addressed

Codex peer review was run repeatedly against `origin/main`. Findings were fixed as separate commits, including:

- Refresh derived caches after delta imports.
- Make stats cache writes atomic and validate cache completeness.
- Preserve case-insensitive prefix semantics for completion/search paths.
- Preserve legacy history grouping for pre-v4 databases.
- Invalidate caches for delta-pack imports.
- Invalidate caches for direct `Database::upsert_observations` writes.

A final Codex review after the last fix reported no discrete correctness issues.

## Validation

- `cargo test --features indexer --quiet` — 343 passed, 1 ignored.
- `cargo test --benches --quiet` — unit/integration tests plus benchmark compile/run checks passed.
- `cargo clippy --features indexer -- -D warnings` — passed.
