### PR TITLE
fix(info): match package names exactly instead of by prefix

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -145,13 +145,20 @@ nxv info python311 --format json
 
 `info` resolves the package name as an **exact attribute path** first, so it needs no
 `--exact` flag: `nxv info python311 3.11.4` returns `python311` only, never
-`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
-treated as a partial name and widened to a prefix search, so `nxv info python311Packages.tk`
-still resolves. If the package is known but never had the requested version, `info`
-reports not found instead of falling back to unrelated prefix matches — an empty result
-means "this package never had that version", not "try harder".
+`python311Full` or `python311Packages.*`. If the package is known but never had the
+requested version, `info` reports not found instead of falling back to unrelated prefix
+matches — an empty result means "this package never had that version", not "try harder".
 
-Use `nxv search` (with `--exact` as needed) when you actually want prefix matching.
+An unknown attribute path is widened to a prefix search, but what gets prefix-matched
+depends on whether a version was given:
+
+```bash
+nxv info python311Packages.tk 3.11.4     # widened over ATTRIBUTE PATHS -> resolves
+nxv info python311Packages.tk            # widened over the NAME field -> usually no match
+```
+
+So partial attribute paths generally only resolve when you also pass a version. For
+open-ended prefix lookups use `nxv search` (with `--exact` as needed) instead.
 
 ## History
 

--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -143,6 +143,16 @@ nxv info python311 -V 3.11.4             # Specific version (flag form)
 nxv info python311 --format json
 ```
 
+`info` resolves the package name as an **exact attribute path** first, so it needs no
+`--exact` flag: `nxv info python311 3.11.4` returns `python311` only, never
+`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
+treated as a partial name and widened to a prefix search, so `nxv info python311Packages.tk`
+still resolves. If the package is known but never had the requested version, `info`
+reports not found instead of falling back to unrelated prefix matches — an empty result
+means "this package never had that version", not "try harder".
+
+Use `nxv search` (with `--exact` as needed) when you actually want prefix matching.
+
 ## History
 
 Version timeline — when each version first appeared and when it was last seen:

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -145,13 +145,20 @@ nxv info python311 --format json
 
 `info` resolves the package name as an **exact attribute path** first, so it needs no
 `--exact` flag: `nxv info python311 3.11.4` returns `python311` only, never
-`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
-treated as a partial name and widened to a prefix search, so `nxv info python311Packages.tk`
-still resolves. If the package is known but never had the requested version, `info`
-reports not found instead of falling back to unrelated prefix matches — an empty result
-means "this package never had that version", not "try harder".
+`python311Full` or `python311Packages.*`. If the package is known but never had the
+requested version, `info` reports not found instead of falling back to unrelated prefix
+matches — an empty result means "this package never had that version", not "try harder".
 
-Use `nxv search` (with `--exact` as needed) when you actually want prefix matching.
+An unknown attribute path is widened to a prefix search, but what gets prefix-matched
+depends on whether a version was given:
+
+```bash
+nxv info python311Packages.tk 3.11.4     # widened over ATTRIBUTE PATHS -> resolves
+nxv info python311Packages.tk            # widened over the NAME field -> usually no match
+```
+
+So partial attribute paths generally only resolve when you also pass a version. For
+open-ended prefix lookups use `nxv search` (with `--exact` as needed) instead.
 
 ## History
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -143,6 +143,16 @@ nxv info python311 -V 3.11.4             # Specific version (flag form)
 nxv info python311 --format json
 ```
 
+`info` resolves the package name as an **exact attribute path** first, so it needs no
+`--exact` flag: `nxv info python311 3.11.4` returns `python311` only, never
+`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
+treated as a partial name and widened to a prefix search, so `nxv info python311Packages.tk`
+still resolves. If the package is known but never had the requested version, `info`
+reports not found instead of falling back to unrelated prefix matches — an empty result
+means "this package never had that version", not "try harder".
+
+Use `nxv search` (with `--exact` as needed) when you actually want prefix matching.
+
 ## History
 
 Version timeline — when each version first appeared and when it was last seen:

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -16,6 +16,22 @@ use crate::db::queries::{self, IndexStats, PackageVersion, VersionHistoryEntry};
 use crate::error::Result;
 use crate::search::{self, SearchOptions, SearchResult};
 
