### PR TITLE
docs: sync all documentation with the code

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -143,7 +143,7 @@ nxv search python312 --exact --format json | jq -r '.[0].platforms | join(", ")'
 nxv search hello --format json | jq -r '.[] | select(.known_vulnerabilities != null) | .attribute_path'
 ```
 
-> **Version note**: nxv **< 0.5.0** emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
+> **Version note**: older nxv releases emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
 
 ## Info
 
@@ -180,7 +180,7 @@ Version timeline — when each version first appeared and when it was last seen:
 ```bash
 nxv history python311                    # All versions of python311
 nxv history python311 3.11.4             # Just one version's window
-nxv history python311 --full             # Add commits, license, homepage, etc.
+nxv history ripgrep --full               # Add commits, license, homepage, etc.
 nxv history python311 --format json
 ```
 
@@ -195,7 +195,7 @@ nxv history python311 --format json
 }
 ```
 
-Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`.
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Caveat: bare `--full` resolves the package by the upstream derivation `name`, so it only returns rows when `name` equals the attribute path (e.g. `ripgrep`); for versioned interpreters (`python311`, `nodejs_20`) and nested package-set members (`python311Packages.*`), name a version or use `nxv search <attr> --full` instead.
 
 ## Using a Found Version
 
@@ -383,6 +383,7 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
 | `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
+| `NXV_RATE_LIMIT_BURST` | `nxv serve` per-IP rate-limit burst size (default: 2x rate_limit)    |
 | `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
 | `NO_COLOR`           | Disable ANSI colors                                                    |
 
@@ -445,7 +446,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
 - **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
-- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in 0.5.0.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in a recent release.
 - **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -143,7 +143,7 @@ nxv search python312 --exact --format json | jq -r '.[0].platforms | join(", ")'
 nxv search hello --format json | jq -r '.[] | select(.known_vulnerabilities != null) | .attribute_path'
 ```
 
-> **Version note**: nxv **< 0.5.0** emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
+> **Version note**: older nxv releases emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
 
 ## Info
 
@@ -180,7 +180,7 @@ Version timeline — when each version first appeared and when it was last seen:
 ```bash
 nxv history python311                    # All versions of python311
 nxv history python311 3.11.4             # Just one version's window
-nxv history python311 --full             # Add commits, license, homepage, etc.
+nxv history ripgrep --full               # Add commits, license, homepage, etc.
 nxv history python311 --format json
 ```
 
@@ -195,7 +195,7 @@ nxv history python311 --format json
 }
 ```
 
-Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`.
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Caveat: bare `--full` resolves the package by the upstream derivation `name`, so it only returns rows when `name` equals the attribute path (e.g. `ripgrep`); for versioned interpreters (`python311`, `nodejs_20`) and nested package-set members (`python311Packages.*`), name a version or use `nxv search <attr> --full` instead.
 
 ## Using a Found Version
 
@@ -383,6 +383,7 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
 | `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
+| `NXV_RATE_LIMIT_BURST` | `nxv serve` per-IP rate-limit burst size (default: 2x rate_limit)    |
 | `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
 | `NO_COLOR`           | Disable ANSI colors                                                    |
 
@@ -445,7 +446,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
 - **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
-- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in 0.5.0.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in a recent release.
 - **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ cargo test db::                  # Run tests in a specific module
 cargo clippy --features indexer -- -D warnings   # Lint (matches CI; CI also runs the featureless variant)
 cargo fmt                        # Format code
 cargo bench                      # Run benchmarks (bloom, search, indexer)
