### PR TITLE
feat!: emit license/maintainers/platforms as real JSON arrays

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -86,20 +86,51 @@ nxv search python --format json                      # Machine-readable JSON
 nxv search python --format plain                     # TSV for shell scripts
 ```
 
-**JSON shape per row:**
+**JSON shape per row** (the same shape is returned by `nxv info`, `nxv history <pkg> <version>`, `nxv history --full`, and the `/api/v1` package endpoints):
 
 ```json
 {
-  "attribute_path": "python311",
-  "version": "3.11.4",
-  "description": "A high-level dynamically-typed programming language",
-  "license": "Python-2.0",
-  "first_commit_hash": "abc123...",
-  "first_commit_date": "2023-06-15T00:00:00Z",
-  "last_commit_hash": "def456...",
-  "last_commit_date": "2023-12-01T00:00:00Z"
+  "id": 9630,
+  "name": "python3",
+  "version": "3.12.13",
+  "first_commit_hash": "d78e468770f4ab5e00c5015f4d77c1a499a76dc8",
+  "first_commit_date": "2026-03-06T20:06:54Z",
+  "last_commit_hash": "3d2613bc58a1f5b7805467a63a825e1d7bc9b7a9",
+  "last_commit_date": "2026-07-21T12:39:35Z",
+  "attribute_path": "python312",
+  "description": "High-level dynamically-typed programming language",
+  "license": ["Python-2.0"],
+  "homepage": "https://www.python.org",
+  "maintainers": ["mweinelt"],
+  "platforms": ["x86_64-linux", "aarch64-darwin"],
+  "source_path": "pkgs/development/interpreters/python/cpython/default.nix",
+  "known_vulnerabilities": null
 }
 ```
+
+| Field                                                     | Type            | Notes                                                                          |
+| --------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------ |
+| `id`                                                      | integer         | Index row id. Not stable across index rebuilds — never persist it.             |
+| `name`                                                    | string          | Upstream derivation name. **Not installable** — see below.                     |
+| `attribute_path`                                          | string          | The nixpkgs attribute. **This is what you install with.**                      |
+| `version`                                                 | string          | Package version.                                                               |
+| `first_commit_hash` / `last_commit_hash`                  | string          | Full 40-char nixpkgs commit hashes.                                            |
+| `first_commit_date` / `last_commit_date`                  | string          | RFC 3339 / ISO 8601 UTC.                                                       |
+| `description`, `homepage`, `source_path`                  | string \| null  | `source_path` is null for older packages.                                      |
+| `license`, `maintainers`, `platforms`                     | array \| null   | Arrays of strings. `null` when the package declares none.                      |
+| `known_vulnerabilities`                                   | array \| null   | `null` (or `[]`) means no known advisory; non-empty means the package is insecure. |
+
+**`name` vs `attribute_path`** — these routinely differ and confusing them produces commands that fail. `name` is the upstream derivation name (`pname` for top-level attrs, the final attribute segment for nested ones); `attribute_path` is the address you actually install with. For the row above, `nix shell nixpkgs/<hash>#python312` works and `#python3` may not. **Always use `attribute_path`.**
+
+`license`, `maintainers`, `platforms`, and `known_vulnerabilities` are real JSON arrays, so `jq` reaches them directly:
+
+```bash
+nxv search python312 --exact --format json | jq -r '.[0].license[]'        # Python-2.0
+nxv search python312 --exact --format json | jq -r '.[0].platforms | join(", ")'
+nxv search hello --format json | jq -r '.[] | select(.known_vulnerabilities != null) | .attribute_path'
+```
+
+> **Version note**: nxv **< 0.5.0** emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
 
 ## Info
 
@@ -123,7 +154,7 @@ nxv history python311 --full             # Add commits, license, homepage, etc.
 nxv history python311 --format json
 ```
 
-**JSON shape per row:**
+**JSON shape per row** — plain `nxv history <pkg>` returns this compact timeline shape:
 
 ```json
 {
@@ -133,6 +164,8 @@ nxv history python311 --format json
   "is_insecure": false
 }
 ```
+
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`.
 
 ## Using a Found Version
 
@@ -375,7 +408,8 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
 - **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
-- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in 0.5.0.
+- **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
 
 ## Practical Tips

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -86,20 +86,51 @@ nxv search python --format json                      # Machine-readable JSON
 nxv search python --format plain                     # TSV for shell scripts
 ```
 
-**JSON shape per row:**
+**JSON shape per row** (the same shape is returned by `nxv info`, `nxv history <pkg> <version>`, `nxv history --full`, and the `/api/v1` package endpoints):
 
 ```json
 {
-  "attribute_path": "python311",
-  "version": "3.11.4",
-  "description": "A high-level dynamically-typed programming language",
-  "license": "Python-2.0",
-  "first_commit_hash": "abc123...",
-  "first_commit_date": "2023-06-15T00:00:00Z",
-  "last_commit_hash": "def456...",
-  "last_commit_date": "2023-12-01T00:00:00Z"
+  "id": 9630,
+  "name": "python3",
+  "version": "3.12.13",
+  "first_commit_hash": "d78e468770f4ab5e00c5015f4d77c1a499a76dc8",
+  "first_commit_date": "2026-03-06T20:06:54Z",
+  "last_commit_hash": "3d2613bc58a1f5b7805467a63a825e1d7bc9b7a9",
+  "last_commit_date": "2026-07-21T12:39:35Z",
+  "attribute_path": "python312",
+  "description": "High-level dynamically-typed programming language",
+  "license": ["Python-2.0"],
+  "homepage": "https://www.python.org",
+  "maintainers": ["mweinelt"],
+  "platforms": ["x86_64-linux", "aarch64-darwin"],
+  "source_path": "pkgs/development/interpreters/python/cpython/default.nix",
+  "known_vulnerabilities": null
 }
 ```
+
+| Field                                                     | Type            | Notes                                                                          |
+| --------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------ |
+| `id`                                                      | integer         | Index row id. Not stable across index rebuilds — never persist it.             |
+| `name`                                                    | string          | Upstream derivation name. **Not installable** — see below.                     |
+| `attribute_path`                                          | string          | The nixpkgs attribute. **This is what you install with.**                      |
+| `version`                                                 | string          | Package version.                                                               |
+| `first_commit_hash` / `last_commit_hash`                  | string          | Full 40-char nixpkgs commit hashes.                                            |
+| `first_commit_date` / `last_commit_date`                  | string          | RFC 3339 / ISO 8601 UTC.                                                       |
+| `description`, `homepage`, `source_path`                  | string \| null  | `source_path` is null for older packages.                                      |
+| `license`, `maintainers`, `platforms`                     | array \| null   | Arrays of strings. `null` when the package declares none.                      |
+| `known_vulnerabilities`                                   | array \| null   | `null` (or `[]`) means no known advisory; non-empty means the package is insecure. |
+
+**`name` vs `attribute_path`** — these routinely differ and confusing them produces commands that fail. `name` is the upstream derivation name (`pname` for top-level attrs, the final attribute segment for nested ones); `attribute_path` is the address you actually install with. For the row above, `nix shell nixpkgs/<hash>#python312` works and `#python3` may not. **Always use `attribute_path`.**
+
+`license`, `maintainers`, `platforms`, and `known_vulnerabilities` are real JSON arrays, so `jq` reaches them directly:
+
+```bash
+nxv search python312 --exact --format json | jq -r '.[0].license[]'        # Python-2.0
+nxv search python312 --exact --format json | jq -r '.[0].platforms | join(", ")'
+nxv search hello --format json | jq -r '.[] | select(.known_vulnerabilities != null) | .attribute_path'
+```
+
+> **Version note**: nxv **< 0.5.0** emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
 
 ## Info
 
@@ -123,7 +154,7 @@ nxv history python311 --full             # Add commits, license, homepage, etc.
 nxv history python311 --format json
 ```
 
-**JSON shape per row:**
+**JSON shape per row** — plain `nxv history <pkg>` returns this compact timeline shape:
 
 ```json
 {
@@ -133,6 +164,8 @@ nxv history python311 --format json
   "is_insecure": false
 }
 ```
+
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`.
 
 ## Using a Found Version
 
@@ -375,7 +408,8 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
 - **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
-- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in 0.5.0.
+- **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
 
 ## Practical Tips

