### PR TITLE
fix(search): honor --exact when a version filter is present

### DIFF
--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -386,6 +386,35 @@ pub fn search_by_attr_exact(
     Ok(results)
 }
 
+/// Search for packages by exact attribute path, restricted to a version prefix.
+///
+/// This is the `--exact` counterpart to [`search_by_name_version`]: the
+/// attribute path must match exactly while the version is still a prefix match
+/// (`2.7` matches `2.7.18`), matching the documented flag semantics — `--exact`
+/// constrains the attribute, never the version.
+///
+/// No row cap is applied: a single attribute path holds at most one row per
+/// distinct version, so the result set is inherently small.
+pub fn search_by_attr_exact_version(
+    conn: &rusqlite::Connection,
+    attr_path: &str,
+    version: &str,
+) -> Result<Vec<PackageVersion>> {
+    let mut stmt = conn.prepare(
+        "SELECT * FROM package_versions WHERE attribute_path = ? \
+           AND version LIKE ? ESCAPE '\\' \
+         ORDER BY last_commit_date DESC",
+    )?;
+    let version_pattern = format!("{}%", escape_like_pattern(version));
+    let rows = stmt.query_map([attr_path, &version_pattern], PackageVersion::from_row)?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
 /// Search for packages by attribute path prefix.
 pub fn search_by_attr(conn: &rusqlite::Connection, attr_path: &str) -> Result<Vec<PackageVersion>> {
     let mut stmt = conn.prepare(&format!(
@@ -1200,6 +1229,49 @@ mod tests {
         let results = search_by_attr_exact(db.connection(), "python").unwrap();
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|p| p.attribute_path == "python"));
+    }
+
+    /// Regression for #52: with a version filter present, the exact-attribute
+    /// restriction must still hold. `python2` carries 2.7.18 and would be
+    /// returned by the prefix-matching version query.
+    #[test]
+    fn test_search_by_attr_exact_version_excludes_prefix_siblings() {
+        let (_dir, db) = create_test_db();
+
+        // The prefix path matches the sibling attr `python2`...
+        let prefixed = search_by_name_version(db.connection(), "python", "2.7").unwrap();
+        assert_eq!(prefixed.len(), 1);
+        assert_eq!(prefixed[0].attribute_path, "python2");
+
+        // ...while the exact path must not: `python` was never at 2.7.x.
+        let exact = search_by_attr_exact_version(db.connection(), "python", "2.7").unwrap();
+        assert!(
+            exact.is_empty(),
+            "--exact must not leak sibling attrs, got {:?}",
+            exact.iter().map(|p| &p.attribute_path).collect::<Vec<_>>()
+        );
+    }
+
+    /// The version half of an exact search stays a prefix match: `3.11`
+    /// resolves `3.11.0` without requiring the full version string.
+    #[test]
+    fn test_search_by_attr_exact_version_matches_version_prefix() {
+        let (_dir, db) = create_test_db();
+        let results = search_by_attr_exact_version(db.connection(), "python", "3.11").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].attribute_path, "python");
+        assert_eq!(results[0].version, "3.11.0");
+    }
+
+    /// LIKE metacharacters in the version filter are literals, not wildcards.
+    #[test]
+    fn test_search_by_attr_exact_version_escapes_wildcards() {
+        let (_dir, db) = create_test_db();
+        let results = search_by_attr_exact_version(db.connection(), "python", "%").unwrap();
+        assert!(
+            results.is_empty(),
+            "'%' must be a literal, not a match-all wildcard"
+        );
     }
 
     // --- Covering prefix-search candidate index (ticket: nxv-covering-prefix-search) ---