-nix flake check                  # Run all Nix checks (build, clippy, fmt, tests)
+nix flake check                  # Run all Nix checks (build, clippy, fmt, tests, a11y)
 ```
 
 The devshell provides shortcuts for all of these (`build`, `clippy`, `fmt-check`, `run-tests`, `coverage`, ...). `ci-local` runs the exact CI sequence: fmt-check, clippy, test — all with `--features indexer`.
@@ -56,7 +56,7 @@ nix run .#nxv-indexer            # Run with indexer feature
 
 ### Backend Abstraction (`backend.rs`, `client.rs`)
 
-The CLI transparently runs against either a local index or a remote `nxv serve` instance. `main.rs` branches on `NXV_API_URL` — if set, `ApiClient` (HTTP) is used; otherwise the local SQLite/bloom backend is used. Both implement the same backend trait, so command handlers are backend-agnostic. `search.rs` holds the search logic shared by the CLI commands and the API server handlers.
+The CLI transparently runs against either a local index or a remote `nxv serve` instance. `main.rs` branches on `NXV_API_URL` — if set, `ApiClient` (HTTP) is used; otherwise the local SQLite/bloom backend is used. Both are handled through a single `Backend` enum (`Local(Database)` | `Remote(ApiClient)`) with matching methods, so command handlers are backend-agnostic. `search.rs` holds the search logic shared by the CLI commands and the API server handlers.
 
 ### Self-Update (`self_update.rs`)
 
@@ -128,6 +128,7 @@ Most are also exposed as CLI flags (see `src/cli.rs`); env vars are useful for t
 - `NXV_LOG_FORMAT` — set to `json` for structured `nxv serve` logs (combine with `RUST_LOG`)
 - `NXV_SECRET_KEY` — minisign secret key (path or contents) for `nxv publish` signing
 - `NXV_RELEASES_URL` — override the releases.nixos.org S3 endpoint for `nxv index` (tests, mirrors)
+- `NXV_GITHUB_API_BASE` — override the GitHub API base URL used by `nxv update`'s self-update check (tests, mirrors)
 - `NXV_FRONTEND_DIR` — serve `index.html`/`app.js`/`favicon.svg` from this directory on every request instead of the embedded copy, and disable the 24h `Cache-Control` for those routes. Used by the devshell `dev` command for live frontend reload (edit → browser refresh, no rebuild; `dev` also runs cargo-watch so `src/` changes rebuild and restart the server). Unset in production.
 - `NXV_GIT_REV` — set by the Nix flake build to embed the git rev in `--version`
 
@@ -141,7 +142,7 @@ The database and bloom filter are stored in platform-specific data directories:
 Files:
 
 - `index.db` - SQLite database with package versions
-- `bloom.bin` - Bloom filter for fast negative lookups
+- `index.bloom` - Bloom filter for fast negative lookups (derived from the db filename; the distributed release artifact is separately named `bloom.bin`)
 
 ## Testing
 
@@ -189,7 +190,7 @@ A NixOS module is provided for running nxv as a systemd service:
   services.nxv = {
     enable = true;
     port = 8080;
-    # indexPath = "/path/to/index.db";  # Optional custom path
+    # dataDir = "/var/lib/nxv";  # Optional custom data directory (holds index.db + bloom filter)
   };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Users download a pre-built compressed index (~220MB) and query it locally or via
 curl -sSfL https://raw.githubusercontent.com/utensils/nxv/main/install.sh | sh
 ```
 
-This installs a pre-built binary to `~/.local/bin`. For extra safety, download and review the script first. Set `NXV_VERIFY=1` to enforce checksum verification against GitHub Releases.
+This installs a pre-built binary to `/usr/local/bin` (if writable) or `~/.local/bin` otherwise; set `NXV_INSTALL_DIR` to override. For extra safety, download and review the script first. Set `NXV_VERIFY=1` to enforce checksum verification against GitHub Releases.
 
 ### Cargo
 
@@ -560,7 +560,16 @@ The `manifest.json` format:
 | `NXV_API_TIMEOUT` | API request timeout in seconds (default: 30) |
 | `NXV_NO_SELF_UPDATE` | Skip the binary self-update check in `nxv update` |
 | `NO_COLOR` | Disable colored output |
-| `NXV_INSTALL_DIR` | Custom install directory for curl installer (default: `~/.local/bin`) |
+| `NXV_HOST` | `nxv serve` bind address (default: `127.0.0.1`) |
+| `NXV_PORT` | `nxv serve` port (default: `8080`) |
+| `NXV_RATE_LIMIT` | `nxv serve` max requests per second per IP |
+| `NXV_RATE_LIMIT_BURST` | `nxv serve` rate-limit burst size |
+| `NXV_MAX_DB_CONNECTIONS` | `nxv serve` max concurrent DB operations (default: 32) |
+| `NXV_DB_TIMEOUT_SECS` | `nxv serve` DB operation timeout in seconds (default: 30) |
+| `NXV_LOG_FORMAT` | `nxv serve` log format, `text` or `json` |
+| `NXV_RELEASES_URL` | Override the releases.nixos.org S3 endpoint for `nxv index` |
+| `NXV_VERIFY` | Set to `1` to verify curl-installer download against `SHA256SUMS.txt` |
+| `NXV_INSTALL_DIR` | Custom install directory for curl installer (default: `/usr/local/bin` if writable, else `~/.local/bin`) |
 | `NXV_VERSION` | Specific version for curl installer (default: latest) |
 
 ## Development
