### PR TITLE
fix(search): preserve relevance ordering by default

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -262,7 +262,7 @@ All paths are under `/api/v1`. Wrapped responses always look like `{ "data": ...
 | `version` | string  | Version filter (prefix match)        |
 | `exact`   | boolean | Exact attribute name match           |
 | `license` | string  | License filter                       |
-| `sort`    | string  | `date`, `version`, or `name`         |
+| `sort`    | string  | `relevance` (default), `date`, `version`, or `name` |
 | `reverse` | boolean | Reverse sort order                   |
 | `limit`   | integer | Max results (default 50)             |
 | `offset`  | integer | Results to skip (default 0)          |

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -262,7 +262,7 @@ All paths are under `/api/v1`. Wrapped responses always look like `{ "data": ...
 | `version` | string  | Version filter (prefix match)        |
 | `exact`   | boolean | Exact attribute name match           |
 | `license` | string  | License filter                       |
-| `sort`    | string  | `date`, `version`, or `name`         |
+| `sort`    | string  | `relevance` (default), `date`, `version`, or `name` |
 | `reverse` | boolean | Reverse sort order                   |
 | `limit`   | integer | Max results (default 50)             |
 | `offset`  | integer | Results to skip (default 0)          |

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -43,7 +43,7 @@
       version: '',
       arch: '',
       license: '',
-      sort: 'date',
+      sort: 'relevance',
       includeInsecure: false,
     },
     view: 'rows',
@@ -201,7 +201,7 @@
     if (STATE.filters.version) p.set('version', STATE.filters.version);
     if (STATE.filters.arch) p.set('arch', STATE.filters.arch);
     if (STATE.filters.license) p.set('license', STATE.filters.license);
-    if (STATE.filters.sort && STATE.filters.sort !== 'date') p.set('sort', STATE.filters.sort);
+    if (STATE.filters.sort && STATE.filters.sort !== 'relevance') p.set('sort', STATE.filters.sort);
     if (STATE.filters.includeInsecure) p.set('insecure', '1');
     if (STATE.view && STATE.view !== 'rows') p.set('view', STATE.view);
     if (STATE.page > 1) p.set('page', String(STATE.page));
@@ -222,7 +222,7 @@
     STATE.filters.version = p.get('version') || '';
     STATE.filters.arch = p.get('arch') || '';
     STATE.filters.license = p.get('license') || '';
-    STATE.filters.sort = p.get('sort') || 'date';
+    STATE.filters.sort = p.get('sort') || 'relevance';
     STATE.filters.includeInsecure = p.get('insecure') === '1';
     STATE.view = p.get('view') || 'rows';
     const pg = parseInt(p.get('page') || '1', 10);
@@ -243,7 +243,7 @@
       version: ['', '2.7', '3.11', '3.12', '18', '22'],
       arch: ['', 'x86_64-linux', 'aarch64-linux', 'x86_64-darwin', 'aarch64-darwin'],
       license: ['', 'MIT', 'GPL-3.0+', 'BSD-3-Clause', 'Apache-2.0', 'LGPL-2.1+'],
-      sort: ['date', 'name', 'version'],
+      sort: ['relevance', 'date', 'name', 'version'],
       includeInsecure: [false, true],
     };
     const cycle = cycles[key];
@@ -270,7 +270,7 @@
         const label = el.textContent.split(':')[0].trim();
         el.innerHTML = `${label}: <span class="ml-1 text-[var(--color-fog-0)]">${labels[k]()}</span>`;
         const v = STATE.filters[k];
-        const isActive = k === 'exact' ? STATE.filters.exact : k === 'sort' ? v !== 'date' : !!v;
+        const isActive = k === 'exact' ? STATE.filters.exact : k === 'sort' ? v !== 'relevance' : !!v;
         el.classList.toggle('active', !!isActive);
       }
     });
