### PR TITLE
perf(db): accelerate cold prefix searches

### DIFF
--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -66,6 +66,13 @@ fn create_benchmark_db(
         CREATE INDEX idx_packages_name ON package_versions(name);
         CREATE INDEX idx_packages_name_version ON package_versions(name, version, first_commit_date);
         CREATE INDEX idx_packages_attr ON package_versions(attribute_path);
+        CREATE INDEX idx_packages_search_nocase ON package_versions(
+            attribute_path COLLATE NOCASE,
+            version COLLATE NOCASE,
+            (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+            last_commit_date DESC,
+            first_commit_date DESC
+        );
         CREATE INDEX idx_packages_first_date ON package_versions(first_commit_date DESC);
         CREATE INDEX idx_packages_last_date ON package_versions(last_commit_date DESC);
         CREATE INDEX idx_version_vulnerabilities ON package_versions(version)
@@ -184,7 +191,7 @@ fn bench_exact_lookup(c: &mut Criterion) {
                 b.iter(|| {
                     let sql = format!(
                         "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' \
-                     ORDER BY {depth} ASC, last_commit_date DESC LIMIT 5000"
+                     ORDER BY {depth} ASC, last_commit_date DESC, id ASC LIMIT 5000"
                     );
                     let rows: Vec<String> = conn
                         .prepare_cached(&sql)
@@ -234,7 +241,7 @@ fn bench_prefix_version_search(c: &mut Criterion) {
                 let sql = format!(
                     "SELECT * FROM package_versions \
                      WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
-                     ORDER BY {depth} ASC, first_commit_date DESC LIMIT 5000"
+                     ORDER BY {depth} ASC, first_commit_date DESC, id ASC LIMIT 5000"
                 );
                 let rows: Vec<String> = conn
                     .prepare_cached(&sql)
@@ -252,7 +259,7 @@ fn bench_prefix_version_search(c: &mut Criterion) {
                 let sql = format!(
                     "SELECT * FROM package_versions \
                      WHERE attribute_path >= ? AND attribute_path < ? AND version LIKE ? ESCAPE '\\' \
-                     ORDER BY {depth} ASC, first_commit_date DESC LIMIT 5000"
+                     ORDER BY {depth} ASC, first_commit_date DESC, id ASC LIMIT 5000"
                 );
                 let rows: Vec<String> = conn
                     .prepare_cached(&sql)
@@ -266,6 +273,37 @@ fn bench_prefix_version_search(c: &mut Criterion) {
                 black_box(rows)
             });
         });
+
+        group.bench_with_input(
+            BenchmarkId::new("covering_candidates", size),
+            size,
+            |b, _| {
+                b.iter(|| {
+                    let sql = format!(
+                        "WITH candidates AS MATERIALIZED ( \
+                             SELECT id, {depth} AS attr_depth, first_commit_date AS rank_date \
+                               FROM package_versions \
+                              WHERE attribute_path LIKE ? ESCAPE '\\' \
+                                AND version LIKE ? ESCAPE '\\' \
+                              ORDER BY attr_depth ASC, first_commit_date DESC, id ASC \
+                              LIMIT 5000 \
+                         ) \
+                         SELECT pv.attribute_path \
+                           FROM candidates c \
+                           JOIN package_versions pv ON pv.id = c.id \
+                          ORDER BY c.attr_depth ASC, c.rank_date DESC, c.id ASC"
+                    );
+                    let rows: Vec<String> = conn
+                        .prepare_cached(&sql)
+                        .unwrap()
+                        .query_map(["python311%", "3.11%"], |row| row.get(0))
+                        .unwrap()
+                        .filter_map(Result::ok)
+                        .collect();
+                    black_box(rows)
+                });
+            },
+        );
     }
 
     group.finish();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -226,6 +226,17 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_packages_name ON package_versions(name);
             CREATE INDEX IF NOT EXISTS idx_packages_name_version ON package_versions(name, version, first_commit_date);
             CREATE INDEX IF NOT EXISTS idx_packages_attr ON package_versions(attribute_path);
+            -- Cover the fields needed to rank prefix-search candidates before
+            -- fetching full rows. NOCASE matches SQLite LIKE's established
+            -- ASCII-case-insensitive behavior; the expression stores attribute
+            -- depth without adding a derived table column.
+            CREATE INDEX IF NOT EXISTS idx_packages_search_nocase ON package_versions(
+                attribute_path COLLATE NOCASE,
+                version COLLATE NOCASE,
+                (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+                last_commit_date DESC,
+                first_commit_date DESC
+            );
             CREATE INDEX IF NOT EXISTS idx_packages_first_date ON package_versions(first_commit_date DESC);
             CREATE INDEX IF NOT EXISTS idx_packages_last_date ON package_versions(last_commit_date DESC);
             "#,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -24,6 +24,30 @@ pub const SCHEMA_VERSION: u32 = 4;
 /// Indexes with min_schema_version > this value are incompatible.
 pub const MIN_READABLE_SCHEMA: u32 = 4;
 
+/// Name of the covering prefix-search index (see `queries.rs` candidate CTE).
+pub const SEARCH_INDEX_NAME: &str = "idx_packages_search_nocase";
+
+/// `meta` flag set while the covering search index is intentionally dropped for
+/// a bulk run. It suppresses `init_schema`'s eager recreation so a crash between
+/// [`Database::drop_search_index`] and [`Database::rebuild_search_index`] does
+/// not force the next `Database::open` to rebuild a ~48s index that the resumed
+/// bulk run would immediately drop again. Cleared atomically by the rebuild.
+const SEARCH_INDEX_DROPPED_META: &str = "search_index_dropped";
+
+/// DDL for the covering search index. Shared by `init_schema` and
+/// [`Database::rebuild_search_index`] so the two definitions can never drift.
+/// NOCASE matches SQLite LIKE's established ASCII-case-insensitive behavior;
+/// the expression stores attribute depth without adding a derived table column.
+const CREATE_SEARCH_INDEX_SQL: &str = r#"
+    CREATE INDEX IF NOT EXISTS idx_packages_search_nocase ON package_versions(
+        attribute_path COLLATE NOCASE,
+        version COLLATE NOCASE,
+        (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+        last_commit_date DESC,
+        first_commit_date DESC
+    );
+"#;
+
 /// Database connection wrapper.
 pub struct Database {
     conn: Connection,
@@ -226,21 +250,20 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_packages_name ON package_versions(name);
             CREATE INDEX IF NOT EXISTS idx_packages_name_version ON package_versions(name, version, first_commit_date);
             CREATE INDEX IF NOT EXISTS idx_packages_attr ON package_versions(attribute_path);
-            -- Cover the fields needed to rank prefix-search candidates before
-            -- fetching full rows. NOCASE matches SQLite LIKE's established
-            -- ASCII-case-insensitive behavior; the expression stores attribute
-            -- depth without adding a derived table column.
-            CREATE INDEX IF NOT EXISTS idx_packages_search_nocase ON package_versions(
-                attribute_path COLLATE NOCASE,
-                version COLLATE NOCASE,
-                (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
-                last_commit_date DESC,
-                first_commit_date DESC
-            );
             CREATE INDEX IF NOT EXISTS idx_packages_first_date ON package_versions(first_commit_date DESC);
             CREATE INDEX IF NOT EXISTS idx_packages_last_date ON package_versions(last_commit_date DESC);
             "#,
         )?;
+
+        // The covering prefix-search index is created here (not in the batch
+        // above) and gated on the drop marker: a bulk run drops it to avoid
+        // date-widen write amplification, and this open must NOT eagerly
+        // rebuild it while that run is mid-flight or being resumed. When the
+        // marker is clear (steady state) this is a cheap `IF NOT EXISTS` no-op.
+        // See drop_search_index / rebuild_search_index for the full lifecycle.
+        if self.get_meta(SEARCH_INDEX_DROPPED_META)?.as_deref() != Some("1") {
+            self.conn.execute_batch(CREATE_SEARCH_INDEX_SQL)?;
+        }
 
         // Keep the derived attr table upgradeable without a schema bump: it is
         // strictly a cache and can be rebuilt from package_versions.
@@ -641,6 +664,75 @@ impl Database {
             END;
             "#,
         )?;
+        Ok(())
+    }
+
+    /// True when the covering prefix-search index (`idx_packages_search_nocase`)
+    /// is present. This is the source of truth for search/publish readiness: an
+    /// absent index means prefix searches fall back to the slow full scan.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn search_index_present(&self) -> Result<bool> {
+        let present: bool = self.conn.query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='index' AND name=?",
+            [SEARCH_INDEX_NAME],
+            |row| row.get(0),
+        )?;
+        Ok(present)
+    }
+
+    /// Drop the covering search index for bulk ingestion.
+    ///
+    /// The widen-only upsert touches `first_commit_date`/`last_commit_date` on
+    /// nearly every alive attr per snapshot; with the covering index live that
+    /// costs 2.70x the WAL frames and 1.99x the date-update work. A large
+    /// catch-up run drops the index up front and rebuilds it once at the finish
+    /// path ([`Self::rebuild_search_index`]).
+    ///
+    /// The drop and the [`SEARCH_INDEX_DROPPED_META`] marker commit together, so
+    /// a crash before the rebuild leaves a recoverable state: `init_schema` will
+    /// not eagerly recreate the index and the next writable run restores it
+    /// deterministically. Idempotent (`DROP INDEX IF EXISTS`).
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn drop_search_index(&self) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, '1')",
+            [SEARCH_INDEX_DROPPED_META],
+        )?;
+        tx.execute_batch(&format!("DROP INDEX IF EXISTS {SEARCH_INDEX_NAME};"))?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Rebuild the covering search index and clear the drop marker.
+    ///
+    /// Recreates the index dropped by [`Self::drop_search_index`] and clears
+    /// [`SEARCH_INDEX_DROPPED_META`] in the same transaction, so the marker is
+    /// only cleared once the index is actually present. If index creation fails
+    /// the transaction rolls back, the marker stays set, and the error
+    /// propagates — readiness is never falsely signalled.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn rebuild_search_index(&self) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute_batch(CREATE_SEARCH_INDEX_SQL)?;
+        // Guard against a name squatted by a non-index object (e.g. a table):
+        // `CREATE INDEX IF NOT EXISTS` would no-op, leaving no real index. Never
+        // clear the marker unless a genuine index now exists.
+        let present: bool = tx.query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='index' AND name=?",
+            [SEARCH_INDEX_NAME],
+            |row| row.get(0),
+        )?;
+        if !present {
+            return Err(NxvError::CorruptIndex(format!(
+                "failed to build covering search index '{SEARCH_INDEX_NAME}'"
+            )));
+        }
+        tx.execute(
+            "DELETE FROM meta WHERE key = ?",
+            [SEARCH_INDEX_DROPPED_META],
+        )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -1566,6 +1658,171 @@ mod tests {
         assert_eq!(
             fts_hits, 1,
             "rows written while triggers were absent must be re-indexed"
+        );
+    }
+
+    /// A fresh database opens with the covering search index present and no
+    /// drop marker, so ordinary reads plan through it immediately.
+    #[test]
+    fn test_search_index_present_on_fresh_open() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        assert!(db.search_index_present().unwrap());
+        assert!(db.get_meta(SEARCH_INDEX_DROPPED_META).unwrap().is_none());
+    }
+
+    /// drop_search_index removes the index and records the marker; the finish
+    /// path's rebuild restores the index and clears the marker.
+    #[test]
+    fn test_search_index_drop_rebuild_roundtrip() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+
+        db.drop_search_index().unwrap();
+        assert!(!db.search_index_present().unwrap());
+        assert_eq!(
+            db.get_meta(SEARCH_INDEX_DROPPED_META).unwrap().as_deref(),
+            Some("1"),
+            "drop must record the marker so a crash is recoverable"
+        );
+
+        // Idempotent: dropping again is a harmless no-op.
+        db.drop_search_index().unwrap();
+        assert!(!db.search_index_present().unwrap());
+
+        db.rebuild_search_index().unwrap();
+        assert!(db.search_index_present().unwrap());
+        assert!(
+            db.get_meta(SEARCH_INDEX_DROPPED_META).unwrap().is_none(),
+            "rebuild must clear the marker once the index exists"
+        );
+    }
+
+    /// The drop marker must survive a reopen and suppress init_schema's eager
+    /// rebuild — otherwise a crash-recovery open would rebuild a ~48s index the
+    /// resumed bulk run drops again.
+    #[test]
+    fn test_dropped_marker_suppresses_init_schema_rebuild() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        {
+            let db = Database::open(&db_path).unwrap();
+            db.drop_search_index().unwrap();
+            assert!(!db.search_index_present().unwrap());
+        }
+
+        // Reopen as the next run's Database::open would.
+        let db = Database::open(&db_path).unwrap();
+        assert!(
+            !db.search_index_present().unwrap(),
+            "init_schema must NOT recreate the index while the drop marker is set"
+        );
+        assert_eq!(
+            db.get_meta(SEARCH_INDEX_DROPPED_META).unwrap().as_deref(),
+            Some("1")
+        );
+
+        // Deterministic recovery: rebuild restores readiness and clears state.
+        db.rebuild_search_index().unwrap();
+        assert!(db.search_index_present().unwrap());
+
+        // A subsequent reopen keeps the index (marker cleared, IF NOT EXISTS).
+        drop(db);
+        let db = Database::open(&db_path).unwrap();
+        assert!(db.search_index_present().unwrap());
+    }
+
+    /// Simulate the indexer's bulk lifecycle at the DB layer (mirrors
+    /// test_fts_triggers_missing_detection_and_heal): drop for bulk, ingest,
+    /// rebuild at finish, and heal an interruption on the next open.
+    #[test]
+    fn test_search_index_bulk_lifecycle_and_recovery() {
+        use chrono::Utc;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let now = Utc::now();
+        let pkg = |attr: &str, ver: &str| PackageVersion {
+            id: 0,
+            name: attr.to_string(),
+            version: ver.to_string(),
+            first_commit_hash: "a".repeat(40),
+            first_commit_date: now,
+            last_commit_hash: "a".repeat(40),
+            last_commit_date: now,
+            attribute_path: attr.to_string(),
+            description: None,
+            license: None,
+            homepage: None,
+            maintainers: None,
+            platforms: None,
+            source_path: None,
+            known_vulnerabilities: None,
+        };
+
+        // Normal bulk completion: drop → ingest → rebuild leaves the index up.
+        {
+            let mut db = Database::open(&db_path).unwrap();
+            db.drop_search_index().unwrap();
+            db.upsert_observations(&[pkg("ripgrep", "14.0.0")]).unwrap();
+            db.rebuild_search_index().unwrap();
+            assert!(db.search_index_present().unwrap());
+            assert!(db.get_meta(SEARCH_INDEX_DROPPED_META).unwrap().is_none());
+        }
+
+        // Interrupted bulk: drop, write, then die before the rebuild.
+        {
+            let mut db = Database::open(&db_path).unwrap();
+            db.drop_search_index().unwrap();
+            db.upsert_observations(&[pkg("fd", "10.0.0")]).unwrap();
+            // no rebuild — simulate a kill/OOM/power loss here.
+        }
+
+        // Next writable open detects the missing index and heals it. Results are
+        // still correct either way (planner falls back to the scan), which we
+        // confirm before and after the rebuild.
+        let db = Database::open(&db_path).unwrap();
+        assert!(!db.search_index_present().unwrap());
+        let before = crate::db::queries::search_by_attr(db.connection(), "fd").unwrap();
+        db.rebuild_search_index().unwrap();
+        assert!(db.search_index_present().unwrap());
+        let after = crate::db::queries::search_by_attr(db.connection(), "fd").unwrap();
+        assert_eq!(
+            before.len(),
+            after.len(),
+            "fallback and indexed paths must agree"
+        );
+        assert!(after.iter().any(|p| p.attribute_path == "fd"));
+    }
+
+    /// If the index cannot actually be built (its name is squatted by another
+    /// object), rebuild must error and must NOT clear the drop marker — so the
+    /// next run still recovers instead of trusting a falsely-ready database.
+    #[test]
+    fn test_search_index_rebuild_failure_keeps_marker() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+
+        db.drop_search_index().unwrap();
+        // Squat the index name with a table so CREATE INDEX IF NOT EXISTS cannot
+        // produce a real index.
+        db.conn
+            .execute_batch("CREATE TABLE idx_packages_search_nocase (x);")
+            .unwrap();
+
+        // The rebuild errors (either SQLite's name-clash error or our own guard
+        // when a version no-ops the CREATE); what matters is that it fails and
+        // leaves the recovery state intact.
+        assert!(db.rebuild_search_index().is_err());
+        assert!(!db.search_index_present().unwrap());
+        assert_eq!(
+            db.get_meta(SEARCH_INDEX_DROPPED_META).unwrap().as_deref(),
+            Some("1"),
+            "a failed rebuild must leave the marker set for recovery"
         );
     }
 

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -389,8 +389,17 @@ pub fn search_by_attr_exact(
 /// Search for packages by attribute path prefix.
 pub fn search_by_attr(conn: &rusqlite::Connection, attr_path: &str) -> Result<Vec<PackageVersion>> {
     let mut stmt = conn.prepare(&format!(
-        "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' \
-         ORDER BY {ATTR_DEPTH_RANK} ASC, last_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
+        "WITH candidates AS MATERIALIZED ( \
+             SELECT id, {ATTR_DEPTH_RANK} AS attr_depth, last_commit_date AS rank_date \
+               FROM package_versions \
+              WHERE attribute_path LIKE ? ESCAPE '\\' \
+              ORDER BY attr_depth ASC, last_commit_date DESC, id ASC \
+              LIMIT {SEARCH_SQL_CAP} \
+         ) \
+         SELECT pv.* \
+           FROM candidates c \
+           JOIN package_versions pv ON pv.id = c.id \
+          ORDER BY c.attr_depth ASC, c.rank_date DESC, c.id ASC"
     ))?;
     let pattern = format!("{}%", escape_like_pattern(attr_path));
     let rows = stmt.query_map([&pattern], PackageVersion::from_row)?;
@@ -432,8 +441,18 @@ pub fn search_by_name_version(
     // unversioned prefix searches agree for mixed-case package-set segments
     // such as `python313Packages`.
     let mut stmt = conn.prepare(&format!(
-        "SELECT * FROM package_versions WHERE attribute_path LIKE ? ESCAPE '\\' AND version LIKE ? ESCAPE '\\' \
-         ORDER BY {ATTR_DEPTH_RANK} ASC, first_commit_date DESC LIMIT {SEARCH_SQL_CAP}"
+        "WITH candidates AS MATERIALIZED ( \
+             SELECT id, {ATTR_DEPTH_RANK} AS attr_depth, first_commit_date AS rank_date \
+               FROM package_versions \
+              WHERE attribute_path LIKE ? ESCAPE '\\' \
+                AND version LIKE ? ESCAPE '\\' \
+              ORDER BY attr_depth ASC, first_commit_date DESC, id ASC \
+              LIMIT {SEARCH_SQL_CAP} \
+         ) \
+         SELECT pv.* \
+           FROM candidates c \
+           JOIN package_versions pv ON pv.id = c.id \
+          ORDER BY c.attr_depth ASC, c.rank_date DESC, c.id ASC"
     ))?;
     let package_pattern = format!("{}%", escape_like_pattern(package));
     let version_pattern = format!("{}%", escape_like_pattern(version));
@@ -1181,6 +1200,213 @@ mod tests {
         let results = search_by_attr_exact(db.connection(), "python").unwrap();
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|p| p.attribute_path == "python"));
+    }
+
+    // --- Covering prefix-search candidate index (ticket: nxv-covering-prefix-search) ---
+
+    /// The unversioned prefix search must plan through the covering candidate
+    /// index rather than scanning the wide `package_versions` table.
+    #[test]
+    fn test_search_by_attr_uses_covering_prefix_index() {
+        let (_dir, db) = create_test_db();
+        let sql = format!(
+            "EXPLAIN QUERY PLAN WITH candidates AS MATERIALIZED ( \
+                 SELECT id, {ATTR_DEPTH_RANK} AS attr_depth, last_commit_date AS rank_date \
+                   FROM package_versions \
+                  WHERE attribute_path LIKE ? ESCAPE '\\' \
+                  ORDER BY attr_depth ASC, last_commit_date DESC, id ASC \
+                  LIMIT {SEARCH_SQL_CAP} \
+             ) \
+             SELECT pv.* FROM candidates c \
+             JOIN package_versions pv ON pv.id = c.id \
+             ORDER BY c.attr_depth ASC, c.rank_date DESC, c.id ASC"
+        );
+        let mut stmt = db.connection().prepare(&sql).unwrap();
+        let plan: Vec<String> = stmt
+            .query_map(["python%"], |row| row.get(3))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+
+        assert!(
+            plan.iter()
+                .any(|detail| detail.contains("COVERING INDEX idx_packages_search_nocase")),
+            "expected covering prefix index in query plan, got: {plan:?}"
+        );
+    }
+
+    /// The version-filtered prefix search must plan through the same covering
+    /// candidate index.
+    #[test]
+    fn test_search_by_name_version_uses_covering_prefix_index() {
+        let (_dir, db) = create_test_db();
+        let sql = format!(
+            "EXPLAIN QUERY PLAN WITH candidates AS MATERIALIZED ( \
+                 SELECT id, {ATTR_DEPTH_RANK} AS attr_depth, first_commit_date AS rank_date \
+                   FROM package_versions \
+                  WHERE attribute_path LIKE ? ESCAPE '\\' \
+                    AND version LIKE ? ESCAPE '\\' \
+                  ORDER BY attr_depth ASC, first_commit_date DESC, id ASC \
+                  LIMIT {SEARCH_SQL_CAP} \
+             ) \
+             SELECT pv.* FROM candidates c \
+             JOIN package_versions pv ON pv.id = c.id \
+             ORDER BY c.attr_depth ASC, c.rank_date DESC, c.id ASC"
+        );
+        let mut stmt = db.connection().prepare(&sql).unwrap();
+        let plan: Vec<String> = stmt
+            .query_map(["python%", "3.11%"], |row| row.get(3))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+
+        assert!(
+            plan.iter()
+                .any(|detail| detail.contains("COVERING INDEX idx_packages_search_nocase")),
+            "expected covering prefix index in query plan, got: {plan:?}"
+        );
+    }
+
+    /// An old v4 database that predates the covering index must still return
+    /// identical results through the scan fallback.
+    #[test]
+    fn test_search_by_attr_is_compatible_without_covering_index() {
+        let (_dir, db) = create_test_db();
+        let indexed_ids: Vec<i64> = search_by_attr(db.connection(), "python")
+            .unwrap()
+            .into_iter()
+            .map(|package| package.id)
+            .collect();
+
+        db.connection()
+            .execute("DROP INDEX idx_packages_search_nocase", [])
+            .unwrap();
+        let fallback_ids: Vec<i64> = search_by_attr(db.connection(), "python")
+            .unwrap()
+            .into_iter()
+            .map(|package| package.id)
+            .collect();
+
+        assert_eq!(fallback_ids, indexed_ids);
+    }
+
+    /// The version-filtered path is equally correct without the covering index.
+    #[test]
+    fn test_search_by_name_version_is_compatible_without_covering_index() {
+        let (_dir, db) = create_test_db();
+        let indexed_ids: Vec<i64> = search_by_name_version(db.connection(), "python", "3.1")
+            .unwrap()
+            .into_iter()
+            .map(|package| package.id)
+            .collect();
+
+        db.connection()
+            .execute("DROP INDEX idx_packages_search_nocase", [])
+            .unwrap();
+        let fallback_ids: Vec<i64> = search_by_name_version(db.connection(), "python", "3.1")
+            .unwrap()
+            .into_iter()
+            .map(|package| package.id)
+            .collect();
+
+        assert_eq!(fallback_ids, indexed_ids);
+        assert_eq!(indexed_ids.len(), 2); // python 3.11.0 and 3.12.0
+    }
+
+    /// When attribute depth and rank date tie, `id ASC` is the deterministic
+    /// final tie-breaker for the unversioned path.
+    #[test]
+    fn test_search_by_attr_deterministic_id_tie() {
+        let (_dir, db) = create_test_db();
+        // Two rows with identical depth (1 dot) and identical last_commit_date,
+        // differing only by insertion order (id).
+        db.connection()
+            .execute(
+                r#"
+            INSERT INTO package_versions (name, version, first_commit_hash, first_commit_date,
+                last_commit_hash, last_commit_date, attribute_path, description)
+            VALUES
+                ('tie-a', '1.0', 'a', 1700000000, 'a', 1700000000, 'tiepkg.alpha', 't'),
+                ('tie-b', '1.0', 'b', 1700000000, 'b', 1700000000, 'tiepkg.beta', 't')
+            "#,
+                [],
+            )
+            .unwrap();
+
+        let ids: Vec<i64> = search_by_attr(db.connection(), "tiepkg")
+            .unwrap()
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids[0] < ids[1], "expected id ASC tie-break, got {ids:?}");
+    }
+
+    /// The version-filtered path applies the same `id ASC` tie-break.
+    #[test]
+    fn test_search_by_name_version_deterministic_id_tie() {
+        let (_dir, db) = create_test_db();
+        db.connection()
+            .execute(
+                r#"
+            INSERT INTO package_versions (name, version, first_commit_hash, first_commit_date,
+                last_commit_hash, last_commit_date, attribute_path, description)
+            VALUES
+                ('tie-a', '9.9.0', 'a', 1700000000, 'a', 1700000000, 'vtie.alpha', 't'),
+                ('tie-b', '9.9.0', 'b', 1700000000, 'b', 1700000000, 'vtie.beta', 't')
+            "#,
+                [],
+            )
+            .unwrap();
+
+        let ids: Vec<i64> = search_by_name_version(db.connection(), "vtie", "9.9")
+            .unwrap()
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids[0] < ids[1], "expected id ASC tie-break, got {ids:?}");
+    }
+
+    /// Literal `_`/`%` in the query must stay literal through the covering
+    /// candidate query (no wildcard injection).
+    #[test]
+    fn test_search_by_attr_escapes_literal_wildcards() {
+        let (_dir, db) = create_test_db();
+        db.connection()
+            .execute(
+                r#"
+            INSERT INTO package_versions (name, version, first_commit_hash, first_commit_date,
+                last_commit_hash, last_commit_date, attribute_path, description)
+            VALUES ('under', '1.0', 'a', 1700000000, 'a', 1700100000, 'python_test', 'u')
+            "#,
+                [],
+            )
+            .unwrap();
+
+        // `python_` must match only the literal underscore row, not `python2`.
+        let results = search_by_attr(db.connection(), "python_").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].attribute_path, "python_test");
+    }
+
+    /// Mixed-case prefixes match through the ASCII-case-insensitive covering
+    /// index, preserving SQLite LIKE's historical behavior.
+    #[test]
+    fn test_search_by_attr_mixed_case_prefix() {
+        let (_dir, db) = create_test_db();
+        let upper: Vec<String> = search_by_attr(db.connection(), "PYTHON")
+            .unwrap()
+            .into_iter()
+            .map(|p| p.attribute_path)
+            .collect();
+        let lower: Vec<String> = search_by_attr(db.connection(), "python")
+            .unwrap()
+            .into_iter()
+            .map(|p| p.attribute_path)
+            .collect();
+        assert_eq!(upper, lower);
+        assert_eq!(upper.len(), 3);
     }
 
     #[test]

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -177,6 +177,20 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         ..Default::default()
     };
 