@@ -590,6 +599,8 @@ src/
 ├── bloom.rs         # Bloom filter
 ├── search.rs        # Search/filter/sort logic
 ├── self_update.rs   # Binary self-update (part of nxv update)
+├── skill/           # Agent skill install/list/uninstall (nxv skill ...)
+├── version.rs       # Version/long-version string helpers
 ├── paths.rs         # Platform-specific paths
 ├── error.rs         # Error types
 └── index/           # Indexer (feature-gated)

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -143,7 +143,7 @@ nxv search python312 --exact --format json | jq -r '.[0].platforms | join(", ")'
 nxv search hello --format json | jq -r '.[] | select(.known_vulnerabilities != null) | .attribute_path'
 ```
 
-> **Version note**: nxv **< 0.5.0** emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
+> **Version note**: older nxv releases emitted these four fields as JSON-encoded *strings* (`"license": "[\"Python-2.0\"]"`), requiring a second `fromjson`. If you must support both, use `(.license | if type == "string" then fromjson else . end)`.
 
 ## Info
 
@@ -180,7 +180,7 @@ Version timeline — when each version first appeared and when it was last seen:
 ```bash
 nxv history python311                    # All versions of python311
 nxv history python311 3.11.4             # Just one version's window
-nxv history python311 --full             # Add commits, license, homepage, etc.
+nxv history ripgrep --full               # Add commits, license, homepage, etc.
 nxv history python311 --format json
 ```
 
@@ -195,7 +195,7 @@ nxv history python311 --format json
 }
 ```
 
-Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`.
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Caveat: bare `--full` resolves the package by the upstream derivation `name`, so it only returns rows when `name` equals the attribute path (e.g. `ripgrep`); for versioned interpreters (`python311`, `nodejs_20`) and nested package-set members (`python311Packages.*`), name a version or use `nxv search <attr> --full` instead.
 
 ## Using a Found Version
 
@@ -383,6 +383,7 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
 | `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
+| `NXV_RATE_LIMIT_BURST` | `nxv serve` per-IP rate-limit burst size (default: 2x rate_limit)    |
 | `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
 | `NO_COLOR`           | Disable ANSI colors                                                    |
 
@@ -445,7 +446,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
 - **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
-- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in 0.5.0.
+- **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in a recent release.
 - **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
 

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -100,7 +100,12 @@ curl "http://localhost:8080/api/v1/search?q=python&version=3.11&limit=5"
       "name": "python311",
       "version": "3.11.4",
       "description": "A high-level dynamically-typed programming language",
-      "license": "Python-2.0",
+      "license": ["Python-2.0"],
+      "homepage": "https://www.python.org",
+      "maintainers": ["Fabian Affolter"],
+      "platforms": ["x86_64-linux", "aarch64-darwin"],
+      "source_path": "pkgs/development/interpreters/python/cpython/default.nix",
+      "known_vulnerabilities": null,
       "first_commit_hash": "abc123...",
       "first_commit_date": "2023-06-15T00:00:00Z",
       "last_commit_hash": "def456...",
@@ -166,7 +171,9 @@ GET /api/v1/packages/{attr}/versions/{version}/first
 GET /api/v1/packages/{attr}/versions/{version}/last
 ```
 
-Get all records, the first occurrence, or last occurrence of a specific version.
+Get the most recent occurrence (the base endpoint behaves the same as `/last`),
+the first occurrence, or the last occurrence of a specific version. All three
+return a single object, not an array.
 
 **Example:**
 
@@ -256,7 +263,7 @@ GET /api/v1/health
 ```json
 {
   "status": "ok",
-  "version": "0.3.0",
+  "version": "<nxv version>",
   "index_commit": "abc123..."
 }
 ```
@@ -289,13 +296,15 @@ All errors return a JSON object:
 
 **HTTP Status Codes:**
 