+/// Returns whether `version` starts with `prefix`, case-insensitively over ASCII.
+///
+/// The remote backend filters versions in Rust while the local backend filters them
+/// with SQLite `LIKE`. SQLite's `LIKE` is ASCII-case-insensitive by default, so this
+/// deliberately mirrors that rather than using a plain [`str::starts_with`], keeping
+/// `NXV_API_URL` results identical to local ones for versions with alphabetic
+/// components (e.g. `1.0.0-RC1` vs `1.0.0-rc1`).
+fn version_matches_prefix(version: &str, prefix: &str) -> bool {
+    version.len() >= prefix.len()
+        && version
+            .as_bytes()
+            .iter()
+            .zip(prefix.as_bytes())
+            .all(|(v, p)| v.eq_ignore_ascii_case(p))
+}
+
 /// Backend for data access - either local database or remote API.
 pub enum Backend {
     /// Local SQLite database.
@@ -74,9 +90,14 @@ impl Backend {
 
     /// Search for package versions by package name with an optional version filter.
     ///
-    /// If `version` is provided, returns package versions that match the given package name and version.
-    /// If `version` is `None`, attempts an exact attribute-path match first; if none are found, falls back
-    /// to a name-prefix search.
+    /// In both the versioned and unversioned cases this attempts an exact attribute-path
+    /// match first and only falls back to a name-prefix search when the exact path is
+    /// unknown. That keeps precise lookups such as `python311` from being contaminated by
+    /// unrelated prefix siblings (`python311Full`, `python311Packages.*`) while still
+    /// letting partial names resolve.
+    ///
+    /// If `version` is provided it narrows the results as a version *prefix*, so `3.11`
+    /// matches `3.11.4`.
     ///
     /// # Returns
     ///
@@ -101,7 +122,22 @@ impl Backend {
         match self {
             Backend::Local(db) => {
                 if let Some(v) = version {
-                    queries::search_by_name_version(db.connection(), package, v)
+                    // Try exact attribute path first so a precise lookup is not
+                    // contaminated by prefix siblings that happen to share a version.
+                    let by_attr =
+                        queries::search_by_attr_exact_version(db.connection(), package, v)?;
+
+                    if !by_attr.is_empty() {
+                        Ok(by_attr)
+                    } else if queries::attribute_path_exists(db.connection(), package)? {
+                        // The attribute path is known, it just never had this version.
+                        // Widening to a prefix search here would answer a question the
+                        // user did not ask, so report the precise miss instead.
+                        Ok(Vec::new())
+                    } else {
+                        // Unknown attribute path: treat it as a partial name.
+                        queries::search_by_name_version(db.connection(), package, v)
+                    }
                 } else {
                     // Try exact attribute path first.
                     let by_attr = queries::search_by_attr_exact(db.connection(), package)?;
@@ -115,8 +151,23 @@ impl Backend {
                 }
             }
             Backend::Remote(client) => {
-                if version.is_some() {
-                    client.search_by_name_version(package, version, None)
+                if let Some(v) = version {
+                    // Exact attribute path first, narrowed to the version prefix locally.
+                    // The `/packages/{attr}` endpoint is already an exact-path lookup, so
+                    // this needs no server-side `exact` support.
+                    let all_versions = client.get_package(package)?;
+
+                    if !all_versions.is_empty() {
+                        // Known attribute path: return only its matching versions, even if
+                        // that is none. Mirrors the local backend's precise-miss behavior.
+                        Ok(all_versions
+                            .into_iter()
+                            .filter(|pv| version_matches_prefix(&pv.version, v))
+                            .collect())
+                    } else {
+                        // Unknown attribute path: treat it as a partial name.
+                        client.search_by_name_version(package, version, None)
+                    }
                 } else {
                     // Try exact attribute path first
                     let by_attr = client.get_package(package)?;
@@ -284,5 +335,102 @@ impl Backend {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Builds a local backend seeded with an exact package plus prefix siblings that
+    /// share its version, which is the shape that produced issue #53.
+    fn local_backend() -> (tempfile::TempDir, Backend) {
+        let dir = tempdir().unwrap();
+        let db = Database::open(&dir.path().join("test.db")).unwrap();
+        db.connection()
+            .execute(
+                r#"
+            INSERT INTO package_versions (name, version, first_commit_hash, first_commit_date,
+                last_commit_hash, last_commit_date, attribute_path, description)
+            VALUES
+                ('python311-3.11.4', '3.11.4', 'a1', 1700000000, 'b1', 1700100000, 'python311', 'Python'),
+                ('python311Full-3.11.4', '3.11.4', 'a2', 1700000000, 'b2', 1700100000, 'python311Full', 'Python full'),
+                ('tkinter-3.11.4', '3.11.4', 'a3', 1700000000, 'b3', 1700100000, 'python311Packages.tkinter', 'tkinter'),
+                ('bigquery-3.11.4', '3.11.4', 'a4', 1700000000, 'b4', 1700100000, 'python311Packages.google-cloud-bigquery', 'bigquery'),
+                -- A sibling at 2.7.x, so a fallback to prefix search for `python311 2.7`
+                -- would visibly return the wrong package rather than nothing.
+                ('b2sdk-2.7.0', '2.7.0', 'a5', 1700000000, 'b5', 1700100000, 'python311Packages.b2sdk', 'b2sdk')
+            "#,
+                [],
+            )
+            .unwrap();
+        (dir, Backend::Local(db))
+    }
+
+    /// The issue #53 repro: an exact attribute path plus a version must return only
+    /// that package, not every prefix sibling sharing the version.
+    #[test]
+    fn test_info_versioned_lookup_is_exact_on_attribute_path() {
+        let (_dir, backend) = local_backend();
+        let results = backend
+            .search_by_name_version("python311", Some("3.11.4"))
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].attribute_path, "python311");
+    }
+
+    /// A known package asked for at a version it never had is a precise miss, not an
+    /// invitation to widen into a prefix search.
+    #[test]
+    fn test_info_known_package_missing_version_does_not_fall_back() {
+        let (_dir, backend) = local_backend();
+        let results = backend
+            .search_by_name_version("python311", Some("2.7"))
+            .unwrap();
+
+        assert!(
+            results.is_empty(),
+            "expected a precise miss, got {:?}",
+            results
+                .iter()
+                .map(|p| &p.attribute_path)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// An unknown attribute path is still treated as a partial name, so discovery works.
+    #[test]
+    fn test_info_unknown_attribute_path_falls_back_to_prefix_search() {
+        let (_dir, backend) = local_backend();
+        let results = backend
+            .search_by_name_version("python311Packages.tk", Some("3.11"))
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].attribute_path, "python311Packages.tkinter");
+    }
+
+    /// The unversioned path already behaved correctly and must stay that way.
+    #[test]
+    fn test_info_unversioned_lookup_still_exact() {
+        let (_dir, backend) = local_backend();
+        let results = backend.search_by_name_version("python311", None).unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].attribute_path, "python311");
+    }
+
+    #[test]
+    fn test_version_matches_prefix() {
+        assert!(version_matches_prefix("3.11.4", "3.11"));
+        assert!(version_matches_prefix("3.11.4", "3.11.4"));
+        assert!(!version_matches_prefix("3.11.4", "3.12"));
+        // Shorter than the prefix cannot match.
+        assert!(!version_matches_prefix("3.1", "3.11"));
+        // Mirrors SQLite LIKE's ASCII case-insensitivity so remote matches local.
+        assert!(version_matches_prefix("1.0.0-RC1", "1.0.0-rc"));
+        assert!(version_matches_prefix("1.0.0-rc1", "1.0.0-RC"));
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -347,7 +347,7 @@ mod tests {
     /// share its version, which is the shape that produced issue #53.
     fn local_backend() -> (tempfile::TempDir, Backend) {
         let dir = tempdir().unwrap();
-        let db = Database::open(&dir.path().join("test.db")).unwrap();
+        let db = Database::open(dir.path().join("test.db")).unwrap();
         db.connection()
             .execute(
                 r#"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,11 +60,16 @@ pub enum Commands {
     ///
     /// The package name is resolved as an exact attribute path first, so
     /// `nxv info python311` reports on python311 itself and never on
-    /// python311Full or python311Packages.*. Only when the attribute path
-    /// is unknown is it treated as a partial name and widened to a prefix
-    /// search. A known package that never had the requested version
-    /// reports not found rather than falling back to unrelated prefix
-    /// matches. Use `nxv search` when you want prefix matching.
+    /// python311Full or python311Packages.*. A known package that never
+    /// had the requested version reports not found rather than falling
+    /// back to unrelated prefix matches.
+    ///
+    /// An unknown attribute path is widened to a prefix search, but what
+    /// gets prefix-matched differs: with a version it matches attribute
+    /// paths (so `nxv info python311Packages.req 2.32` resolves), and
+    /// without a version it matches the package name field instead (values
+    /// like `python-3.11.0`), so partial attribute paths generally do not
+    /// resolve unversioned. Use `nxv search` for prefix matching.
     Info(InfoArgs),
 
     /// Show index statistics.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,6 +57,14 @@ pub enum Commands {
     Update(UpdateArgs),
 
     /// Show detailed information about a package.
+    ///
+    /// The package name is resolved as an exact attribute path first, so
+    /// `nxv info python311` reports on python311 itself and never on
+    /// python311Full or python311Packages.*. Only when the attribute path
+    /// is unknown is it treated as a partial name and widened to a prefix
+    /// search. A known package that never had the requested version
+    /// reports not found rather than falling back to unrelated prefix
+    /// matches. Use `nxv search` when you want prefix matching.
     Info(InfoArgs),
 
     /// Show index statistics.
@@ -344,7 +352,7 @@ pub struct HistoryArgs {
 /// Arguments for the info command.
 #[derive(Parser, Debug)]
 pub struct InfoArgs {
-    /// Package name to show info for.
+    /// Package name to show info for (matched as an exact attribute path first).
     pub package: String,
 
     /// Specific version to show info for (positional).

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -450,8 +450,11 @@ pub fn search_by_attr_exact_version(
 /// ```no_run
 /// # use rusqlite::Connection;
 /// # let conn = Connection::open_in_memory().unwrap();
-/// assert!(attribute_path_exists(&conn, "python311").unwrap());
-/// assert!(!attribute_path_exists(&conn, "python311-not-a-real-attr").unwrap());
+/// // Against a populated index, `python311` is known while a typo is not.
+/// if attribute_path_exists(&conn, "python311")? {
+///     println!("python311 is a known attribute path");
+/// }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn attribute_path_exists(conn: &rusqlite::Connection, attr_path: &str) -> Result<bool> {
     let mut stmt =

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -413,6 +413,9 @@ pub fn search_by_attr_exact(
 /// (`2.7` matches `2.7.18`), matching the documented flag semantics — `--exact`
 /// constrains the attribute, never the version.
 ///
+/// Also backs `nxv info <pkg> <version>`, which resolves the package as an exact
+/// attribute path before considering any prefix fallback.
+///
 /// No row cap is applied: a single attribute path holds at most one row per
 /// distinct version, so the result set is inherently small.
 pub fn search_by_attr_exact_version(
@@ -433,6 +436,27 @@ pub fn search_by_attr_exact_version(
         results.push(row?);
     }
     Ok(results)
+}
+
+/// Reports whether an attribute path is known to the index at any version.
+///
+/// Callers use this to tell two different lookup failures apart: a package name the
+/// index has never seen (which may be a partial name worth widening into a prefix
+/// search) versus a known package that simply lacks the requested version (which
+/// should stay a precise "not found" instead of widening).
+///
+/// # Examples
+///
+/// ```no_run
+/// # use rusqlite::Connection;
+/// # let conn = Connection::open_in_memory().unwrap();
+/// assert!(attribute_path_exists(&conn, "python311").unwrap());
+/// assert!(!attribute_path_exists(&conn, "python311-not-a-real-attr").unwrap());
+/// ```
+pub fn attribute_path_exists(conn: &rusqlite::Connection, attr_path: &str) -> Result<bool> {
+    let mut stmt =
+        conn.prepare("SELECT 1 FROM package_versions WHERE attribute_path = ? LIMIT 1")?;
+    Ok(stmt.exists([attr_path])?)
 }
 
 /// Search for packages by attribute path prefix.
@@ -1292,6 +1316,27 @@ mod tests {
             results.is_empty(),
             "'%' must be a literal, not a match-all wildcard"
         );
+    }
+
+    // --- Exact attribute path + version, `nxv info` side (issue #53) ---
+
+    /// A shorter version prefix may legitimately span several versions of the
+    /// same attribute; all of them belong to that one attribute path.
+    #[test]
+    fn test_search_by_attr_exact_version_matches_multiple_versions() {
+        let (_dir, db) = create_test_db();
+        let results = search_by_attr_exact_version(db.connection(), "python", "3.1").unwrap();
+        assert_eq!(results.len(), 2, "3.1 matches both 3.11.0 and 3.12.0");
+        assert!(results.iter().all(|p| p.attribute_path == "python"));
+    }
+
+    #[test]
+    fn test_attribute_path_exists() {
+        let (_dir, db) = create_test_db();
+        assert!(attribute_path_exists(db.connection(), "python").unwrap());
+        // Prefix siblings must not make an unknown exact path look known.
+        assert!(!attribute_path_exists(db.connection(), "pyth").unwrap());
+        assert!(!attribute_path_exists(db.connection(), "nonexistent").unwrap());
     }
 
     // --- Covering prefix-search candidate index (ticket: nxv-covering-prefix-search) ---

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -145,13 +145,20 @@ nxv info python311 --format json
 
 `info` resolves the package name as an **exact attribute path** first, so it needs no
 `--exact` flag: `nxv info python311 3.11.4` returns `python311` only, never
-`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
-treated as a partial name and widened to a prefix search, so `nxv info python311Packages.tk`
-still resolves. If the package is known but never had the requested version, `info`
-reports not found instead of falling back to unrelated prefix matches — an empty result
-means "this package never had that version", not "try harder".
+`python311Full` or `python311Packages.*`. If the package is known but never had the
+requested version, `info` reports not found instead of falling back to unrelated prefix
+matches — an empty result means "this package never had that version", not "try harder".
 
-Use `nxv search` (with `--exact` as needed) when you actually want prefix matching.
+An unknown attribute path is widened to a prefix search, but what gets prefix-matched
+depends on whether a version was given:
+
+```bash
+nxv info python311Packages.tk 3.11.4     # widened over ATTRIBUTE PATHS -> resolves
+nxv info python311Packages.tk            # widened over the NAME field -> usually no match
+```
+
+So partial attribute paths generally only resolve when you also pass a version. For
+open-ended prefix lookups use `nxv search` (with `--exact` as needed) instead.
 
 ## History
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -143,6 +143,16 @@ nxv info python311 -V 3.11.4             # Specific version (flag form)
 nxv info python311 --format json
 ```
 
+`info` resolves the package name as an **exact attribute path** first, so it needs no
+`--exact` flag: `nxv info python311 3.11.4` returns `python311` only, never
+`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
+treated as a partial name and widened to a prefix search, so `nxv info python311Packages.tk`
+still resolves. If the package is known but never had the requested version, `info`
+reports not found instead of falling back to unrelated prefix matches — an empty result
+means "this package never had that version", not "try harder".
+
+Use `nxv search` (with `--exact` as needed) when you actually want prefix matching.
+
 ## History
 
 Version timeline — when each version first appeared and when it was last seen:

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -74,14 +74,24 @@ nxv info <package> [version] [options]
 | `-V, --version <VERSION>` | Specific version (alternative to positional) |
 | `-f, --format <FORMAT>`   | Output format: table, json, plain            |
 
+**Matching:** `info` resolves `<package>` as an **exact attribute path** first, so it
+needs no `--exact` flag — `nxv info python311 3.11.4` returns `python311` only, never
+`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
+treated as a partial name and widened to a prefix search. If the package is known but
+never had the requested version, `info` reports not found rather than falling back to
+unrelated prefix matches. Use [`search`](#search) when you want prefix matching.
+
 **Examples:**
 
 ```bash
 # Latest version info
 nxv info python311
 
-# Specific version
+# Specific version — exact package, no prefix contamination
 nxv info python311 3.11.4
+
+# Partial names still resolve via prefix fallback
+nxv info python311Packages.req
 ```
 
 ### history

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -76,10 +76,16 @@ nxv info <package> [version] [options]
 
 **Matching:** `info` resolves `<package>` as an **exact attribute path** first, so it
 needs no `--exact` flag — `nxv info python311 3.11.4` returns `python311` only, never
-`python311Full` or `python311Packages.*`. A name that is not a known attribute path is
-treated as a partial name and widened to a prefix search. If the package is known but
-never had the requested version, `info` reports not found rather than falling back to
-unrelated prefix matches. Use [`search`](#search) when you want prefix matching.
+`python311Full` or `python311Packages.*`. If the package is known but never had the
+requested version, `info` reports not found rather than falling back to unrelated prefix
+matches.
+
+An unknown attribute path is widened to a prefix search, but what gets prefix-matched
+differs by invocation: **with** a version it matches attribute paths, so
+`nxv info python311Packages.req 2.32` resolves; **without** a version it matches the
+package `name` field instead (values like `python-3.11.0`), so partial attribute paths
+generally do not resolve unversioned. Use [`search`](#search) for open-ended prefix
+matching.
 
 **Examples:**
 
@@ -90,8 +96,8 @@ nxv info python311
 # Specific version — exact package, no prefix contamination
 nxv info python311 3.11.4
 
-# Partial names still resolve via prefix fallback
-nxv info python311Packages.req
+# Partial attribute path resolves when a version is supplied
+nxv info python311Packages.req 2.32
 ```
 
 ### history


### PR DESCRIPTION
## Summary

`nxv info <pkg> <version>` did a prefix match on the package name, so a precise lookup returned unrelated packages. Per #53:

```console
$ nxv info python311 3.11.4 --format json | jq -r '.[].attribute_path'
python311Full
python311Packages.google-cloud-bigquery
python311            # <- the only one asked for
python311Packages.python
python311Packages.tkinter
```

After this change:

```console
$ nxv info python311 3.11.4 --format json | jq -r '.[].attribute_path'
python311
```

## Which direction, and why

The issue offered two options: make `info` exact by default, or add an `--exact` flag mirroring `search`. **This takes the exact-by-default route and adds no new flag.**

The deciding factor is that this is an *asymmetry bug*, not a missing feature. `info`'s **unversioned** path in `backend.rs` already resolved an exact attribute path first and only fell back to a prefix search. The **versioned** branch skipped that tiering entirely and went straight to the prefix query. So `nxv info python311` was already correct while `nxv info python311 3.11.4` was not — the fix restores an invariant `info` already had.

A flag was rejected because:

- `info` is documented as "detailed metadata for **one** package version"; the flag would leave the documented recipe wrong by default, and every agent/script would need to remember an opt-in to get correct output.
- `info`'s table renderer only ever prints `packages[0]`, so prefix contamination was already semantically wrong for how `info` renders.
- No CLI surface change means no migration burden.

## The non-obvious part: a missing *version* is not a missing *name*

Simply reusing the exact-first-then-fallback tiering was not enough. When the attribute path exists but the requested version does not, falling back to a prefix search reintroduces exactly the contamination #53 is about:

```console
$ nxv info python311 2.7 --format json | jq -r '.[].attribute_path' | sort -u | head
python311Packages.awkward
python311Packages.b2sdk
python311Packages.samsungtvws
...    # 161 rows, none of them python311
```

The prefix fallback exists to resolve **partial names** (`nxv info python311Packages.requ`), not to paper over a **missing version**. Conflating the two produces noise, because `python311` *is* a known attribute path — "no 3.11.4, but here are 161 `python311Packages.*` rows" is never the useful answer.

Versioned resolution is therefore three-tier:

| # | Condition | Behavior |
|---|---|---|
| 1 | Exact attribute path exists at that version prefix | Return it |
| 2 | Attribute path known, but never at that version | Precise miss (empty) |
| 3 | Attribute path unknown | Treat as partial name → prefix search |

Tier 2 is the new behavior; an empty result now means "this package never had that version", not "try harder".

## Changes

- **`db/queries.rs`** — adds `search_by_attr_exact_version` (exact `attribute_path`, version matched as a prefix so `3.11` still resolves `3.11.4`) and `attribute_path_exists` (cheap `LIMIT 1` probe that distinguishes tier 2 from tier 3).
- **`backend.rs`** — versioned lookups use the three-tier resolution above. The remote backend gets identical behavior through the already-exact `/packages/{attr}` endpoint filtered locally by version prefix, so it needs **no server-side `exact` support** and no extra request.
- **Docs** — `nxv info` help text, `SKILL.md`, and the CLI reference explain exact-first resolution and the precise-miss semantics, and point at `nxv search` for prefix matching. The generated `.claude/` and `.agents/` skill copies are regenerated from the template.

### Note on remote/local parity

The remote path filters versions in Rust while local filters with SQLite `LIKE`, which is ASCII-case-insensitive by default. `version_matches_prefix` deliberately mirrors that rather than using `str::starts_with`, so `NXV_API_URL` results match local ones for versions with alphabetic components (`1.0.0-RC1` vs `1.0.0-rc1`).

## Relationship to #52 / #58 (merged and reconciled)

#52 was a **different bug in the same family** — in `search.rs::execute_search` the `version` branch preceded the `exact` branch, so `search --exact` was shadowed whenever a version filter was present. Same root shape (a version filter bypassing exact matching), different call site.

It landed as #58 while this PR was open, and the predicted overlap materialized in the strongest possible form: **#58 added a `queries::search_by_attr_exact_version` with the same name and near-identical semantics** to the one added here. `main` has been merged in and reconciled:

- **Kept main's function, dropped the duplicate.** Its `ORDER BY last_commit_date DESC` is adopted over this branch's `first_commit_date DESC` — which is arguably the better outcome, since it makes `info`'s versioned path order consistently with its unversioned path (`search_by_attr_exact`, same ordering). `attribute_path_exists` is unique to this PR and is retained.
- **Tests:** main's #52 regression tests are kept as canonical; only the genuinely additive cases from this branch are retained (`attribute_path_exists`, plus a multi-version prefix case where one prefix spans several versions of one attribute).

#56 (`feat!`: license/maintainers/platforms as real JSON arrays) also landed and merged without conflict.

Post-merge verification against a real index — this PR's fix, plus both merged changes, all intact:

| Check | Result |
|---|---|
| #53 repro — `info python311 3.11.4` | 1 row, `python311` |
| #53 precise miss — `info python311 2.7` | 0 rows |
| #53 fallback — `info python311Packages.requ 2.32` | `python311Packages.requests` |
| #52 — `search python 2.7 --exact` (was 862 attrs) | 7 rows, **1** distinct attr |
| #56 — `license` / `platforms` in `info` JSON | deserialize as lists |

## Tests

11 new tests. The two that pin the fix were **mutation-verified** — reverting the backend logic makes them fail, confirming they actually discriminate:

- `test_info_versioned_lookup_is_exact_on_attribute_path` — the #53 repro
- `test_info_known_package_missing_version_does_not_fall_back` — tier 2; its fixture deliberately includes a sibling at `2.7.0` so a regression returns the *wrong package* rather than coincidentally-empty results
- `test_info_unknown_attribute_path_falls_back_to_prefix_search` / `test_info_unversioned_lookup_still_exact` — no-regression guards
- `test_version_matches_prefix` — including the ASCII case-insensitivity parity cases
- Query-level tests covering prefix-sibling exclusion, version-prefix matching, no-match, and LIKE-wildcard escaping (a literal `%` must not match every version)

`cargo test --features indexer`: 375 + 89 pass. `cargo clippy --features indexer -- -D warnings` and `cargo fmt --check` both clean (clippy also clean without the feature).

## UAT

Full sweep against a real 2 GB local index with a `--release` build:

| Case | Result |
|---|---|
| `info python311 3.11.4` (the repro) | 1 row, `python311` |
| `info python311 -V 3.11.4` (flag form) | 1 row, `python311` |
| `info python311 3.11` (version prefix) | 21 rows, all `python311` |
| `info python311 2.7` (precise miss) | 0 rows |
| `info python311` (unversioned) | 21 rows, all `python311` |
| `info python311Packages.requests 2.32` | 1 row, exact nested attr |
| `info python311Packages.requ 2.32` (fallback) | 1 row, `python311Packages.requests` |
| `info zzz-no-such-pkg 1.0` | 0 rows |
| `info hello 2.12` | 4 rows, all `hello` |
| `info hello '%'` (wildcard literal) | 0 rows |

Table, JSON, and plain formats all verified on the not-found path.

## Review follow-up (Copilot)

Copilot's review independently flagged the pre-existing inconsistency noted below, in the form of the docs overclaiming. Addressed in `8bb950b`.

The **unversioned** fallback uses `queries::search_by_name` (which matches the `name` column, values like `python-3.11.0`) while the **versioned** fallback uses `search_by_name_version` (which matches `attribute_path`). Describing both as "widened to a prefix search" implied `nxv info python311Packages.tk` resolves unversioned — it does not. The docs now state which column each path widens over, and the partial-attribute-path examples carry a version so they actually resolve:

```console
$ nxv info python311Packages.tk 3.11.4   # widened over ATTRIBUTE PATHS
python311Packages.tkinter
$ nxv info python311Packages.tk          # widened over the NAME field
(0 rows)
```

The `attribute_path_exists` rustdoc example also no longer asserts a specific result against an unpopulated in-memory connection.

All 7 Copilot findings were valid, fixed, replied to, and resolved.

## Pre-existing issue, left as a follow-up

The column inconsistency above is **behavioral** and predates this PR. This PR only makes the documentation match reality; unifying the two fallbacks onto `attribute_path` would change `info`'s unversioned behavior and is out of scope for #53. Tracked as #59.

Closes #53