@@ -1086,6 +1086,16 @@
     },
     {
       cat: 'cmd',
+      label: 'sort by relevance',
+      hint: 'sort',
+      action: () => {
+        STATE.filters.sort = 'relevance';
+        renderFilterChips();
+        runSearch();
+      },
+    },
+    {
+      cat: 'cmd',
       label: 'sort by name',
       hint: 'sort',
       action: () => {
@@ -1124,7 +1134,7 @@
           version: '',
           arch: '',
           license: '',
-          sort: 'date',
+          sort: 'relevance',
           includeInsecure: false,
         };
         renderFilterChips();
@@ -1335,7 +1345,7 @@
       f.version ||
       f.arch ||
       f.license ||
-      (f.sort && f.sort !== 'date') ||
+      (f.sort && f.sort !== 'relevance') ||
       f.exact ||
       f.includeInsecure ||
       STATE.page > 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -272,7 +272,7 @@ pub struct SearchArgs {
     pub show_platforms: bool,
 
     /// Sort results.
-    #[arg(long, value_enum, default_value_t = SortOrder::Date)]
+    #[arg(long, value_enum, default_value_t = SortOrder::Relevance)]
     pub sort: SortOrder,
 
     /// Reverse sort order.
@@ -672,6 +672,7 @@ mod tests {
                 assert_eq!(search.package, "python");
                 assert!(!search.exact);
                 assert_eq!(search.limit, 50);
+                assert_eq!(search.sort, SortOrder::Relevance);
             }
             _ => panic!("Expected Search command"),
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -137,12 +137,18 @@ impl ApiClient {
             url.push_str(&format!("&license={}", urlencoding::encode(license)));
         }
 
+        // Omit the new default so a current client can still query an older
+        // server that does not know the `relevance` enum value. Current servers
+        // default an omitted sort to relevance; older ones retain date order.
         let sort_str = match opts.sort {
-            SortOrder::Date => "date",
-            SortOrder::Version => "version",
-            SortOrder::Name => "name",
+            SortOrder::Relevance => None,
+            SortOrder::Date => Some("date"),
+            SortOrder::Version => Some("version"),
+            SortOrder::Name => Some("name"),
         };
-        url.push_str(&format!("&sort={}", sort_str));
+        if let Some(sort_str) = sort_str {
+            url.push_str(&format!("&sort={}", sort_str));
+        }
 
         if opts.reverse {
             url.push_str("&reverse=true");

--- a/src/search.rs
+++ b/src/search.rs
@@ -16,8 +16,10 @@ use std::collections::HashSet;
 )]
 #[serde(rename_all = "lowercase")]
 pub enum SortOrder {
-    /// Sort by date (newest first).
+    /// Preserve query relevance (exact/shallow attribute paths before nested sets).
     #[default]
+    Relevance,
+    /// Sort by date (newest first).
     Date,
     /// Sort by version (semver-aware).
     Version,
@@ -59,7 +61,7 @@ impl Default for SearchOptions {
     /// - `exact`: `false`
     /// - `desc`: `false`
     /// - `license`: `None`
-    /// - `sort`: `SortOrder::Date`
+    /// - `sort`: `SortOrder::Relevance`
     /// - `reverse`: `false`
     /// - `full`: `false`
     /// - `limit`: `50`
@@ -73,7 +75,7 @@ impl Default for SearchOptions {
     /// assert!(opts.version.is_none());
     /// assert!(!opts.exact && !opts.desc && !opts.reverse && !opts.full);
     /// assert!(opts.license.is_none());
-    /// assert_eq!(opts.sort, crate::search::SortOrder::Date);
+    /// assert_eq!(opts.sort, crate::search::SortOrder::Relevance);
     /// assert_eq!(opts.limit, 50);
     /// assert_eq!(opts.offset, 0);
     /// ```
@@ -84,7 +86,7 @@ impl Default for SearchOptions {
             exact: false,
             desc: false,
             license: None,
-            sort: SortOrder::Date,
+            sort: SortOrder::Relevance,
             reverse: false,
             full: false,
             limit: 50,
@@ -214,6 +216,9 @@ pub fn filter_by_license(
 /// For `Version` sort, uses semver-aware comparison with fallback to string comparison.
 pub fn sort_results(results: &mut [PackageVersion], order: SortOrder, reverse: bool) {
     match order {
+        // The query layer has already produced deterministic relevance order
+        // using the covering search index. Preserve it without another sort.
+        SortOrder::Relevance => {}
         SortOrder::Date => {
             results.sort_by_key(|r| std::cmp::Reverse(r.last_commit_date));
         }
@@ -472,7 +477,7 @@ mod tests {
         assert!(!opts.desc);
         assert!(!opts.full);
         assert!(!opts.reverse);
-        assert_eq!(opts.sort, SortOrder::Date);
+        assert_eq!(opts.sort, SortOrder::Relevance);
     }
 }
 
@@ -596,6 +601,70 @@ mod exact_with_version_tests {
     }
 }
 
+/// Regression coverage for broad version searches such as `python 2.7`.
+/// The query layer returns shallow attribute paths before nested package sets;
+/// the default search pipeline must preserve that relevance ordering instead
+/// of replacing it with last-seen-date ordering.
+#[cfg(test)]
+mod relevance_order_tests {
+    use super::*;
+    use crate::db::Database;
+    use tempfile::tempdir;
+
+    const SEED: &str = r#"
+        INSERT INTO package_versions
+            (name, version, first_commit_hash, first_commit_date,
+             last_commit_hash, last_commit_date, attribute_path, description)
+        VALUES
+            ('python',   '2.7.18', 'h1', 100, 'l1', 200, 'python', 'interpreter'),
+            ('python',   '2.7.18', 'h2', 300, 'l2', 400, 'python27', 'interpreter alias'),
+            ('icontract','2.7.3',  'h3', 800, 'l3', 900, 'python314Packages.icontract', 'library');
+    "#;
+
+    fn opts() -> SearchOptions {
+        SearchOptions {
+            query: "python".to_string(),
+            version: Some("2.7".to_string()),
+            limit: 0,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_search_keeps_top_level_python_packages_before_recent_nested_libraries() {
+        let dir = tempdir().unwrap();
+        let db = Database::open(dir.path().join("test.db")).unwrap();
+        db.connection().execute_batch(SEED).unwrap();
+
+        let result = execute_search(db.connection(), &opts()).unwrap();
+        let attrs: Vec<_> = result
+            .data
+            .iter()
+            .map(|package| package.attribute_path.as_str())
+            .collect();
+
+        assert_eq!(attrs, ["python27", "python", "python314Packages.icontract"]);
+    }
+
+    #[test]
+    fn explicit_date_sort_still_puts_the_newest_nested_library_first() {
+        let dir = tempdir().unwrap();
+        let db = Database::open(dir.path().join("test.db")).unwrap();
+        db.connection().execute_batch(SEED).unwrap();
+
+        let result = execute_search(
+            db.connection(),
+            &SearchOptions {
+                sort: SortOrder::Date,
+                ..opts()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.data[0].attribute_path, "python314Packages.icontract");
+    }
+}
+
 #[cfg(test)]
 mod proptests {
     use super::*;
@@ -640,6 +709,7 @@ mod proptests {
         fn sort_never_panics(
             packages in prop::collection::vec(arb_package_version(), 0..100),
             order in prop_oneof![
+                Just(SortOrder::Relevance),
                 Just(SortOrder::Date),
                 Just(SortOrder::Version),
                 Just(SortOrder::Name),
@@ -694,6 +764,7 @@ mod proptests {
         fn sort_is_deterministic(
             packages in prop::collection::vec(arb_package_version(), 1..20),
             order in prop_oneof![
+                Just(SortOrder::Relevance),
                 Just(SortOrder::Date),
                 Just(SortOrder::Version),
                 Just(SortOrder::Name),
@@ -832,7 +903,12 @@ mod indexed_parity_tests {
                 ..base("parity")
             },
         ];
-        for sort in [SortOrder::Date, SortOrder::Version, SortOrder::Name] {
+        for sort in [
+            SortOrder::Relevance,
+            SortOrder::Date,
+            SortOrder::Version,
+            SortOrder::Name,
+        ] {
             for reverse in [false, true] {
                 matrix.push(SearchOptions {
                     sort,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -107,19 +107,18 @@ where
 /// # Examples
 ///
 /// ```
-/// use std::sync::Arc;
-/// use axum::extract::Query;
-/// use crate::server::{AppState, SearchParams};
+/// use crate::search::SortOrder;
+/// use crate::server::SearchParams;
 /// // Construct query params (as if received from a request)
 /// let params = SearchParams {
 ///     q: "serde".to_string(),
 ///     version: None,
-///     exact: None,
+///     exact: false,
 ///     license: None,
-///     sort: None,
-///     reverse: None,
-///     limit: Some(10),
-///     offset: Some(0),
+///     sort: SortOrder::Relevance,
+///     reverse: false,
+///     limit: 10,
+///     offset: 0,
 /// };
 /// // In an application handler you'd call `search_packages(State(state), Query(params)).await`.
 /// // This example demonstrates the intended parameters; actual invocation requires an Axum runtime and AppState.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -132,7 +132,7 @@ params(
 ("version" = Option<String>, Query, description = "Filter by version prefix"),
 ("exact" = Option<bool>, Query, description = "Exact match only"),
 ("license" = Option<String>, Query, description = "Filter by license"),
-("sort" = Option<String>, Query, description = "Sort order: date, version, or name"),
+("sort" = Option<String>, Query, description = "Sort order: relevance, date, version, or name"),
 ("reverse" = Option<bool>, Query, description = "Reverse sort order"),
 ("limit" = Option<usize>, Query, description = "Maximum results (default: 50)"),
 ("offset" = Option<usize>, Query, description = "Results to skip"),

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -97,7 +97,7 @@ pub struct SearchParams {
     /// Filter by license (case-insensitive contains).
     #[serde(default)]
     pub license: Option<String>,
-    /// Sort order: date, version, or name.
+    /// Sort order: relevance, date, version, or name.
     #[serde(default)]
     pub sort: SortOrder,
     /// Reverse sort order (default: false).

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -262,7 +262,7 @@ All paths are under `/api/v1`. Wrapped responses always look like `{ "data": ...
 | `version` | string  | Version filter (prefix match)        |
 | `exact`   | boolean | Exact attribute name match           |
 | `license` | string  | License filter                       |
-| `sort`    | string  | `date`, `version`, or `name`         |
+| `sort`    | string  | `relevance` (default), `date`, `version`, or `name` |
 | `reverse` | boolean | Reverse sort order                   |
 | `limit`   | integer | Max results (default 50)             |
 | `offset`  | integer | Results to skip (default 0)          |

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -368,6 +368,56 @@ fn test_search_with_version_filter() {
 }
 
 #[test]
+fn test_search_defaults_to_relevance_but_allows_explicit_date_sort() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "INSERT INTO package_versions \
+         (name, version, first_commit_hash, first_commit_date, last_commit_hash, \
+          last_commit_date, attribute_path, description) \
+         VALUES ('icontract', '2.7.3', 'new-first', 1800000000, 'new-last', \
+                 1800100000, 'python314Packages.icontract', 'Python library')",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let run = |extra: &[&str]| {
+        let mut args = vec![
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "search",
+            "python",
+            "2.7",
+            "--format",
+            "json",
+            "--limit",
+            "0",
+        ];
+        args.extend_from_slice(extra);
+        let output = nxv()
+            .args(args)
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        serde_json::from_slice::<Vec<serde_json::Value>>(&output).unwrap()
+    };
+
+    let relevant = run(&[]);
+    assert_eq!(relevant[0]["attribute_path"], "python2");
+    assert_eq!(relevant[1]["attribute_path"], "python314Packages.icontract");
+
+    let by_date = run(&["--sort", "date"]);
+    assert_eq!(by_date[0]["attribute_path"], "python314Packages.icontract");
+    assert_eq!(by_date[1]["attribute_path"], "python2");
+}
+
+#[test]
 fn test_search_json_output() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -70,7 +70,7 @@ GET /api/v1/search
 | `version` | string  | Version filter (prefix match)            |
 | `exact`   | boolean | Exact name match                         |
 | `license` | string  | License filter                           |
-| `sort`    | string  | Sort order: date, version, name          |
+| `sort`    | string  | Sort order: relevance (default), date, version, name |
 | `reverse` | boolean | Reverse sort                             |
 | `limit`   | integer | Max results (default: 50, capped at 100) |
 | `offset`  | integer | Results to skip (default: 0)             |

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -33,7 +33,7 @@ nxv search <PACKAGE> [VERSION]
 | `--desc`                  | Search in descriptions (full-text)            |
 | `--license <LICENSE>`     | Filter by license                             |
 | `--show-platforms`        | Show platforms column                         |
-| `--sort <ORDER>`          | Sort order: date, version, name               |
+| `--sort <ORDER>`          | Sort order: relevance (default), date, version, name |
 | `-r, --reverse`           | Reverse sort order                            |
 | `-n, --limit <N>`         | Maximum results (default: 50, 0=unlimited)    |
 | `--full`                  | Show all commits (no deduplication)           |


### PR DESCRIPTION
## Summary

- preserve the covering-index relevance order by default so top-level packages precede nested package-set libraries
- retain explicit date, version, and name sorting across the CLI, API, and web frontend
- keep new clients compatible with older servers and synchronize docs plus generated agent skills

## Performance

- production SQLite plan remains on the existing covering idx_packages_search_nocase index
- 100-run warm comparison for python 2.7: 2.72s relevance vs 2.72s date
- python 3.13 stayed within noise: 2.22s vs 2.20s
- broad python improved slightly: 7.76s vs 7.89s

## Verification

- cargo test --features indexer: 394 passed, 1 ignored; 93 integration tests passed
- cargo clippy --all-targets --features indexer -- -D warnings
- cargo fmt -- --check
- nix flake check: all 7 checks passed