-| Code | Description                      |
-| ---- | -------------------------------- |
-| 200  | Success                          |
-| 400  | Bad request (invalid parameters) |
-| 404  | Not found                        |
-| 429  | Rate limited                     |
-| 500  | Internal server error            |
+| Code | Description                                                   |
+| ---- | ------------------------------------------------------------- |
+| 200  | Success                                                       |
+| 400  | Bad request (invalid parameters)                              |
+| 404  | Not found                                                     |
+| 429  | Rate limited                                                  |
+| 500  | Internal server error                                         |
+| 503  | Service unavailable (no/corrupt index, or server at capacity) |
+| 504  | Gateway timeout (DB operation exceeded `NXV_DB_TIMEOUT_SECS`) |
 
 ## OpenAPI Documentation
 
@@ -319,10 +328,13 @@ nxv serve --cors
 nxv serve --cors-origins "https://example.com,https://app.example.com"
 ```
 
-## Request Headers
+## Response Headers
 
-| Header         | Description                                                 |
-| -------------- | ----------------------------------------------------------- |
-| `X-Request-ID` | Correlation ID for tracing (auto-generated if not provided) |
+When rate limiting is enabled (`--rate-limit`), the server adds standard
+`X-RateLimit-*` headers to responses:
 
-The server echoes back the request ID in responses for distributed tracing.
+| Header                  | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `X-RateLimit-Limit`     | The configured per-IP request limit                    |
+| `X-RateLimit-Remaining` | Requests remaining in the current window               |
+| `X-RateLimit-After`     | Seconds to wait before retrying (present when limited) |

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -333,8 +333,9 @@ nxv serve --cors-origins "https://example.com,https://app.example.com"
 When rate limiting is enabled (`--rate-limit`), the server adds standard
 `X-RateLimit-*` headers to responses:
 
-| Header                  | Description                                            |
-| ----------------------- | ------------------------------------------------------ |
-| `X-RateLimit-Limit`     | The configured per-IP request limit                    |
-| `X-RateLimit-Remaining` | Requests remaining in the current window               |
-| `X-RateLimit-After`     | Seconds to wait before retrying (present when limited) |
+| Header                  | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| `X-RateLimit-Limit`     | The configured per-IP request limit                      |
+| `X-RateLimit-Remaining` | Requests remaining in the current window                 |
+| `X-RateLimit-After`     | Seconds to wait before retrying (present when limited)   |
+| `Retry-After`           | Same value as `X-RateLimit-After` (present when limited) |

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -210,6 +210,10 @@ nxv serve [options]
 | `--rate-limit <N>`         | Rate limiting per IP (req/sec)    |
 | `--rate-limit-burst <N>`   | Burst size for rate limiting      |
 
+`--host`, `--port`, `--rate-limit`, and `--rate-limit-burst` are also settable
+via `NXV_HOST`, `NXV_PORT`, `NXV_RATE_LIMIT`, and `NXV_RATE_LIMIT_BURST` — see
+[Configuration](/guide/configuration).
+
 **Examples:**
 
 ```bash
@@ -292,13 +296,14 @@ nxv publish [options]
 
 **Options:**
 
-| Flag                 | Description                                                                      |
-| -------------------- | -------------------------------------------------------------------------------- |
-| `-o, --output <DIR>` | Output directory for generated artifacts (default: ./publish)                    |
-| `--url-prefix <URL>` | Base URL prefix for manifest URLs                                                |
-| `--sign`             | Sign the manifest with a minisign secret key                                     |
-| `--secret-key <KEY>` | Secret key for signing (file path or raw key; also `NXV_SECRET_KEY` env)         |
-| `--min-version <N>`  | Minimum schema version required to read this index (default: the schema version) |
+| Flag                              | Description                                                                                                                                                                |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-o, --output <DIR>`              | Output directory for generated artifacts (default: ./publish)                                                                                                              |
+| `--url-prefix <URL>`              | Base URL prefix for manifest URLs                                                                                                                                          |
+| `--artifact-name-prefix <PREFIX>` | Prefix added to index/bloom artifact filenames in the manifest (useful when uploading immutable, run-specific artifact names while manifest.json stays the stable pointer) |
+| `--sign`                          | Sign the manifest with a minisign secret key                                                                                                                               |
+| `--secret-key <KEY>`              | Secret key for signing (file path or raw key; also `NXV_SECRET_KEY` env)                                                                                                   |
+| `--min-version <N>`               | Minimum schema version required to read this index (default: the schema version)                                                                                           |
 
 ### keygen
 
@@ -408,7 +413,7 @@ python311        3.11.3    def5678   2023-04-05   High-level dynamically-typed p
 
 ### json
 
-Machine-readable JSON:
+Machine-readable JSON (abbreviated below):
 
 ```json
 [
@@ -420,6 +425,10 @@ Machine-readable JSON:
   }
 ]
 ```
+
+Each row also carries `id`, `name`, `last_commit_hash`, `last_commit_date`,
+`description`, `license`, `homepage`, `maintainers`, `platforms`, `source_path`,
+and `known_vulnerabilities` (array or null where applicable).
 
 ### plain
 

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -21,7 +21,14 @@ One-liner install that downloads a static binary:
 curl -fsSL https://raw.githubusercontent.com/utensils/nxv/main/install.sh | sh
 ```
 