--- a/src/search.rs
+++ b/src/search.rs
@@ -133,8 +133,14 @@ pub fn execute_search(conn: &Connection, opts: &SearchOptions) -> Result<SearchR
         // FTS search on description
         queries::search_by_description(conn, &opts.query)?
     } else if let Some(ref version) = opts.version {
-        // Search by name and version
-        queries::search_by_name_version(conn, &opts.query, version)?
+        // Search by name and version. `--exact` composes with the version
+        // filter rather than being shadowed by it: the attribute path must
+        // match exactly, the version stays a prefix match.
+        if opts.exact {
+            queries::search_by_attr_exact_version(conn, &opts.query, version)?
+        } else {
+            queries::search_by_name_version(conn, &opts.query, version)?
+        }
     } else if opts.exact {
         // Exact match on attribute_path. Avoid the old prefix query + Rust
         // filter path, which materialized thousands of sibling attrs on v4 DBs.
@@ -467,6 +473,126 @@ mod tests {
         assert!(!opts.full);
         assert!(!opts.reverse);
         assert_eq!(opts.sort, SortOrder::Date);
+    }
+}
+
+/// Regression coverage for #52: `--exact` was shadowed by the version filter
+/// because `execute_search` dispatched on `version` before `exact`, routing the
+/// query into the prefix-matching `search_by_name_version`. These tests drive
+/// the real dispatch, so they fail if the branch ordering regresses.
+///
+/// Both the CLI and the API server build `SearchOptions` and call
+/// `execute_search`, so covering it here covers both front ends.
+#[cfg(test)]
+mod exact_with_version_tests {
+    use super::*;
+    use crate::db::Database;
+    use tempfile::{TempDir, tempdir};
+
+    /// Mirrors the issue's repro shape. Deliberately tuned so every assertion
+    /// below is non-vacuous — i.e. genuinely fails if the `exact` branch is
+    /// removed from `execute_search`:
+    ///  * `python` is the only exact attr, and it is NEVER at 2.7.x, so the
+    ///    2.7 queries must return zero rather than the siblings that do match;
+    ///  * `python313Packages.django` sits at 3.11.2 so even the "matching"
+    ///    3.11 query has a sibling to wrongly pick up without the fix.
+    const SEED: &str = r#"
+        INSERT INTO package_versions
+            (name, version, first_commit_hash, first_commit_date,
+             last_commit_hash, last_commit_date, attribute_path, description, license)
+        VALUES
+            ('python', '3.11.0', 'h1', 100, 'l1', 900, 'python',  'd', 'MIT'),
+            ('python2', '2.7.18', 'h2', 100, 'l2', 800, 'python2', 'd', 'MIT'),
+            ('granian', '2.7.9', 'h3', 100, 'l3', 700, 'python314Packages.granian', 'd', 'MIT'),
+            ('aiohappyeyeballs', '2.7.1', 'h4', 100, 'l4', 600, 'python313Packages.aiohappyeyeballs', 'd', 'MIT'),
+            ('django', '3.11.2', 'h5', 100, 'l5', 500, 'python313Packages.django', 'd', 'MIT');
+    "#;
+
+    fn seeded_db() -> (TempDir, Database) {
+        let dir = tempdir().unwrap();
+        let db = Database::open(dir.path().join("test.db")).unwrap();
+        db.connection().execute_batch(SEED).unwrap();
+        (dir, db)
+    }
+
+    fn opts(query: &str, version: Option<&str>, exact: bool) -> SearchOptions {
+        SearchOptions {
+            query: query.to_string(),
+            version: version.map(str::to_string),
+            exact,
+            limit: 0, // unlimited, matching the issue's `--limit 0`
+            ..Default::default()
+        }
+    }
+
+    /// The version the exact attr does carry: only `python` may come back,
+    /// never `python313Packages.django`, which also sits at 3.11.x.
+    #[test]
+    fn exact_with_version_filter_restricts_to_the_named_attr() {
+        let (_dir, db) = seeded_db();
+
+        let res = execute_search(db.connection(), &opts("python", Some("3.11"), true)).unwrap();
+
+        assert_eq!(
+            res.total,
+            1,
+            "--exact leaked sibling attrs: {:?}",
+            res.data
+                .iter()
+                .map(|p| &p.attribute_path)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(res.data[0].attribute_path, "python");
+        assert_eq!(res.data[0].version, "3.11.0");
+    }
+
+    /// The issue's own repro: `python` was never at 2.7.x, so the result must
+    /// be empty even though three sibling attrs do match that version prefix.
+    #[test]
+    fn exact_with_version_never_held_by_the_attr_returns_no_rows() {
+        let (_dir, db) = seeded_db();
+
+        let res = execute_search(db.connection(), &opts("python", Some("2.7"), true)).unwrap();
+
+        assert_eq!(
+            res.total,
+            0,
+            "python was never at 2.7.x, got {:?}",
+            res.data
+                .iter()
+                .map(|p| &p.attribute_path)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Guard the other half of the contract: without `--exact` the prefix
+    /// behavior is unchanged, so this failing means the fix over-reached.
+    #[test]
+    fn non_exact_with_version_filter_still_matches_prefix_siblings() {
+        let (_dir, db) = seeded_db();
+
+        let res = execute_search(db.connection(), &opts("python", Some("2.7"), false)).unwrap();
+
+        assert_eq!(res.total, 3, "prefix search should keep all 2.7.x siblings");
+        assert!(
+            res.data
+                .iter()
+                .any(|p| p.attribute_path == "python314Packages.granian")
+        );
+    }
+
+    /// `--exact` composes with the version filter without disturbing the
+    /// version's prefix semantics: a bare `3` still resolves `3.11.0`, and
+    /// still excludes the 3.11.x sibling.
+    #[test]
+    fn exact_keeps_version_as_a_prefix_match() {
+        let (_dir, db) = seeded_db();
+
+        let res = execute_search(db.connection(), &opts("python", Some("3"), true)).unwrap();
+
+        assert_eq!(res.total, 1);
+        assert_eq!(res.data[0].attribute_path, "python");
+        assert_eq!(res.data[0].version, "3.11.0");
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -230,6 +230,109 @@ fn test_search_exact_match() {
         .stdout(predicate::str::contains("3.11").or(predicate::str::contains("3.12")));
 }
 
+/// Regression for #52: `--exact` used to be silently dropped whenever a
+/// version filter was present, so `nxv search python 3.11 --exact` returned
+/// `python311` too. Both invocation styles (positional and `-V`) are covered
+/// because they feed the same `SearchOptions`.
+#[test]
+fn test_search_exact_with_version_filter_restricts_to_exact_attr() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bloom_path = dir.path().join("nonexistent.bloom");
+    create_test_db(&db_path);
+
+    // `python` and `python311` both carry 3.11.0; --exact must keep only `python`.
+    for version_args in [vec!["3.11"], vec!["-V", "3.11"]] {
+        let mut args = vec![
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "search",
+            "python",
+            "--exact",
+            "--format",
+            "json",
+            "--limit",
+            "0",
+        ];
+        args.extend(version_args.iter());
+
+        let output = nxv()
+            .args(&args)
+            .env("NXV_BLOOM_PATH", bloom_path.to_str().unwrap())
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let results: Vec<serde_json::Value> =
+            serde_json::from_slice(&output).expect("search --format json must emit a JSON array");
+
+        assert!(
+            !results.is_empty(),
+            "expected the exact `python` 3.11 row, got nothing ({version_args:?})"
+        );
+        for r in &results {
+            assert_eq!(
+                r["attribute_path"], "python",
+                "--exact leaked a non-exact attr with a version filter ({version_args:?})"
+            );
+        }
+    }
+}
+
+/// The complementary case from the issue: `python` was never at 2.7.x, so an
+/// exact search must return zero rows rather than the `python2` sibling.
+#[test]
+fn test_search_exact_with_version_filter_returns_empty_when_unmatched() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bloom_path = dir.path().join("nonexistent.bloom");
+    create_test_db(&db_path);
+
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "search",
+            "python",
+            "2.7",
+            "--exact",
+            "--format",
+            "json",
+            "--limit",
+            "0",
+        ])
+        .env("NXV_BLOOM_PATH", bloom_path.to_str().unwrap())
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout must be UTF-8");
+
+    // An empty result set writes nothing to stdout and reports "No packages
+    // found" on stderr instead of emitting `[]` — pre-existing behavior,
+    // unrelated to #52. Accept an empty stdout or an empty array, never a
+    // populated one.
+    if !stdout.trim().is_empty() {
+        let results: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("non-empty stdout must be a JSON array ({e}): {stdout}"));
+        assert!(
+            results.is_empty(),
+            "python was never at 2.7.x; got {results:?}"
+        );
+    }
+
+    // Belt and braces: the `python2` sibling does hold 2.7.18, so it would be
+    // returned by the buggy prefix path. It must appear in neither stream.
+    let stderr = String::from_utf8(output.stderr).expect("stderr must be UTF-8");
+    assert!(
+        !stdout.contains("python2") && !stderr.contains("python2"),
+        "--exact leaked the `python2` sibling:\nstdout: {stdout}\nstderr: {stderr}"
+    );
+}
+
 #[test]
 fn test_search_prefix_match() {
     let dir = tempdir().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -254,7 +254,7 @@ fn test_search_exact_with_version_filter_restricts_to_exact_attr() {
             "--limit",
             "0",
         ];
-        args.extend(version_args.iter());
+        args.extend(version_args.iter().copied());
 
         let output = nxv()
             .args(&args)


### PR DESCRIPTION
Fixes #52.

## The bug

`nxv search <pkg> <version> --exact` silently dropped the exact-attribute filter and returned matches from any package whose version shared the given prefix:

```console
$ nxv search python 2.7 --exact --format json --limit 0 | jq -r '[.[].attribute_path] | unique | length'
862      # should be just "python"
```

## Root cause

Not a SQL bug — a **branch-ordering** bug in `execute_search` (`src/search.rs`). The dispatch chain reads:

```rust
if opts.desc { ... }
else if let Some(version) = opts.version { search_by_name_version(...) }   // <-- swallows the exact case
else if opts.exact { search_by_attr_exact(...) }
else { search_by_attr(...) }
```

Because `version` is tested *before* `exact`, any search carrying a version filter routed into `search_by_name_version`, which only knows how to prefix-match `attribute_path`. The `exact` flag never reached the query builder at all.

The two flags describe different dimensions — `exact` is *how to match the attribute*, `version` is *an additional filter* — so encoding both into a flat branch chain wrongly forced them to be mutually exclusive.

## The fix

Add `search_by_attr_exact_version` (`src/db/queries.rs`), which composes the two: `attribute_path = ?` while the version stays a prefix match (`2.7` still resolves `2.7.18`), matching the documented semantics — *"`--exact` for whole-attribute matches, not for whole-version matches."* Version LIKE metacharacters are escaped, consistent with the sibling queries. No row cap is applied: one attribute path holds at most one row per distinct version, so the result set is inherently small.

Both the CLI and the API server (`server/handlers.rs`) build `SearchOptions` and call `execute_search`, so **both front ends are fixed** by the single dispatch change.

## Tests

Nine tests across three layers, all verified to **fail without the fix** (I re-ran each against a reverted dispatch — fixtures are deliberately tuned so no assertion is vacuous):

- `db/queries.rs` — the new query in isolation: sibling exclusion, version-prefix semantics, LIKE-wildcard escaping.
- `search.rs` (`exact_with_version_tests`) — drives the real `execute_search` dispatch, so it fails if the branch ordering regresses. Includes a `non_exact_...` guard that fails if the fix over-reaches and breaks prefix search.
- `tests/integration.rs` — end-to-end CLI, covering **both** invocation styles (positional `2.7` and `-V 2.7`).

## UAT

Verified against the real 2.1 GB local index with release builds of both the unfixed and fixed code — not just unit tests:

| | unique `attribute_path` values |
|---|---|
| before (unfixed build) | **862** — `python2`, `python27Packages.Babel`, … |
| after | **1** — `python` |

```console
$ ./nxv search python 2.7 --exact --format json --limit 0 | jq -r '.[] | "\(.attribute_path) \(.version)"'
python 2.7.18
python 2.7.17
python 2.7.16
python 2.7.15
python 2.7.14
python 2.7.13
python 2.7.12
```

The `-V 2.7` form returns the same. Regression-checked alongside it: non-exact + version still returns all 862 (unchanged), `--exact` alone unchanged, nested attrs work (`python313Packages.requests 2.32 --exact` → 1 attr), and no-match returns empty.

`nix develop -c ci-local` is green: 372 unit + 91 integration tests, `cargo fmt`, `cargo clippy --features indexer -- -D warnings`.

## Note on an unrelated pre-existing quirk

While tightening a test I found that an empty result set writes **nothing to stdout** and prints `No packages found` to stderr, even under `--format json` — so `nxv search ... --format json` can emit non-JSON on stdout. That is pre-existing and out of scope here; the test accommodates it explicitly rather than papering over it. Happy to file it separately if you'd like `[]` emitted instead.