+    let bulk = worklist.len() >= FTS_BULK_THRESHOLD;
+
+    // Search-index recovery. A bulk run drops the covering index and rebuilds
+    // it at the finish path; if a previous bulk run was interrupted,
+    // `Database::open` left the index absent (the drop marker suppresses
+    // init_schema's eager rebuild). Restore it now UNLESS this run is itself
+    // bulk and will drop it again anyway — rebuilding a ~48s index only to
+    // immediately drop it is pure waste. A non-bulk or no-work run must leave
+    // the database search-ready.
+    if !bulk && !db.search_index_present()? {
+        progress("rebuilding search index (recovering interrupted bulk run)...");
+        db.rebuild_search_index()?;
+    }
+
     if worklist.is_empty() {
         progress("nothing to ingest: all known releases are settled");
     } else {
@@ -187,9 +201,12 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
                 .unwrap_or(2)
         });
 
-        let bulk = worklist.len() >= FTS_BULK_THRESHOLD;
+        // Bulk catch-up: drop the FTS triggers and the covering search index so
+        // the widen-only upserts avoid recurring write amplification; both are
+        // rebuilt on the finish path below before the run returns.
         if bulk {
             db.drop_fts_triggers()?;
+            db.drop_search_index()?;
         }
 
         let outcome = ingest_worklist(
@@ -203,9 +220,15 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
             &progress,
         );
 
