### PR TITLE
docs: sync prefix index documentation

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -383,7 +383,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python27`.
 - **Use `--exact`** when the package name is unambiguous; otherwise `python` returns dozens of variants (`python27`, `python311`, `python311Packages.numpy`, etc.).
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
-- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~190MB index download entirely if you only need occasional lookups.
+- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.
 - **Update regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv update` pulls the latest.
 - **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -383,7 +383,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python27`.
 - **Use `--exact`** when the package name is unambiguous; otherwise `python` returns dozens of variants (`python27`, `python311`, `python311Packages.numpy`, etc.).
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
-- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~190MB index download entirely if you only need occasional lookups.
+- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.
 - **Update regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv update` pulls the latest.
 - **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Note the directory is `src/index/` even though the Cargo feature is named `index
 ### Database Schema (`db/mod.rs`, schema v4)
 
 - `package_versions`: One row per `(attribute_path, version)` with **observation-backed** bounds: the pair was seen at `first_commit` and `last_commit` (real, Hydra-built channel commits); interior presence is interpolated, not guaranteed
+- `idx_packages_search_nocase`: Covering ASCII-NOCASE index for prefix and prefix+version candidate ranking; bulk ingestion drops and transactionally rebuilds it, and publication repairs or refuses an incomplete index
 - `releases`: Per-channel ingestion ledger (pending/ingested/failed/skipped + retry backoff) — replaces the old single-checkpoint model; a gap is just a pending row the next run picks up
 - `package_versions_fts`: FTS5 virtual table for description search (triggers are WHEN-guarded; bulk runs drop + rebuild)
 - `meta`: Key-value store (last_indexed_commit = newest ingested release commit, schema_version, min_schema_version)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or visit **<https://nxv.urandom.io>** to search in your browser.
                                                         ▼
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │   nxv search    │◀────│   Query Engine  │◀────│  Download from  │
-│   nxv serve     │     │ (bloom + indexes)│     │  remote/local   │
+│   nxv serve     │     │ bloom + indexes │     │  remote/local   │
 └─────────────────┘     └─────────────────┘     └─────────────────┘
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Or visit **<https://nxv.urandom.io>** to search in your browser.
 - **Version history** — See when each version was introduced and when it was superseded
 - **Multiple interfaces** — CLI tool, HTTP API server with web UI, or query via remote API
 - **NixOS module** — Run as a systemd service with automatic index updates
-- **Lightweight** — ~10MB static binary, ~190MB compressed index
+- **Lightweight** — ~10MB static binary, ~220MB compressed index
 
 ## How It Works
 
@@ -56,12 +56,12 @@ Or visit **<https://nxv.urandom.io>** to search in your browser.
                                                         ▼
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 │   nxv search    │◀────│   Query Engine  │◀────│  Download from  │
-│   nxv serve     │     │  (bloom + FTS5) │     │  remote/local   │
+│   nxv serve     │     │ (bloom + indexes)│     │  remote/local   │
 └─────────────────┘     └─────────────────┘     └─────────────────┘
 ```
 
 The indexer ingests Hydra-built channel-release snapshots from releases.nixos.org (back to 2016): `packages.json.br` for releases from 2020 onward, and `nix-env` evaluation of `nixexprs.tar.xz` for the earlier era. Every recorded commit is one where the package version verifiably existed — including nested package sets like `python3Packages.*` and `haskellPackages.*`.
-Users download a pre-built compressed index (~190MB) and query it locally or via the API server.
+Users download a pre-built compressed index (~220MB) and query it locally or via the API server.
 
 ## Installation
 
@@ -340,7 +340,7 @@ Generate distribution-ready artifacts with the `publish` command:
 nxv publish --output ./publish --url-prefix https://your-server.com/nxv
 
 # Files created:
