### PR TITLE
fix(history): resolve full history by attribute path

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -195,7 +195,7 @@ nxv history python311 --format json
 }
 ```
 
-Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Caveat: bare `--full` resolves the package by the upstream derivation `name`, so it only returns rows when `name` equals the attribute path (e.g. `ripgrep`); for versioned interpreters (`python311`, `nodejs_20`) and nested package-set members (`python311Packages.*`), name a version or use `nxv search <attr> --full` instead.
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Like the compact timeline, bare `--full` resolves the package by its exact installable `attribute_path`.
 
 ## Using a Found Version
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -195,7 +195,7 @@ nxv history python311 --format json
 }
 ```
 
-Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Caveat: bare `--full` resolves the package by the upstream derivation `name`, so it only returns rows when `name` equals the attribute path (e.g. `ripgrep`); for versioned interpreters (`python311`, `nodejs_20`) and nested package-set members (`python311Packages.*`), name a version or use `nxv search <attr> --full` instead.
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Like the compact timeline, bare `--full` resolves the package by its exact installable `attribute_path`.
 
 ## Using a Found Version
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -183,8 +183,9 @@ impl Backend {
 
     /// Search packages by name, using either an exact match or a prefix match.
     ///
-    /// If `exact` is `true`, only packages whose attribute path exactly equals `name` are returned.
-    /// If `exact` is `false`, packages whose names start with `name` are returned.
+    /// If `exact` is `true`, only packages whose derivation `name` exactly matches are returned.
+    /// If `exact` is `false`, packages whose derivation names start with `name` are returned.
+    /// Use [`Self::get_package`] for an exact installable attribute-path lookup.
     ///
     /// # Returns
     ///
@@ -195,8 +196,8 @@ impl Backend {
     /// ```
     /// // Search for packages whose name starts with "libfoo"
     /// let results = backend.search_by_name("libfoo", false).unwrap();
-    /// // Search for the package whose attribute path is exactly "libfoo/pkg"
-    /// let exact = backend.search_by_name("libfoo/pkg", true).unwrap();
+    /// // Search for packages whose derivation name is exactly "libfoo"
+    /// let exact = backend.search_by_name("libfoo", true).unwrap();
     /// ```
     #[allow(dead_code)]
     pub fn search_by_name(&self, name: &str, exact: bool) -> Result<Vec<PackageVersion>> {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -80,7 +80,6 @@ impl Backend {
     ///     assert_eq!(pv.attribute_path, "example/package");
     /// }
     /// ```
-    #[allow(dead_code)]
     pub fn get_package(&self, attr: &str) -> Result<Vec<PackageVersion>> {
         match self {
             Backend::Local(db) => queries::search_by_attr_exact(db.connection(), attr),
@@ -199,6 +198,7 @@ impl Backend {
     /// // Search for the package whose attribute path is exactly "libfoo/pkg"
     /// let exact = backend.search_by_name("libfoo/pkg", true).unwrap();
     /// ```
+    #[allow(dead_code)]
     pub fn search_by_name(&self, name: &str, exact: bool) -> Result<Vec<PackageVersion>> {
         match self {
             Backend::Local(db) => queries::search_by_name(db.connection(), name, exact),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1137,7 +1137,7 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
         }
     } else if args.full {
         // Show full details for all versions
-        let packages = backend.search_by_name(&args.package, true)?;
+        let packages = backend.get_package(&args.package)?;
 
         if packages.is_empty() {
             match args.format {

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -195,7 +195,7 @@ nxv history python311 --format json
 }
 ```
 
-Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Caveat: bare `--full` resolves the package by the upstream derivation `name`, so it only returns rows when `name` equals the attribute path (e.g. `ripgrep`); for versioned interpreters (`python311`, `nodejs_20`) and nested package-set members (`python311Packages.*`), name a version or use `nxv search <attr> --full` instead.
+Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Like the compact timeline, bare `--full` resolves the package by its exact installable `attribute_path`.
 
 ## Using a Found Version
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -814,6 +814,36 @@ fn test_history_full_json_format() {
 }
 
 #[test]
+fn test_history_full_resolves_exact_attribute_path() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    // Regression for #55 and #64: the installable attribute path can differ
+    // from the upstream derivation name. `--full` must accept the same
+    // attribute-path identifier as the compact history view.
+    let output = nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "history",
+            "python312",
+            "--full",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(&stdout).expect("--full --format json should be pure JSON");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["attribute_path"], "python312");
+    assert_eq!(rows[0]["name"], "python-3.12.0");
+}
+
+#[test]
 fn test_history_specific_version_json() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -838,9 +838,9 @@ fn test_history_full_resolves_exact_attribute_path() {
     let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
     let rows: Vec<serde_json::Value> =
         serde_json::from_str(&stdout).expect("--full --format json should be pure JSON");
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0]["attribute_path"], "python312");
-    assert_eq!(rows[0]["name"], "python-3.12.0");
+    assert!(!rows.is_empty());
+    assert!(rows.iter().all(|row| row["attribute_path"] == "python312"));
+    assert!(rows.iter().any(|row| row["name"] == "python-3.12.0"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- resolve bare `history --full` lookups by exact installable attribute path
- add regression coverage where derivation name differs from attribute path
- remove the obsolete limitation from the embedded and generated agent skills

## Validation
- `NO_COLOR=false nix develop -c ci-local`
- live local index: `python312 --full` returned 17 rows, all for attribute `python312` with derivation name `python3`

Closes #55
Closes #64