+        // Rebuild before propagating any ingest error so the database is left
+        // search/publish ready. A rebuild failure here propagates (leaving the
+        // drop marker set for the next run to recover) rather than returning a
+        // falsely-ready database.
         if bulk {
             progress("rebuilding FTS index...");
             db.rebuild_fts()?;
+            progress("rebuilding search index...");
+            db.rebuild_search_index()?;
         }
         outcome?;
     }

--- a/src/index/publisher.rs
+++ b/src/index/publisher.rs
@@ -438,6 +438,31 @@ pub fn generate_full_index<P: AsRef<Path>, Q: AsRef<Path>>(
         )));
     }
 
+    // Search-index readiness gate: the covering index must ship with the
+    // published database, or every client inherits the slow full-scan cold
+    // path. A crash mid-bulk can leave it dropped (the drop marker suppresses
+    // init_schema's auto-rebuild on open), so repair it here, then validate —
+    // never silently ship a missing-index artifact.
+    if !db.search_index_present()? {
+        if show_progress {
+            eprintln!("  Covering search index missing; rebuilding before publish...");
+        }
+        if let Err(e) = db.rebuild_search_index() {
+            return Err(NxvError::CorruptIndex(format!(
+                "covering search index '{}' is missing and could not be rebuilt ({e}); \
+                 refusing to publish the slow full-scan artifact",
+                crate::db::SEARCH_INDEX_NAME
+            )));
+        }
+    }
+    if !db.search_index_present()? {
+        return Err(NxvError::CorruptIndex(format!(
+            "covering search index '{}' is missing; \
+             refusing to publish the slow full-scan artifact",
+            crate::db::SEARCH_INDEX_NAME
+        )));
+    }
+
     // Set the indexed date to now (publish time) so it matches the manifest
     db.set_meta("last_indexed_date", &Utc::now().to_rfc3339())?;
     // Write min_schema_version to database for direct-download validation