-#   publish/index.db.zst   - Compressed SQLite database (~190MB)
+#   publish/index.db.zst   - Compressed SQLite database (~220MB)
 #   publish/bloom.bin      - Bloom filter for fast lookups (~330KB)
 #   publish/manifest.json  - Manifest with URLs and checksums
 ```

--- a/docs/indexer-rewrite/DESIGN.md
+++ b/docs/indexer-rewrite/DESIGN.md
@@ -140,6 +140,14 @@ CREATE TABLE releases (
     ingested_at INTEGER,
     UNIQUE(channel, release_name)
 );
+
+CREATE INDEX idx_packages_search_nocase ON package_versions(
+    attribute_path COLLATE NOCASE,
+    version COLLATE NOCASE,
+    (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+    last_commit_date DESC,
+    first_commit_date DESC
+);
 ```
 
 - **Writes**: order-agnostic widen-only upsert (CASE-WHEN bounds extension;
@@ -158,6 +166,12 @@ CREATE TABLE releases (
   triggers are dropped and FTS is rebuilt once at Finish
   (`INSERT INTO package_versions_fts(package_versions_fts) VALUES('rebuild')`).
   Measured: 28× writer slowdown without this.
+- **Prefix-search covering index**: `idx_packages_search_nocase` supplies
+  compact candidates for ASCII-case-insensitive prefix and prefix+version
+  searches before full rows are fetched by primary key. Bulk ingestion drops
+  it behind a durable marker and transactionally rebuilds it at finish; the
+  next writable run repairs interrupted drops, and publication repairs or
+  refuses an incomplete artifact.
 - **Bloom filter**: full dotted attribute paths (quoted segments stored
   unquoted). Leaf-segment entries are NOT added (no consumer in the query
   path; leaf-name resolution is a possible fast-follow, see §12).
@@ -384,16 +398,18 @@ API. `nxv stats` grep-scraping is replaced by the `--report` JSON.
 | Full rebuild, packages.json era (~2,866 releases, ~14.6 GB) | hours, parse-bound; 4 workers × ~250 MB + writer + aggregator ≈ **<2 GB RSS** |
 | Backfill 2016–2020 (~1,283 nix-env runs, 15–25 s each) | **~1.5–3 h**, 4 workers × ~1.5 GB |
 | Incremental (CI) | seconds–minutes, <500 MB; ~70% of runs ingest nothing and skip publish |
-| Row count, full history | ~1.1–1.4 M (attr,version) pairs (+~170k/yr) |
-| DB size | ~1.5–1.9 GB raw, **artifact target ≤250 MB zstd**; if exceeded, intern license/platforms/maintainers into dictionary side-tables behind the existing query API (measured ~50× metadata duplication — the named lever, not a v1 requirement) |
+| Row count, full history | ~1.77 M (attr,version) pairs as of 2026-07 (+~170k/yr) |
+| DB size | ~2.1 GB raw / ~220 MB zstd as of 2026-07, including the covering prefix index; **artifact target ≤250 MB zstd**. If exceeded, intern license/platforms/maintainers into dictionary side-tables behind the existing query API (measured ~50× metadata duplication — the named lever, not a v1 requirement) |
 | FTS | dropped-trigger ingest + one rebuild (~1–2 min at 1.2M rows) |
 | Write amplification | aggregator keeps writes O(distinct pairs), not O(attrs × releases) |
 
-Search under 144k dotted attrs (verified hazards): prefix search on
-`python` would match all ~11k `python313Packages.*` rows and
-`execute_search` materializes full result sets pre-pagination. v2 ships:
-(a) ranking that orders shallower attr paths first (`attribute_path` dot
-count ASC, then name), (b) SQL-level LIMIT pushdown in the search queries.
+Search under ~139k dotted attrs (verified hazards): prefix search on `python`
+matches thousands of `python3xxPackages.*` rows. Prefix and prefix+version
+queries use the covering ASCII-NOCASE index to rank at most 5,000 compact
+candidate IDs, then fetch full rows by primary key with deterministic `id ASC`
+tie-breaking. Ranking still orders shallower attr paths first
+(`attribute_path` dot count ASC, then name), and SQL-level LIMIT pushdown keeps
+pagination bounded.
 Bare-leaf resolution (`requests` → `python313Packages.requests`) is a named
 fast-follow, not v1.
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -383,7 +383,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python27`.
 - **Use `--exact`** when the package name is unambiguous; otherwise `python` returns dozens of variants (`python27`, `python311`, `python311Packages.numpy`, etc.).
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
-- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~190MB index download entirely if you only need occasional lookups.
+- **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.
 - **Update regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv update` pulls the latest.
 - **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
 

--- a/website/advanced/indexer-cli.md
+++ b/website/advanced/indexer-cli.md
@@ -137,7 +137,7 @@ backward-compatible schema changes. Publishing a schema-4 index with
 
 | File                    | Size    | Description                            |
 | ----------------------- | ------- | -------------------------------------- |
-| `index.db.zst`          | ~190 MB | Zstd-compressed SQLite database        |
+| `index.db.zst`          | ~220 MB | Zstd-compressed SQLite database        |
 | `bloom.bin`             | ~330 KB | Bloom filter for fast negative lookups |
 | `manifest.json`         | ~1 KB   | Metadata with checksums                |
 | `manifest.json.minisig` | ~1 KB   | minisign signature (when `--sign`)     |

--- a/website/advanced/indexer.md
+++ b/website/advanced/indexer.md
@@ -153,7 +153,7 @@ nxv publish --output ./publish --sign --secret-key ./nxv.key
 
 | File                    | Size    | Description                        |
 | ----------------------- | ------- | ---------------------------------- |
-| `index.db.zst`          | ~190 MB | Zstd-compressed SQLite database    |
+| `index.db.zst`          | ~220 MB | Zstd-compressed SQLite database    |
 | `bloom.bin`             | ~330 KB | Bloom filter for fast lookups      |
 | `manifest.json`         | ~1 KB   | Metadata with checksums            |
 | `manifest.json.minisig` | ~1 KB   | minisign signature (when `--sign`) |
@@ -257,6 +257,15 @@ CREATE TABLE releases (
 CREATE VIRTUAL TABLE package_versions_fts
 USING fts5(name, description, content=package_versions, content_rowid=id);
 
+-- Cover prefix and prefix+version candidate ranking without fetching full rows
+CREATE INDEX idx_packages_search_nocase ON package_versions(
+    attribute_path COLLATE NOCASE,
+    version COLLATE NOCASE,
+    (LENGTH(attribute_path) - LENGTH(REPLACE(attribute_path, '.', ''))),
+    last_commit_date DESC,
+    first_commit_date DESC
+);
+
 -- Metadata
 CREATE TABLE meta (
     key TEXT PRIMARY KEY,
@@ -270,6 +279,12 @@ A given `(attribute_path, version)` pair is exactly one row, enforced by the
 `UNIQUE(attribute_path, version)` constraint. Re-observing a pair only widens
 its range. `nxv dedupe` exists to repair databases built by pre-0.1.5 indexer
 versions that left duplicate rows behind.
+
+Prefix searches first rank compact entries from `idx_packages_search_nocase`,
+then fetch at most 5,000 full rows by primary key. Bulk ingestion drops this
+covering index to avoid write amplification and rebuilds it transactionally. If
+a run is interrupted, the next writable run repairs it; publishing also repairs
+the index or refuses to emit a slow artifact.
 
 ### Insecure Packages
 

--- a/website/advanced/troubleshooting.md
+++ b/website/advanced/troubleshooting.md
@@ -80,7 +80,7 @@ if updates are managed externally.
 
 ### Disk full
 
-The compressed index download is ~190MB and unpacks to ~2GB of disk space:
+The compressed index download is ~220MB and unpacks to ~2.1GB of disk space:
 
 - Linux: `~/.local/share/nxv/`
 - macOS: `~/Library/Application Support/nxv/`

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -26,7 +26,7 @@ nix run github:utensils/nxv -- search python
 # One-liner install (downloads static binary)
 curl -fsSL https://raw.githubusercontent.com/utensils/nxv/main/install.sh | sh
 
-# Update the package index (downloads ~190MB)
+# Update the package index (downloads ~220MB)
 nxv update
 
 # Search for a package
@@ -50,7 +50,7 @@ For each package version, nxv provides:
 
 nxv uses a pre-built SQLite index containing:
 
-- ~1.75 million version records across ~282,000 package attributes
+- ~1.77 million version records across ~139,000 package attributes
 - Package metadata (description, license, homepage)
 - Bloom filter for instant "not found" responses
 

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -123,7 +123,7 @@ After installation, download the package index:
 nxv update
 ```
 
-This downloads ~190MB of compressed data to your local data directory:
+This downloads ~220MB of compressed data to your local data directory:
 
 - **Linux**: `~/.local/share/nxv/`
 - **macOS**: `~/Library/Application Support/nxv/`


### PR DESCRIPTION
## Summary

- document the new covering ASCII-NOCASE prefix-search index and its crash-safe bulk lifecycle
- refresh index download, disk, row-count, and attribute-count figures from the live published index and API
- regenerate the checked-in Claude and generic agent skill copies from the canonical template

## Why

The v0.4.4 search-index work increased the compressed artifact to about 220 MB and changed query/index lifecycle behavior, while current user and maintainer docs still described the pre-change artifact and schema.

## Validation

- `env -u NO_COLOR nix develop -c ci-local` (365 unit tests passed, 1 ignored; 89 integration tests passed; fmt and clippy passed)
- `nix develop -c docs-build`
- canonical skill template is byte-identical to both checked-in generated copies
- live `index-latest` manifest and `https://nxv.urandom.io/api/v1/stats`