-This installs to `~/.local/bin/nxv` (or `/usr/local/bin` with sudo).
+This installs to `/usr/local/bin` if that directory is writable, otherwise to
+`~/.local/bin`.
+
+**Installer options** (environment variables):
+
+- `NXV_INSTALL_DIR` — override the installation directory.
+- `NXV_VERSION` — pin a specific release instead of the latest.
+- `NXV_VERIFY` — set to `1` to verify the download against `SHA256SUMS.txt`.
 
 ## Nix Flakes
 


### PR DESCRIPTION
## Summary

Full accuracy audit of every documentation surface against the code as ground truth, following the Blueprint UI refresh (#63) and the recent search fixes (#57/#58/#61/#62). Five parallel auditors (one per surface) verified claims against `src/`, `--help` output from the built binary, live server responses, `install.sh`, `flake.nix`, and the workflow files; fixers re-verified each finding before editing; a final verifier re-checked the entire diff hunk-by-hunk and sample-checked unchanged claims.

**22 discrepancies fixed across 8 files.** No behavior from the unmerged `feat/cli-update-sync` branch was introduced (`nxv update` remains documented as index refresh + self-update), and no version strings run ahead of the pending v0.5.0 release (hardcoded `0.3.0`/`0.5.0` examples became version-agnostic).

## Highlights by surface

**README.md** — install.sh actually prefers `/usr/local/bin` when writable (docs said `~/.local/bin`); env-var table gains the serve/db/log/releases/installer vars it was missing; `src/` tree listing gains `skill/` and `version.rs`.

**AGENTS.md / CLAUDE.md** — NixOS module option is `dataDir`, not the nonexistent `indexPath`; the local bloom file is `index.bloom` (`bloom.bin` is the release artifact name); the backend is a `Backend` enum, not a trait; adds `NXV_GITHUB_API_BASE`; `nix flake check` description now includes the a11y gate.

**API docs (`website/api/`)** — search response example corrected field-by-field against `PackageVersionSchema` (`license` is an array; adds `homepage`/`maintainers`/`platforms`/`source_path`/`known_vulnerabilities`); `GET .../versions/{version}` documented as returning a single record (it calls `get_last_occurrence`); adds the real 503/504 error rows; replaces a fabricated `X-Request-ID` section with the actual `X-RateLimit-*` response headers emitted by tower_governor.

**CLI reference / installation** — documents `publish --artifact-name-prefix` (was completely missing); serve env-var bindings; the full JSON row field list; installer options (`NXV_INSTALL_DIR`, `NXV_VERSION`, `NXV_VERIFY`).

**Agent-skill template (`src/skill/SKILL.md`)** — the `nxv history python311 --full` example was falsified live: bare `--full` resolves by upstream derivation name only, so it returns `[]` for packages whose name differs from the attribute path. Example swapped to a working one plus a caveat; the underlying resolution bug is filed as #64. Checked-in copies regenerated (`test_checked_in_skill_copies_match_template` passes).

## Verification

- `nix develop -c docs-build` + `docs-fmt` green.
- `cargo test --features indexer`: 403 unit + 95 integration, 0 failed.
- Independent verifier re-checked every changed hunk against the code (all accurate, none of the failure modes it hunted for: invented flags, wrong defaults, unmerged behavior, premature versions) and sample-checked 6 unchanged claims (all accurate).

## Sequencing

Intended to merge **before** release PR #60 so the v0.5.0 release ships with accurate docs; release-plz will refresh #60 automatically after this lands.