@@ -736,6 +761,70 @@ mod tests {
             "#,
         )
         .unwrap();
+    }
+
+    /// Force the crash-recovery state on a publishable database: the covering
+    /// index dropped and the drop marker set, so `Database::open`'s init_schema
+    /// leaves it absent.
+    fn strand_search_index(path: &Path) {
+        let db = Database::open(path).unwrap();
+        db.drop_search_index().unwrap();
+        assert!(!db.search_index_present().unwrap());
+    }
+
+    #[test]
+    fn test_generate_full_index_repairs_missing_search_index() {
+        use crate::remote::download::decompress_zstd;
+
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let output_dir = dir.path().join("output");
+
+        create_test_db(&db_path);
+        strand_search_index(&db_path);
+
+        // Publishing must repair the stranded index, not ship the slow artifact.
+        generate_full_index(&db_path, &output_dir, None, None, false, None).unwrap();
+
+        let compressed_path = output_dir.join(INDEX_DB_NAME);
+        let decompressed_path = dir.path().join("decompressed.db");
+        decompress_zstd(&compressed_path, &decompressed_path, false).unwrap();
+
+        let db = Database::open(&decompressed_path).unwrap();
+        assert!(
+            db.search_index_present().unwrap(),
+            "published database must carry the covering search index"
+        );
+        assert!(
+            db.get_meta("search_index_dropped").unwrap().is_none(),
+            "publish repair must clear the drop marker"
+        );
+    }
+
+    #[test]
+    fn test_generate_full_index_refuses_when_search_index_cannot_be_built() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let output_dir = dir.path().join("output");
+
+        create_test_db(&db_path);
+        strand_search_index(&db_path);
+
+        // Squat the index name with a table so the publish-time rebuild cannot
+        // produce a real index; publishing must refuse rather than ship it.
+        {
+            let db = Database::open(&db_path).unwrap();
+            db.connection()
+                .execute_batch("CREATE TABLE idx_packages_search_nocase (x);")
+                .unwrap();
+        }
+
+        let err = generate_full_index(&db_path, &output_dir, None, None, false, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("refusing to publish") && msg.contains("search index"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -585,3 +585,282 @@ mod proptests {
         }
     }
 }