--- a/src/db/json_array.rs
+++ b/src/db/json_array.rs
@@ -1,0 +1,199 @@
+//! Helpers for columns that store a JSON array in a TEXT column.
+//!
+//! The indexer normalizes nixpkgs' loosely-typed `meta` fields (`license` is
+//! dict | list[dict] | str | list[str]; `platforms` is str | list[str | attrs])
+//! into a canonical JSON array which SQLite stores as TEXT — see
+//! [`crate::index::snapshot`]. That string is a *storage* detail: it must not
+//! leak into `--format json`, the HTTP API, or human-readable output.
+//!
+//! [`parse`] is the single place that decodes such a column. [`serialize_opt`]
+//! emits a real JSON array on the wire, and [`deserialize_opt`] accepts both
+//! that array and the legacy stringified form, so a newer CLI keeps working
+//! against an older `nxv serve` (and vice versa for stored fixtures).
+
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Decode a JSON-array column into its elements.
+///
+/// Tolerates every shape the column has held historically: a JSON array, a
+/// bare string (pre-v4 indexes stored `MIT` rather than `["MIT"]`), the
+/// `null`/`None` sentinels some older rows carry, and malformed JSON — the
+/// last of which is returned as a single element rather than being dropped, so
+/// data is never silently lost.
+pub fn parse(raw: &str) -> Vec<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "null" || trimmed == "None" {
+        return Vec::new();
+    }
+
+    if trimmed.starts_with('[')
+        && let Ok(values) = serde_json::from_str::<Vec<serde_json::Value>>(trimmed)
+    {
+        return values.iter().filter_map(value_to_string).collect();
+    }
+
+    vec![raw.to_string()]
+}
+
+/// Render a JSON-array column for human-readable output (table, plain, info).
+pub fn join(raw: &str) -> String {
+    parse(raw).join(", ")
+}
+
+/// Render an optional JSON-array column, falling back to `placeholder` when the
+/// column is NULL or decodes to nothing.
+pub fn join_or(raw: Option<&str>, placeholder: &str) -> String {
+    let joined = raw.map(join).unwrap_or_default();
+    if joined.is_empty() {
+        placeholder.to_string()
+    } else {
+        joined
+    }
+}
+
+/// Flatten a JSON value into a display string, dropping nulls.
+fn value_to_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(s) => Some(s.clone()),
+        other => Some(other.to_string()),
+    }
+}
+
+/// Serialize a JSON-array column as a real JSON array.
+///
+/// A NULL column stays `null`; anything else becomes an array, so consumers can
+/// rely on the field being either `null` or a list — never a string that needs
+/// a second `fromjson`.
+pub fn serialize_opt<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        Some(raw) => serializer.collect_seq(parse(raw)),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// Deserialize a JSON-array column from either a real array or a legacy string.
+///
+/// The value is normalized back to the canonical stringified form so the rest
+/// of the codebase sees one representation regardless of backend.
+pub fn deserialize_opt<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Str(String),
+        List(Vec<serde_json::Value>),
+    }
+
+    let repr = Option::<Repr>::deserialize(deserializer)?;
+    Ok(repr.map(|repr| match repr {
+        Repr::Str(s) => s,
+        Repr::List(items) => {
+            let items: Vec<String> = items.iter().filter_map(value_to_string).collect();
+            serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Holder {
+        #[serde(serialize_with = "serialize_opt", deserialize_with = "deserialize_opt")]
+        field: Option<String>,
+    }
+
+    fn holder(field: Option<&str>) -> Holder {
+        Holder {
+            field: field.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn parses_json_arrays() {
+        assert_eq!(parse(r#"["MIT","BSD-3-Clause"]"#), ["MIT", "BSD-3-Clause"]);
+        assert_eq!(parse("[]"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn parses_legacy_and_sentinel_values() {
+        // Pre-v4 indexes stored a bare license string.
+        assert_eq!(parse("MIT"), ["MIT"]);
+        assert_eq!(parse("null"), Vec::<String>::new());
+        assert_eq!(parse("None"), Vec::<String>::new());
+        assert_eq!(parse("   "), Vec::<String>::new());
+    }
+
+    #[test]
+    fn malformed_json_is_preserved_not_dropped() {
+        assert_eq!(parse(r#"["unterminated"#), [r#"["unterminated"#]);
+    }
+
+    #[test]
+    fn non_string_elements_are_stringified_and_nulls_dropped() {
+        assert_eq!(parse(r#"["a",null,7]"#), ["a", "7"]);
+    }
+
+    #[test]
+    fn joins_for_display() {
+        assert_eq!(
+            join(r#"["x86_64-linux","aarch64-darwin"]"#),
+            "x86_64-linux, aarch64-darwin"
+        );
+        assert_eq!(join_or(None, "-"), "-");
+        assert_eq!(join_or(Some("[]"), "-"), "-");
+        assert_eq!(join_or(Some(r#"["MIT"]"#), "-"), "MIT");
+    }
+
+    #[test]
+    fn serializes_as_real_array() {
+        let json = serde_json::to_string(&holder(Some(r#"["Python-2.0"]"#))).unwrap();
+        assert_eq!(json, r#"{"field":["Python-2.0"]}"#);
+    }
+
+    #[test]
+    fn serializes_legacy_string_as_single_element_array() {
+        let json = serde_json::to_string(&holder(Some("MIT"))).unwrap();
+        assert_eq!(json, r#"{"field":["MIT"]}"#);
+    }
+
+    #[test]
+    fn serializes_null_column_as_null() {
+        let json = serde_json::to_string(&holder(None)).unwrap();
+        assert_eq!(json, r#"{"field":null}"#);
+    }
+
+    #[test]
+    fn deserializes_real_array() {
+        let parsed: Holder = serde_json::from_str(r#"{"field":["MIT","ISC"]}"#).unwrap();
+        assert_eq!(parsed, holder(Some(r#"["MIT","ISC"]"#)));
+    }
+
+    #[test]
+    fn deserializes_legacy_stringified_array_from_older_server() {
+        let parsed: Holder = serde_json::from_str(r#"{"field":"[\"MIT\"]"}"#).unwrap();
+        assert_eq!(parsed, holder(Some(r#"["MIT"]"#)));
+    }
+
+    #[test]
+    fn deserializes_null() {
+        let parsed: Holder = serde_json::from_str(r#"{"field":null}"#).unwrap();
+        assert_eq!(parsed, holder(None));
+    }
+
+    #[test]
+    fn round_trips_through_serialization() {
+        let original = holder(Some(r#"["x86_64-linux","aarch64-darwin"]"#));
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: Holder = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+}

--- a/src/db/json_array.rs
+++ b/src/db/json_array.rs
@@ -77,8 +77,10 @@ where
 
 /// Deserialize a JSON-array column from either a real array or a legacy string.
 ///
-/// The value is normalized back to the canonical stringified form so the rest
-/// of the codebase sees one representation regardless of backend.
+/// An array is re-encoded to the stringified form the DB uses, so a value that
+/// arrived over HTTP is indistinguishable from one read out of SQLite. A legacy
+/// bare string is kept verbatim rather than wrapped — [`parse`] already accepts
+/// both spellings, so every consumer sees the same elements either way.
 pub fn deserialize_opt<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: Deserializer<'de>,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,7 @@
 //! Database module for nxv index storage.
 
 pub mod import;
+pub mod json_array;
 pub mod queries;
 pub mod releases;
 

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -111,13 +111,33 @@ pub struct PackageVersion {
     pub last_commit_date: DateTime<Utc>,
     pub attribute_path: String,
     pub description: Option<String>,
+    /// SPDX identifiers. Stored as a JSON array string; serialized as an array.
+    #[serde(
+        serialize_with = "super::json_array::serialize_opt",
+        deserialize_with = "super::json_array::deserialize_opt"
+    )]
     pub license: Option<String>,
     pub homepage: Option<String>,
+    /// Maintainer handles. Stored as a JSON array string; serialized as an array.
+    #[serde(
+        serialize_with = "super::json_array::serialize_opt",
+        deserialize_with = "super::json_array::deserialize_opt"
+    )]
     pub maintainers: Option<String>,
+    /// Supported systems. Stored as a JSON array string; serialized as an array.
+    #[serde(
+        serialize_with = "super::json_array::serialize_opt",
+        deserialize_with = "super::json_array::deserialize_opt"
+    )]
     pub platforms: Option<String>,
     /// Source file path relative to nixpkgs root
     pub source_path: Option<String>,
-    /// Known security vulnerabilities or EOL notices (JSON array)
+    /// Known security vulnerabilities or EOL notices. Stored as a JSON array
+    /// string; serialized as an array.
+    #[serde(
+        serialize_with = "super::json_array::serialize_opt",
+        deserialize_with = "super::json_array::deserialize_opt"
+    )]
     pub known_vulnerabilities: Option<String>,
 }
 
@@ -272,8 +292,8 @@ impl PackageVersion {
     /// Get parsed known vulnerabilities as a vector of strings.
     pub fn vulnerabilities(&self) -> Vec<String> {
         self.known_vulnerabilities
-            .as_ref()
-            .and_then(|v| serde_json::from_str(v).ok())
+            .as_deref()
+            .map(super::json_array::parse)
             .unwrap_or_default()
     }
 }
@@ -2087,13 +2107,16 @@ mod tests {
     }
 
     #[test]
-    fn test_vulnerabilities_invalid_json() {
+    fn test_vulnerabilities_invalid_json_is_preserved() {
         let pkg = make_test_package(
             Utc.timestamp_opt(1700000000, 0).unwrap(),
             Some("invalid json".to_string()),
         );
-        let vulns = pkg.vulnerabilities();
-        assert!(vulns.is_empty());
+        // Unparseable content is surfaced verbatim rather than dropped:
+        // `is_insecure()` already flags such a row, so returning an empty list
+        // would print the "has known vulnerabilities" banner with no reason.
+        assert!(pkg.is_insecure());
+        assert_eq!(pkg.vulnerabilities(), ["invalid json"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -590,15 +590,24 @@ fn cmd_pkg_info(cli: &Cli, args: &cli::InfoArgs) -> Result<()> {
                 println!("last_commit\t{}", pkg.last_commit_hash);
                 println!("last_date\t{}", pkg.last_commit_date.format("%Y-%m-%d"));
                 println!("description\t{}", pkg.description.as_deref().unwrap_or("-"));
-                println!("license\t{}", pkg.license.as_deref().unwrap_or("-"));
+                println!(
+                    "license\t{}",
+                    db::json_array::join_or(pkg.license.as_deref(), "-")
+                );
                 println!("homepage\t{}", pkg.homepage.as_deref().unwrap_or("-"));
-                println!("maintainers\t{}", pkg.maintainers.as_deref().unwrap_or("-"));
-                println!("platforms\t{}", pkg.platforms.as_deref().unwrap_or("-"));
+                println!(
+                    "maintainers\t{}",
+                    db::json_array::join_or(pkg.maintainers.as_deref(), "-")
+                );
+                println!(
+                    "platforms\t{}",
+                    db::json_array::join_or(pkg.platforms.as_deref(), "-")
+                );
                 println!("insecure\t{}", if pkg.is_insecure() { "yes" } else { "no" });
                 if pkg.is_insecure() {
                     println!(
                         "known_vulnerabilities\t{}",
-                        pkg.known_vulnerabilities.as_deref().unwrap_or("[]")
+                        db::json_array::join_or(pkg.known_vulnerabilities.as_deref(), "-")
                     );
                 }
                 println!();
@@ -636,7 +645,7 @@ fn cmd_pkg_info(cli: &Cli, args: &cli::InfoArgs) -> Result<()> {
             println!(
                 "  {:<16} {}",
                 "License:",
-                pkg.license.as_deref().unwrap_or("-")
+                db::json_array::join_or(pkg.license.as_deref(), "-")
             );
             println!();
 
@@ -655,22 +664,19 @@ fn cmd_pkg_info(cli: &Cli, args: &cli::InfoArgs) -> Result<()> {
             );
             println!();
 
-            if let Some(ref maintainers) = pkg.maintainers {
+            let maintainers = db::json_array::parse(pkg.maintainers.as_deref().unwrap_or(""));
+            if !maintainers.is_empty() {
                 println!("{}", "Maintainers".bold().underline());
-                // Parse JSON array and display
-                if let Ok(list) = serde_json::from_str::<Vec<String>>(maintainers) {
-                    for m in list {
-                        println!("  • {}", m);
-                    }
-                } else {
-                    println!("  {}", maintainers);
+                for m in maintainers {
+                    println!("  • {}", m);
                 }
                 println!();
             }
 
-            if let Some(ref platforms) = pkg.platforms {
+            let list = db::json_array::parse(pkg.platforms.as_deref().unwrap_or(""));
+            if !list.is_empty() {
                 println!("{}", "Platforms".bold().underline());
-                if let Ok(list) = serde_json::from_str::<Vec<String>>(platforms) {
+                {
                     // Detect current platform
                     let current_platform = format!(
                         "{}-{}",
@@ -718,8 +724,6 @@ fn cmd_pkg_info(cli: &Cli, args: &cli::InfoArgs) -> Result<()> {
                         let formatted: Vec<_> = other.iter().map(|p| format_platform(p)).collect();
                         println!("  Other:  {}", formatted.join(", "));
                     }
-                } else {
-                    println!("  {}", platforms);
                 }
                 println!();
             }
@@ -1104,7 +1108,7 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
                         pkg.last_commit_short(),
                         pkg.last_commit_date.format("%Y-%m-%d"),
                         pkg.description.as_deref().unwrap_or("-"),
-                        pkg.license.as_deref().unwrap_or("-"),
+                        db::json_array::join_or(pkg.license.as_deref(), "-"),
                         pkg.homepage.as_deref().unwrap_or("-"),
                     );
                 }

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -38,7 +38,7 @@ pub fn print_plain(results: &[PackageVersion], show_platforms: bool) {
         let description = pkg.description.as_deref().unwrap_or("-");
 
         if show_platforms {
-            let platforms = pkg.platforms.as_deref().unwrap_or("-");
+            let platforms = crate::db::json_array::join_or(pkg.platforms.as_deref(), "-");
             println!(
                 "{}\t{}\t{}\t{}\t{}\t{}",
                 pkg.attribute_path, pkg.version, pkg.last_commit_hash, date, description, platforms

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -69,7 +69,7 @@ pub fn print_table(results: &[PackageVersion], options: TableOptions) {
         ];
 
         if options.show_platforms {
-            let platforms = pkg.platforms.as_deref().unwrap_or("-");
+            let platforms = crate::db::json_array::join_or(pkg.platforms.as_deref(), "-");
             row.push(Cell::new(platforms));
         }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -800,6 +800,40 @@ mod tests {
         assert!(json["meta"]["total"].as_u64().unwrap() >= 2);
     }
 
+    /// The API must return the same row shape the CLI does (issue #54):
+    /// array-valued metadata fields, and nullable fields present as `null`
+    /// rather than omitted.
+    #[tokio::test]
+    async fn test_search_row_shape_matches_cli() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        create_test_db(&db_path);
+
+        let state = Arc::new(AppState::new(db_path));
+        let app = build_router(state, None, None);
+
+        let (_, json) = get_json(&app, "/api/v1/search?q=python311&exact=true").await;
+        let row = &json["data"][0];
+
+        // The fixture stores a legacy bare-string license; it still serializes
+        // as an array so consumers never have to branch on the encoding.
+        assert_eq!(row["license"], serde_json::json!(["PSF"]));
+
+        // Columns the fixture leaves NULL are present and null, not absent.
+        for field in [
+            "maintainers",
+            "platforms",
+            "source_path",
+            "known_vulnerabilities",
+        ] {
+            assert!(
+                row.get(field).is_some_and(|v| v.is_null()),
+                "{field} should be present and null, got {:?}",
+                row.get(field)
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_search_exact_match() {
         let dir = tempdir().unwrap();

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -263,15 +263,26 @@ pub struct PackageVersionSchema {
     pub last_commit_date: DateTime<Utc>,
     pub attribute_path: String,
     pub description: Option<String>,
+    /// SPDX license identifiers (may be null when the package declares none).
+    #[serde(serialize_with = "crate::db::json_array::serialize_opt")]
+    #[schema(value_type = Option<Vec<String>>)]
     pub license: Option<String>,
     pub homepage: Option<String>,
+    /// Maintainer handles (may be null when the package declares none).
+    #[serde(serialize_with = "crate::db::json_array::serialize_opt")]
+    #[schema(value_type = Option<Vec<String>>)]
     pub maintainers: Option<String>,
+    /// Systems the package declares support for.
+    #[serde(serialize_with = "crate::db::json_array::serialize_opt")]
+    #[schema(value_type = Option<Vec<String>>)]
     pub platforms: Option<String>,
     /// Source file path relative to nixpkgs root (may be null for older packages).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
-    /// Known security vulnerabilities (JSON array, may be null for secure packages).
+    /// Known security vulnerabilities (may be null for secure packages).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(serialize_with = "crate::db::json_array::serialize_opt")]
+    #[schema(value_type = Option<Vec<String>>)]
     pub known_vulnerabilities: Option<String>,
 }
 

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -276,11 +276,15 @@ pub struct PackageVersionSchema {
     #[serde(serialize_with = "crate::db::json_array::serialize_opt")]
     #[schema(value_type = Option<Vec<String>>)]
     pub platforms: Option<String>,
-    /// Source file path relative to nixpkgs root (may be null for older packages).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Source file path relative to nixpkgs root (null for older packages).
+    ///
+    /// Serialized even when absent: the CLI emits `null` here, and omitting it
+    /// would make `/docs` and the API diverge from the row shape SKILL.md
+    /// documents for both backends.
     pub source_path: Option<String>,
-    /// Known security vulnerabilities (may be null for secure packages).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Known security vulnerabilities (null for secure packages).
+    ///
+    /// Serialized even when absent, for the same reason as `source_path`.
     #[serde(serialize_with = "crate::db::json_array::serialize_opt")]
     #[schema(value_type = Option<Vec<String>>)]
     pub known_vulnerabilities: Option<String>,
@@ -291,7 +295,7 @@ impl From<PackageVersion> for PackageVersionSchema {
     ///
     /// The resulting schema preserves all public metadata fields (ids, version and
     /// commit timestamps, paths, description, license, homepage, maintainers,
-    /// platforms, and optional `source_path`).
+    /// platforms, `source_path` and `known_vulnerabilities`).
     ///
     /// # Examples
     ///

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -86,20 +86,51 @@ nxv search python --format json                      # Machine-readable JSON
 nxv search python --format plain                     # TSV for shell scripts
 ```
 
-**JSON shape per row:**
+**JSON shape per row** (the same shape is returned by `nxv info`, `nxv history <pkg> <version>`, `nxv history --full`, and the `/api/v1` package endpoints):
 
 ```json
 {
-  "attribute_path": "python311",
-  "version": "3.11.4",
-  "description": "A high-level dynamically-typed programming language",
-  "license": "Python-2.0",
-  "first_commit_hash": "abc123...",
-  "first_commit_date": "2023-06-15T00:00:00Z",
-  "last_commit_hash": "def456...",
-  "last_commit_date": "2023-12-01T00:00:00Z"
+  "id": 9630,
+  "name": "python3",
+  "version": "3.12.13",
+  "first_commit_hash": "d78e468770f4ab5e00c5015f4d77c1a499a76dc8",
+  "first_commit_date": "2026-03-06T20:06:54Z",
+  "last_commit_hash": "3d2613bc58a1f5b7805467a63a825e1d7bc9b7a9",
+  "last_commit_date": "2026-07-21T12:39:35Z",
+  "attribute_path": "python312",
+  "description": "High-level dynamically-typed programming language",
+  "license": ["Python-2.0"],
+  "homepage": "https://www.python.org",
+  "maintainers": ["mweinelt"],
+  "platforms": ["x86_64-linux", "aarch64-darwin"],
+  "source_path": "pkgs/development/interpreters/python/cpython/default.nix",
+  "known_vulnerabilities": null
 }
 ```
+
+| Field                                                     | Type            | Notes                                                                          |
+| --------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------ |
+| `id`                                                      | integer         | Index row id. Not stable across index rebuilds — never persist it.             |
+| `name`                                                    | string          | Upstream derivation name. **Not installable** — see below.                     |
+| `attribute_path`                                          | string          | The nixpkgs attribute. **This is what you install with.**                      |
+| `version`                                                 | string          | Package version.                                                               |
+| `first_commit_hash` / `last_commit_hash`                  | string          | Full 40-char nixpkgs commit hashes.                                            |
+| `first_commit_date` / `last_commit_date`                  | string          | RFC 3339 / ISO 8601 UTC.                                                       |
+| `description`, `homepage`, `source_path`                  | string \| null  | `source_path` is null for older packages.                                      |
+| `license`, `maintainers`, `platforms`                     | array \| null   | Arrays of strings. `null` when the package declares none.                      |
+| `known_vulnerabilities`                                   | array \| null   | `null` (or `[]`) means no known advisory; non-empty means the package is insecure. |
+
+**`name` vs `attribute_path`** — these routinely differ and confusing them produces commands that fail. `name` is the upstream derivation name (`pname` for top-level attrs, the final attribute segment for nested ones); `attribute_path` is the address you actually install with. For the row above, `nix shell nixpkgs/<hash>#python312` works and `#python3` may not. **Always use `attribute_path`.**
+
+`license`, `maintainers`, `platforms`, and `known_vulnerabilities` are real JSON arrays, so `jq` reaches them directly:
+
+```bash
+nxv search python312 --exact --format json | jq -r '.[0].license[]'        # Python-2.0
+nxv search python312 --exact --format json | jq -r '.[0].platforms | join(", ")'
+nxv search hello --format json | jq -r '.[] | select(.known_vulnerabilities != null) | .attribute_path'
+```
+
+> **Version note**: nxv **< 0.5.0** emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
 
 ## Info
 
@@ -123,7 +154,7 @@ nxv history python311 --full             # Add commits, license, homepage, etc.
 nxv history python311 --format json
 ```
 
-**JSON shape per row:**
+**JSON shape per row** — plain `nxv history <pkg>` returns this compact timeline shape:
 
 ```json
 {
@@ -133,6 +164,8 @@ nxv history python311 --format json
   "is_insecure": false
 }
 ```
+
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`.
 
 ## Using a Found Version
 
@@ -375,7 +408,8 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
 - **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
-- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in 0.5.0.
+- **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
 
 ## Practical Tips

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -289,6 +289,52 @@ fn test_search_json_output() {
     assert!(parsed.is_array(), "JSON output should be an array");
 }
 
+/// The JSON row shape documented in `src/skill/SKILL.md`. `license`,
+/// `maintainers`, `platforms` and `known_vulnerabilities` are stored in SQLite
+/// as JSON-array *strings*; that storage detail must never reach the wire
+/// (issue #54), so they serialize as real arrays or `null`.
+#[test]
+fn test_search_json_array_fields_are_not_stringified() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "search",
+            "rustc",
+            "--exact",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let row = &parsed.as_array().unwrap()[0];
+
+    assert_eq!(
+        row.get("license").unwrap(),
+        &serde_json::json!(["MIT", "Apache-2.0"]),
+        "multi-element license must be a real array, not a stringified one"
+    );
+
+    // Columns the fixture leaves NULL stay null rather than becoming `[]`.
+    for field in ["maintainers", "platforms", "known_vulnerabilities"] {
+        assert!(
+            row.get(field).unwrap().is_null(),
+            "{field} should be null when the column is NULL"
+        );
+    }
+
+    // Scalar fields are unaffected by the array treatment.
+    assert_eq!(row.get("attribute_path").unwrap(), "rustc");
+    assert_eq!(row.get("homepage").unwrap(), "https://rust-lang.org");
+}
+
 #[test]
 fn test_search_plain_output() {
     let dir = tempdir().unwrap();
@@ -1025,12 +1071,18 @@ fn test_search_with_license_filter() {
     // Should find python packages with MIT license
     assert!(!results.is_empty(), "Should find packages with MIT license");
 
-    // Verify all results have MIT in their license
+    // Verify all results have MIT in their license. `license` is a real JSON
+    // array, never a stringified one.
     for result in results {
-        let license = result.get("license").and_then(|l| l.as_str()).unwrap_or("");
+        let license = result.get("license").expect("license field present");
+        let entries = license
+            .as_array()
+            .unwrap_or_else(|| panic!("license should be a JSON array, got {}", license));
         assert!(
-            license.contains("MIT"),
-            "License '{}' should contain 'MIT'",
+            entries
+                .iter()
+                .any(|l| l.as_str().is_some_and(|l| l.contains("MIT"))),
+            "License {} should contain 'MIT'",
             license
         );
     }


### PR DESCRIPTION
Closes #54.

## Problem

The indexer normalizes nixpkgs' loosely-typed `meta` fields (`license` is `dict | list[dict] | str | list[str]`; `platforms` is `str | list[str | attrs]`) into a canonical JSON array, which SQLite stores as TEXT. That **storage detail leaked straight through serde** into every output path:

```json
"license": "[\"Python-2.0\"]",
"maintainers": "[\"mweinelt\"]",
"platforms": "[\"x86_64-linux\",\"aarch64-linux\", ...]"
```

So `jq -r '.license'` returned the literal string `["Python-2.0"]`, requiring a second `fromjson` — directly contradicting SKILL.md's own invariant that the JSON shape is *"safe to pipe to `jq`"*.

The same leak corrupted **human-readable** output, which the issue didn't mention:

- `nxv search --show-platforms` rendered a raw ~2000-char JSON blob as a single table cell, blowing the table far past terminal width
- `nxv info --format plain` and `nxv history --full` printed `["MIT"]` for license

## Direction

I chose **fixing the serialization** over documenting the quirk. Documenting `"license": "[\"Python-2.0\"]"` would bake a storage detail into the public contract permanently and leave the "safe to pipe to jq" invariant hollow. Three call sites had already independently hand-rolled `serde_json::from_str::<Vec<String>>` to undo the encoding (`main.rs` maintainers + platforms, `queries.rs::vulnerabilities`), and the web frontend carries a `parseJsonArrayOrString()` helper for the same reason — a clear signal the encoding was wrong at the boundary, not at each render site.

## Changes

**New `src/db/json_array.rs`** — the single decoder for JSON-array columns:

- `parse` tolerates every shape the column has held: real arrays, bare strings (pre-v4 indexes stored `MIT`, not `["MIT"]`), the `null`/`None` sentinels in older rows, and malformed JSON (preserved as a single element rather than silently dropped)
- `serialize_opt` emits a real array, or `null` for a NULL column
- `deserialize_opt` accepts **both** the array form and the legacy stringified form, normalizing back to the canonical string internally

Applied to `license`, `maintainers`, `platforms`, `known_vulnerabilities` on both `PackageVersion` and the API's `PackageVersionSchema` (with `#[schema(value_type = Option<Vec<String>>)]` so `/docs` reflects reality).

Because `deserialize_opt` normalizes back to the stored representation, the table/plain/license-filter/frontend paths needed **no** changes to keep working against either backend.

**Human output** — all render sites now use the shared helper, replacing the three hand-rolled parsers.

**Latent bug fixed along the way**: `is_insecure()` flags any non-empty, non-`[]`, non-`null` string as insecure, but the old `vulnerabilities()` returned `[]` on unparseable JSON — so such a row printed the red *"This package has known vulnerabilities!"* banner followed by **zero** bullet points. `parse` preserving unparseable input makes the two agree. `test_vulnerabilities_invalid_json` was updated to encode that intent.

**Docs** — `src/skill/SKILL.md` (canonical template) now documents all 15 fields with a type table, explains `name` vs `attribute_path` (`name` is the derivation name and is **not** installable — `#python312` works, `#python3` may not), clarifies that `history --full` / `history <pkg> <ver>` return the search row shape rather than the compact timeline shape, and carries a version note with the both-versions `jq` idiom. Checked-in copies regenerated via `cargo run -- skill install claude agents --dir .`.

## Breaking change

`license`, `maintainers`, `platforms` and `known_vulnerabilities` are now arrays instead of JSON-encoded strings in CLI `--format json` and `/api/v1` responses. A **pre-0.5.0 CLI pointed at an upgraded server** will fail to deserialize these fields; the reverse (new CLI → old server) is handled by the tolerant deserializer. Marked `feat!` so release-plz bumps the 0.x minor.

## Testing

- `cargo test --features indexer` — 377 unit + 90 integration, all passing
- `cargo clippy --features indexer --all-targets -- -D warnings` and the featureless variant — both clean
- `cargo fmt` applied
- 13 new unit tests in `json_array` covering legacy strings, sentinels, malformed JSON, non-string elements, null handling and round-tripping
- New `test_search_json_array_fields_are_not_stringified` integration test pins the documented shape, including that NULL columns stay `null` rather than becoming `[]`

## UAT

Against the real 2.1 GB local index, running the SKILL.md examples **verbatim**:

```console
$ nxv search python312 --exact --format json | jq -r '.[0].license[]'
Python-2.0

$ nxv search python312 --exact --format json | jq '.[0] | {license:(.license|type), platforms:(.platforms|type)}'
{ "license": "array", "platforms": "array" }

$ nxv search python312 --exact --show-platforms      # was a raw JSON blob
… ┆ x86_64-linux, aarch64-linux, arc-linux, armv5tel-linux, …

$ nxv info python312 --format plain | grep ^license
license	Python-2.0
```

Verified across `search`, `info`, and `history` in json/plain/table modes.

## Out of scope

UAT surfaced a **separate pre-existing bug** — `nxv history <attr> --full` looks up by the `name` column while the default path uses `attribute_path`, so it silently returns `[]` for any package where they differ (`nxv history python312 --full` → `[]`). Filed as #55 rather than expanding this PR into query semantics.