+
+/// Prove the covering candidate index and the scan fallback yield identical
+/// observable output through the full `execute_search` pipeline — license
+/// filtering, sorting, dedup/full, `--limit 0`, and offset pagination across
+/// tie boundaries. Each test builds two databases with identical rows: one
+/// carrying `idx_packages_search_nocase`, one with it dropped so its candidate
+/// queries take the scan path. A green assertion therefore means the changed
+/// indexed path matches the fallback observably, not that both ran the fallback.
+#[cfg(test)]
+mod indexed_parity_tests {
+    use super::*;
+    use crate::db::Database;
+    use tempfile::{TempDir, tempdir};
+
+    // Rows are hand-tuned so higher-level modes are non-trivial. The production
+    // schema enforces UNIQUE(attribute_path, version) and
+    // CHECK(first_commit_date <= last_commit_date), so every row is a distinct
+    // pair with first_date <= last_date:
+    //  * `parity.alpha/bravo/charlie` share depth and `last_commit_date`,
+    //    forcing sort ties that only the SQL `id ASC` tie-break resolves
+    //    deterministically; `charlie` is GPL so a `license` filter drops it;
+    //  * `vpar.*` exercise the version-filtered path (`vpar.four` is excluded by
+    //    a `1` version prefix);
+    //  * `lw%hit` / `lw_hit` / `lwXhit` verify literal `%` and `_` handling.
+    const SEED: &str = r#"
+        INSERT INTO package_versions
+            (name, version, first_commit_hash, first_commit_date,
+             last_commit_hash, last_commit_date, attribute_path, description, license)
+        VALUES
+            ('aaa', '1.0.0', 'h1',  100, 'l1', 900, 'parity.alpha',   'd', 'MIT'),
+            ('bbb', '1.0.0', 'h2',  100, 'l2', 900, 'parity.bravo',   'd', 'MIT'),
+            ('ccc', '1.0.0', 'h3',  100, 'l3', 900, 'parity.charlie', 'd', 'GPL-3.0'),
+            ('ddd', '2.0.0', 'h4',  200, 'l4', 800, 'parity.delta',   'd', 'MIT'),
+            ('eee', '2.0.0', 'h5',  200, 'l5', 700, 'parity.echo',    'd', 'MIT'),
+            ('vaa', '1.1.0', 'h7',  300, 'l7', 600, 'vpar.one',       'd', 'MIT'),
+            ('vbb', '1.1.0', 'h8',  300, 'l8', 600, 'vpar.two',       'd', 'MIT'),
+            ('vcc', '1.2.0', 'h9',  300, 'l9', 650, 'vpar.three',     'd', 'MIT'),
+            ('vdd', '2.0.0', 'h10', 300, 'la', 660, 'vpar.four',      'd', 'MIT'),
+            ('lw1', '1.0.0', 'h11', 400, 'lb', 500, 'lw%hit',         'd', 'MIT'),
+            ('lw2', '1.0.0', 'h12', 400, 'lc', 500, 'lw_hit',         'd', 'MIT'),
+            ('lw3', '1.0.0', 'h13', 400, 'ld', 500, 'lwXhit',         'd', 'MIT');
+    "#;
+
+    fn index_present(db: &Database) -> bool {
+        db.connection()
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_packages_search_nocase'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+            > 0
+    }
+
+    /// `(dir, indexed, fallback)` seeded identically; `fallback` has the covering
+    /// index dropped so its candidate queries take the scan path.
+    fn parity_dbs() -> (TempDir, Database, Database) {
+        let dir = tempdir().unwrap();
+        let indexed = Database::open(dir.path().join("indexed.db")).unwrap();
+        indexed.connection().execute_batch(SEED).unwrap();
+        let fallback = Database::open(dir.path().join("fallback.db")).unwrap();
+        fallback.connection().execute_batch(SEED).unwrap();
+        fallback
+            .connection()
+            .execute("DROP INDEX idx_packages_search_nocase", [])
+            .unwrap();
+
+        // Guard: the two databases genuinely differ in the covering index, so a
+        // green parity assertion can never mean "both fell back to the scan".
+        assert!(
+            index_present(&indexed),
+            "indexed db must carry the covering index"
+        );
+        assert!(
+            !index_present(&fallback),
+            "fallback db must not carry the covering index"
+        );
+        (dir, indexed, fallback)
+    }
+
+    fn ids(result: &SearchResult) -> Vec<i64> {
+        result.data.iter().map(|p| p.id).collect()
+    }
+
+    fn base(query: &str) -> SearchOptions {
+        SearchOptions {
+            query: query.to_string(),
+            limit: 50,
+            ..Default::default()
+        }
+    }
+
+    /// `execute_search` must agree on rows, order, total, and `has_more` across
+    /// both databases for the given options.
+    fn assert_parity(indexed: &Database, fallback: &Database, opts: &SearchOptions) {
+        let a = execute_search(indexed.connection(), opts).unwrap();
+        let b = execute_search(fallback.connection(), opts).unwrap();
+        assert_eq!(ids(&a), ids(&b), "row id order diverged for {opts:?}");
+        assert_eq!(a.total, b.total, "total diverged for {opts:?}");
+        assert_eq!(a.has_more, b.has_more, "has_more diverged for {opts:?}");
+    }
+
+    #[test]
+    fn indexed_matches_fallback_across_filter_sort_full_and_limit() {
+        let (_dir, indexed, fallback) = parity_dbs();
+
+        let mut matrix: Vec<SearchOptions> = vec![
+            base("parity"),
+            SearchOptions {
+                license: Some("mit".to_string()),
+                ..base("parity")
+            },
+            SearchOptions {
+                full: true,
+                ..base("parity")
+            },
+            SearchOptions {
+                limit: 0,
+                ..base("parity")
+            },
+        ];
+        for sort in [SortOrder::Date, SortOrder::Version, SortOrder::Name] {
+            for reverse in [false, true] {
+                matrix.push(SearchOptions {
+                    sort,
+                    reverse,
+                    ..base("parity")
+                });
+            }
+        }
+
+        for opts in &matrix {
+            assert_parity(&indexed, &fallback, opts);
+        }
+
+        // Sanity: the license filter actually changes the set, so the parity
+        // above is meaningful rather than vacuous. (Production's
+        // UNIQUE(attribute_path, version) means dedup and `--full` return the
+        // same rows on real data, so only their cross-path agreement is
+        // asserted, not a count difference.)
+        let all = execute_search(indexed.connection(), &base("parity")).unwrap();
+        assert_eq!(all.total, 5, "five distinct parity rows expected");
+        let mit = execute_search(
+            indexed.connection(),
+            &SearchOptions {
+                license: Some("mit".to_string()),
+                ..base("parity")
+            },
+        )
+        .unwrap();
+        assert!(
+            mit.total < all.total,
+            "expected license filter to drop the GPL row"
+        );
+    }
+
+    #[test]
+    fn indexed_offset_pagination_is_deterministic_across_ties() {
+        let (_dir, indexed, fallback) = parity_dbs();
+
+        // Walk fixed-size pages and confirm both databases return the same page
+        // at every offset — including across the `parity.*` tie boundary.
+        for offset in [0, 2, 4, 6] {
+            assert_parity(
+                &indexed,
+                &fallback,
+                &SearchOptions {
+                    limit: 2,
+                    offset,
+                    ..base("parity")
+                },
+            );
+        }
+
+        // Concatenating pages must reconstruct the unpaginated order exactly, so
+        // no tie row is dropped or repeated across a page boundary.
+        let full_ids = ids(&execute_search(
+            indexed.connection(),
+            &SearchOptions {
+                limit: 0,
+                ..base("parity")
+            },
+        )
+        .unwrap());
+        let mut paged: Vec<i64> = Vec::new();
+        let mut offset = 0;
+        loop {
+            let page = execute_search(
+                indexed.connection(),
+                &SearchOptions {
+                    limit: 2,
+                    offset,
+                    ..base("parity")
+                },
+            )
+            .unwrap();
+            if page.data.is_empty() {
+                break;
+            }
+            paged.extend(ids(&page));
+            offset += 2;
+            assert!(offset < 100, "pagination walk failed to terminate");
+        }
+        assert_eq!(
+            paged, full_ids,
+            "paged walk diverged from unpaginated order"
+        );
+    }
+
+    #[test]
+    fn indexed_matches_fallback_on_version_filtered_path() {
+        let (_dir, indexed, fallback) = parity_dbs();
+
+        let versioned = || SearchOptions {
+            version: Some("1".to_string()),
+            ..base("vpar")
+        };
+
+        // The `1` version prefix excludes `vpar.four` (2.0.0) on both paths.
+        let res = execute_search(indexed.connection(), &versioned()).unwrap();
+        assert_eq!(res.total, 3, "version prefix should keep only the 1.x rows");
+        assert!(res.data.iter().all(|p| p.version.starts_with('1')));
+
+        let mut matrix = vec![
+            versioned(),
+            SearchOptions {
+                sort: SortOrder::Version,
+                ..versioned()
+            },
+            SearchOptions {
+                full: true,
+                ..versioned()
+            },
+            SearchOptions {
+                limit: 0,
+                ..versioned()
+            },
+        ];
+        for offset in [0, 1, 2] {
+            matrix.push(SearchOptions {
+                limit: 1,
+                offset,
+                ..versioned()
+            });
+        }
+        for opts in &matrix {
+            assert_parity(&indexed, &fallback, opts);
+        }
+    }
+
+    #[test]
+    fn indexed_matches_fallback_on_literal_wildcards() {
+        let (_dir, indexed, fallback) = parity_dbs();
+
+        // Literal `%` must not act as a wildcard: only `lw%hit` matches, not the
+        // `lwXhit` decoy.
+        let pct = execute_search(indexed.connection(), &base("lw%")).unwrap();
+        assert_eq!(
+            pct.data
+                .iter()
+                .map(|p| p.attribute_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["lw%hit"]
+        );
+        assert_parity(&indexed, &fallback, &base("lw%"));
+
+        // Literal `_` must not act as a wildcard: only `lw_hit` matches.
+        let underscore = execute_search(indexed.connection(), &base("lw_hit")).unwrap();
+        assert_eq!(
+            underscore
+                .data
+                .iter()
+                .map(|p| p.attribute_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["lw_hit"]
+        );
+        assert_parity(&indexed, &fallback, &base("lw_hit"));
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -708,6 +708,15 @@ mod tests {
             );
             CREATE INDEX idx_packages_name ON package_versions(name);
             CREATE INDEX idx_packages_attr ON package_versions(attribute_path);
+            -- Carry the production covering index so API search/pagination tests
+            -- run the indexed candidate path, not only the scan fallback.
+            CREATE INDEX idx_packages_search_nocase ON package_versions(
+                attribute_path COLLATE NOCASE,
+                version COLLATE NOCASE,
+                (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+                last_commit_date DESC,
+                first_commit_date DESC
+            );
             CREATE VIRTUAL TABLE package_versions_fts USING fts5(
                 attribute_path, description, content='package_versions', content_rowid='id'
             );
@@ -1000,6 +1009,93 @@ mod tests {
         let data = json["data"].as_array().unwrap();
         assert_eq!(data.len(), 1);
         assert_eq!(json["meta"]["offset"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_pagination_deterministic_across_ties() {
+        // Rows that tie on attribute depth and last_commit_date: only the SQL
+        // `id ASC` tie-break gives them a stable order, so this exercises the
+        // indexed candidate path's determinism through the real API offset
+        // plumbing. Walking pages must reconstruct the unpaginated order with no
+        // row dropped or repeated across a page boundary.
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("ties.db");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                r#"
+                CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                CREATE TABLE package_versions (
+                    id INTEGER PRIMARY KEY, name TEXT NOT NULL, version TEXT NOT NULL,
+                    first_commit_hash TEXT NOT NULL, first_commit_date INTEGER NOT NULL,
+                    last_commit_hash TEXT NOT NULL, last_commit_date INTEGER NOT NULL,
+                    attribute_path TEXT NOT NULL, description TEXT, license TEXT,
+                    homepage TEXT, maintainers TEXT, platforms TEXT, source_path TEXT,
+                    known_vulnerabilities TEXT,
+                    UNIQUE(attribute_path, version, first_commit_hash)
+                );
+                CREATE INDEX idx_packages_search_nocase ON package_versions(
+                    attribute_path COLLATE NOCASE,
+                    version COLLATE NOCASE,
+                    (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+                    last_commit_date DESC,
+                    first_commit_date DESC
+                );
+                CREATE VIRTUAL TABLE package_versions_fts USING fts5(
+                    attribute_path, description, content='package_versions', content_rowid='id'
+                );
+                INSERT INTO meta (key, value) VALUES ('last_indexed_commit', 'abc');
+                INSERT INTO package_versions
+                    (name, version, first_commit_hash, first_commit_date,
+                     last_commit_hash, last_commit_date, attribute_path, description, license)
+                VALUES
+                    ('tie', '1.0', 't1', 100, 'x', 900, 'tiepkg.a', 'd', 'MIT'),
+                    ('tie', '1.0', 't2', 100, 'x', 900, 'tiepkg.b', 'd', 'MIT'),
+                    ('tie', '1.0', 't3', 100, 'x', 900, 'tiepkg.c', 'd', 'MIT'),
+                    ('tie', '1.0', 't4', 100, 'x', 900, 'tiepkg.d', 'd', 'MIT'),
+                    ('tie', '1.0', 't5', 100, 'x', 900, 'tiepkg.e', 'd', 'MIT');
+                INSERT INTO package_versions_fts (rowid, attribute_path, description)
+                SELECT id, attribute_path, description FROM package_versions;
+                "#,
+            )
+            .unwrap();
+        }
+
+        let state = Arc::new(AppState::new(db_path));
+        let app = build_router(state, None, None);
+
+        let attrs = |json: &Value| -> Vec<String> {
+            json["data"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|r| r["attribute_path"].as_str().unwrap().to_string())
+                .collect()
+        };
+
+        // Full unpaginated order.
+        let (_s, full_json) = get_json(&app, "/api/v1/search?q=tiepkg&limit=0").await;
+        let full = attrs(&full_json);
+        assert_eq!(full.len(), 5, "all five tie rows should be returned");
+
+        // Walk two-row pages; the concatenation must equal the full order.
+        let mut paged: Vec<String> = Vec::new();
+        let mut offset = 0;
+        loop {
+            let uri = format!("/api/v1/search?q=tiepkg&limit=2&offset={offset}");
+            let (_s, page_json) = get_json(&app, &uri).await;
+            let rows = attrs(&page_json);
+            if rows.is_empty() {
+                break;
+            }
+            paged.extend(rows);
+            offset += 2;
+            assert!(offset < 100, "pagination walk failed to terminate");
+        }
+        assert_eq!(
+            paged, full,
+            "API offset pagination diverged across a tie boundary"
+        );
     }
 
     #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2809,11 +2809,37 @@ fn test_index_end_to_end_with_mock_bucket() {
         .unwrap();
     assert_eq!(ingested, 2);
 
+    let search_index_present: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master \
+             WHERE type = 'index' AND name = 'idx_packages_search_nocase'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        search_index_present,
+        "a small index run must preserve the normally-maintained covering index"
+    );
+
     // Bloom filter must resolve dotted attrs (written next to the DB).
     let bloom_path = dir.path().join("index.bloom");
     assert!(bloom_path.exists(), "bloom filter should be written");
 
-    // Idempotence: a second run ingests nothing and stays healthy.
+    // Simulate an interrupted bulk run after its transactional marker+drop.
+    // The idempotent no-work run below must heal this state even though it has
+    // no package observations to write.
+    conn.execute_batch(
+        "BEGIN IMMEDIATE;
+         INSERT OR REPLACE INTO meta (key, value)
+         VALUES ('search_index_dropped', '1');
+         DROP INDEX idx_packages_search_nocase;
+         COMMIT;",
+    )
+    .unwrap();
+
+    // Idempotence: a second run ingests nothing, repairs the covering index,
+    // and stays healthy.
     nxv()
         .env("NXV_RELEASES_URL", server.url())
         .args([
@@ -2826,7 +2852,31 @@ fn test_index_end_to_end_with_mock_bucket() {
         .timeout(std::time::Duration::from_secs(60))
         .assert()
         .success()
-        .stderr(predicate::str::contains("nothing to ingest"));
+        .stderr(
+            predicate::str::contains("rebuilding search index")
+                .and(predicate::str::contains("nothing to ingest")),
+        );
+
+    let recovered: (bool, i64) = conn
+        .query_row(
+            "SELECT
+                 EXISTS(
+                     SELECT 1 FROM sqlite_master
+                     WHERE type = 'index' AND name = 'idx_packages_search_nocase'
+                 ),
+                 (SELECT COUNT(*) FROM meta WHERE key = 'search_index_dropped')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert!(
+        recovered.0,
+        "the no-work run must rebuild the covering index"
+    );
+    assert_eq!(
+        recovered.1, 0,
+        "the no-work recovery must clear the drop marker"
+    );
 }
 
 /// A truncated artifact must fail its release without polluting the table,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -61,6 +61,15 @@ fn create_test_db(path: &std::path::Path) {
         CREATE INDEX IF NOT EXISTS idx_packages_name ON package_versions(name);
         CREATE INDEX IF NOT EXISTS idx_packages_name_version ON package_versions(name, version, first_commit_date);
         CREATE INDEX IF NOT EXISTS idx_packages_attr ON package_versions(attribute_path);
+        -- Match the production schema so higher-level search tests exercise the
+        -- covering candidate index rather than only the scan fallback.
+        CREATE INDEX IF NOT EXISTS idx_packages_search_nocase ON package_versions(
+            attribute_path COLLATE NOCASE,
+            version COLLATE NOCASE,
+            (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+            last_commit_date DESC,
+            first_commit_date DESC
+        );
         CREATE INDEX IF NOT EXISTS idx_packages_first_date ON package_versions(first_commit_date DESC);
         CREATE INDEX IF NOT EXISTS idx_packages_last_date ON package_versions(last_commit_date DESC);
 
@@ -1294,6 +1303,13 @@ fn create_compressed_test_db() -> (Vec<u8>, String) {
         CREATE INDEX idx_packages_name ON package_versions(name);
         CREATE INDEX idx_packages_name_version ON package_versions(name, version, first_commit_date);
         CREATE INDEX idx_packages_attr ON package_versions(attribute_path);
+        CREATE INDEX idx_packages_search_nocase ON package_versions(
+            attribute_path COLLATE NOCASE,
+            version COLLATE NOCASE,
+            (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+            last_commit_date DESC,
+            first_commit_date DESC
+        );
         CREATE INDEX idx_packages_first_date ON package_versions(first_commit_date DESC);
         CREATE INDEX idx_packages_last_date ON package_versions(last_commit_date DESC);
         CREATE VIRTUAL TABLE package_versions_fts USING fts5(name, description, content=package_versions, content_rowid=id);


### PR DESCRIPTION
## Summary

- add an ASCII-NOCASE covering index and a materialized candidate-ID phase for prefix and prefix+version searches
- fetch at most 5,000 full rows by primary key after ranking compact index entries, with `id ASC` as the deterministic final SQL tie-break
- make bulk index ingestion drop/rebuild the covering index transactionally, recover an interrupted drop on the next writable run, and repair/refuse missing-index publication state
- add indexed/fallback observable-parity, API pagination, query-plan, recovery, rebuild-failure, and publisher-readiness coverage

## Compatibility and recovery

Schema and manifest shapes remain v4. A new binary falls back to the existing scan plan on an old v4 database without the index, while old binaries can open and query an indexed v4 database. The old SQL never specified equal-key order, so an old binary may expose a different broad-prefix tie order when SQLite chooses the added index; the new binary preserves baseline output across indexed and fallback databases through the explicit `id ASC` tie-break.

Bulk drops write a marker and remove the index in one transaction. Rebuild creates and validates the index before clearing that marker in the same transaction. Non-bulk/no-work index runs heal an interrupted state, and publication repairs a missing index or refuses to emit the slow artifact.

## Measured production-snapshot impact

Measurements used APFS clones of the fixed 1,772,555-row schema-v4 snapshot; the live database was never opened writable.

| Workload | Baseline cold median | Candidate cold median | Candidate cold max | Candidate warm median |
|---|---:|---:|---:|---:|
| `search nxv` | 18.70 s | 0.049 s | 0.116 s | 0.009 s |
| `search python --limit 50` | 25.80 s | 1.665 s | 2.244 s | 0.074 s |
| `search python 3.13 --limit 50` | 30.56 s | 0.466 s | 0.606 s | 0.022 s |

The primary improvements are supported by the changed query plans and same-snapshot reference reruns. Absolute cross-run timings include host noise; unchanged controls are not presented as wins.

- query plan: covering prefix range seek, temp rank sort, then integer-primary-key fetch; scan fallback remains valid without the index
- exact output parity: 22 CLI/control cases (stats normalized only for path/size) and 6 API cases, including offset pagination
- raw database: 2,009,456,640 → 2,117,394,432 bytes, +5.37%
- zstd-19 artifact: 202,365,251 → 219,331,211 bytes, +8.38%
- index build + checkpoint: 26.83 s
- actual publish: 363.06 s; decompressed artifact passed `quick_check`, retained the index, and had no drop marker
- representative 284,776-row write: 170,888 WAL frames with the index maintained versus 151,549 while dropped; rebuild added 26,356 frames. A one-flush drop/write/rebuild/checkpoint was near break-even (39.37 s vs 36.92 s), while repeated catch-up flushes amortize the fixed rebuild. This is comfortably inside the six-hour publisher window, not a claim of a universal single-flush speedup.

## Checks

- `NO_COLOR=true nix develop -c ci-local` — format/clippy passed; 365 unit tests passed, 1 ignored; 89 integration tests passed
- `nix develop -c cargo build --release`
- `nix develop -c cargo build --release --features indexer`
- `nix flake check` — all seven `aarch64-darwin` checks passed
- production-snapshot CLI/API byte parity, plans, five-cold/ten-warm matrix, lifecycle timing, publisher compression, and decompression verification
