### PR TITLE
feat(cli)!: split application update from index sync

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -21,11 +21,13 @@ nxv info python311 3.11.4                # Detailed info for specific version
 nxv history python311                    # Version timeline (first/last seen)
 nxv history python311 3.11.4             # When was 3.11.4 available?
 nxv stats                                # Index statistics
-nxv update                               # Refresh index + check for newer nxv binary
-nxv update --no-self-update              # Refresh index only (CI / systemd timers)
+nxv update                               # Update nxv itself to the latest release
+nxv sync                                 # Download or refresh the local package index
+nxv sync --force                         # Force a full index re-download
 nxv serve --host 0.0.0.0 --port 8080     # Start HTTP API + web UI
 nxv completions zsh                      # Generate shell completions
-nxv skill install                        # Install this skill for detected AI agents
+nxv skill install codex                  # Install this skill for one explicit agent
+nxv skill install --detected             # Install for detected AI agents
 nxv skill list                           # Agents, skill paths, install status
 ```
 
@@ -33,7 +35,7 @@ nxv skill list                           # Agents, skill paths, install status
 
 Parse `$ARGUMENTS` to determine the action:
 
-- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
+- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
 - If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
 - If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
 - If no arguments, run `nxv stats` to give the user a quick health check of their index.
@@ -66,7 +68,7 @@ export NXV_API_URL=http://gpu-host:8080
 nxv search rust 1.70
 ```
 
-If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv update` to download the latest published index on first use.
+If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv sync` to download the latest published index on first use.
 
 ## Search
 
@@ -214,24 +216,27 @@ inputs.nixpkgs-python27.url = "github:NixOS/nixpkgs/<commit>";
 
 Pick `first_commit_hash` for the canonical "introduced in" commit; pick `last_commit_hash` if you want the most recent commit that still shipped that version.
 
-## Index Management
+## Application and Index Management
 
 ```bash
-nxv update                               # Refresh index + check for newer nxv binary
-nxv update --force                       # Force full re-download of the index
-nxv update --no-self-update              # Only refresh the index, leave binary alone
-nxv update --skip-verify                 # Skip minisign signature check (INSECURE)
-nxv update --public-key /path/key.pub    # Use a custom public key (self-hosted index)
-nxv update --manifest-url <URL>          # Use a custom manifest (self-hosted index)
+nxv update                               # Update the nxv application only
+nxv sync                                 # Download or refresh the package index only
+nxv sync --force                         # Force full re-download of the index
+nxv sync --skip-verify                   # Skip minisign signature check (INSECURE)
+nxv sync --public-key /path/key.pub      # Use a custom public key (self-hosted index)
+nxv sync --manifest-url <URL>            # Use a custom manifest (self-hosted index)
 nxv stats                                # Index size, commit range, last update
 ```
 
-`nxv update` always refreshes the package index first. Then it checks GitHub for a newer nxv release:
+`nxv update` only checks GitHub for the latest nxv release:
 
 - **Local install** (install.sh / manual download): downloads the platform binary, verifies SHA-256, atomically swaps the running executable.
 - **Nix / cargo / Homebrew**: prints the matching upgrade hint (e.g. `brew upgrade nxv`) and exits successfully.
 
-Set `NXV_NO_SELF_UPDATE=1` for CI/systemd timers that should only refresh the index.
+`nxv sync` independently refreshes the SQLite index and bloom filter. It never
+checks for or replaces the application. If a published index requires a newer
+schema, run `nxv update` (or the printed package-manager command) and retry
+`nxv sync`.
 
 ## API Server
 
@@ -300,8 +305,10 @@ This metadata is additive; package rows and the CLI JSON array are unchanged.
 nxv can install this very skill for any major AI coding agent — the binary embeds the SKILL.md and writes it where each agent looks, per the [Agent Skills standard](https://agentskills.io):
 
 ```bash
-nxv skill install                        # Install user-wide for detected agents
-nxv skill install --project              # Install into the current project (.claude + .agents)
+nxv skill install codex                  # Install user-wide for one agent
+nxv skill install --detected             # Explicitly install for detected agents
+nxv skill install codex --project        # Install for Codex in the current project
+nxv skill install --detected --project   # Map detected agents to project paths
 nxv skill install claude codex           # Install for specific agents only
 nxv skill install --all                  # Install for every supported agent
 nxv skill install copilot --dir ~/repo   # Project install into another directory
@@ -329,7 +336,12 @@ The table shows each agent's primary directory — the one `nxv skill install <a
 
 Semantics:
 
-- With no agent arguments, a user-wide install targets the agents detected on the machine (their config dir exists), falling back to the generic `agents` directory if none are found. A project install (`--project` / `--dir`) defaults to the `.claude` + `.agents` pair — per the read paths above, every supported agent picks up one of the two.
+- Installation requires one explicit target mode: one or more agent names,
+  `--detected`, or `--all`. With no target, nxv exits without writing anything.
+- `--detected` checks user configuration directories. With `--project` / `--dir`,
+  those detected agents are mapped to their corresponding project paths. No
+  detected agents is an error; use the explicit `agents` target for the generic
+  Agent Skills directory.
 - Agents sharing a directory (e.g. codex/cursor/gemini at project level) are deduplicated into a single write.
 - Install overwrites `skills/nxv/SKILL.md` unconditionally and never touches other files; uninstall removes only that file (and the `nxv/` directory if it is then empty).
 
@@ -365,7 +377,7 @@ Every recorded commit is a real, Hydra-built channel commit — `nix shell` comm
 
 Retired commands: `nxv backfill` and `nxv reset` are gone — snapshots carry complete metadata (source_path, homepage, known_vulnerabilities), and there is no checkout to reset.
 
-Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
+Most users never need these — they consume a pre-built published index via `nxv sync`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
 
 ## Key Environment Variables
 
@@ -374,11 +386,10 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_API_URL`        | Point CLI at a remote `nxv serve` instead of the local DB              |
 | `NXV_DB_PATH`        | Override local SQLite path                                             |
 | `NXV_API_TIMEOUT`    | HTTP client timeout in seconds (default 30)                            |
-| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv update`                         |
+| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv sync`                           |
 | `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
 | `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
 | `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
-| `NXV_NO_SELF_UPDATE` | Skip the binary self-update check during `nxv update`                  |
 | `NXV_VERSION`        | Pin the version installed by `install.sh` (self-update targets latest) |
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
@@ -399,7 +410,7 @@ Files:
 - `index.db` — SQLite database with package versions
 - `bloom.bin` — Bloom filter sibling for fast negative lookups (loaded at search time)
 
-Safe to delete; `nxv update` will rebuild from the published manifest.
+Safe to delete; `nxv sync` will rebuild from the published manifest.
 
 ## Agent Patterns
 
@@ -445,7 +456,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Version searches use the closest attribute tier**: nested package-set members do not fill a direct-package miss. Inspect API `meta.resolution` or CLI stderr for suggestions, query the package-set prefix directly, or opt into `--all-depths` / `all_depths=true`.
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
-- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
+- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv sync` rejects the signature.
 - **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in a recent release.
 - **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
@@ -456,17 +467,18 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Use `--exact`** when one exact attribute is required. Default version searches stay within the shallowest matching tier; use `--all-depths` only when nested variants are intentional.
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
 - **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.
-- **Update regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv update` pulls the latest.
-- **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
+- **Sync regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv sync` pulls the latest.
+- **For CI**: run `nxv sync`; it never checks for or replaces the application.
 
 ## Updating This Skill
 
 This skill is generated by the nxv binary itself. To refresh it after upgrading nxv:
 
 ```bash
-nxv update                               # Get the latest nxv (also refreshes the index)
-nxv skill install                        # Rewrite user-wide installs from the new binary
-nxv skill install --project              # ...or refresh a project-level install
+nxv update                               # Get the latest nxv application
+nxv skill install codex                  # Rewrite one user-wide install
+nxv skill install --detected             # ...or explicitly refresh detected agents
+nxv skill install codex --project        # Refresh one project-level install
 ```
 
 Without an nxv binary on hand, fetch the canonical copy from the repository:

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -21,11 +21,13 @@ nxv info python311 3.11.4                # Detailed info for specific version
 nxv history python311                    # Version timeline (first/last seen)
 nxv history python311 3.11.4             # When was 3.11.4 available?
 nxv stats                                # Index statistics
-nxv update                               # Refresh index + check for newer nxv binary
-nxv update --no-self-update              # Refresh index only (CI / systemd timers)
+nxv update                               # Update nxv itself to the latest release
+nxv sync                                 # Download or refresh the local package index
+nxv sync --force                         # Force a full index re-download
 nxv serve --host 0.0.0.0 --port 8080     # Start HTTP API + web UI
 nxv completions zsh                      # Generate shell completions
-nxv skill install                        # Install this skill for detected AI agents
+nxv skill install codex                  # Install this skill for one explicit agent
+nxv skill install --detected             # Install for detected AI agents
 nxv skill list                           # Agents, skill paths, install status
 ```
 
@@ -33,7 +35,7 @@ nxv skill list                           # Agents, skill paths, install status
 
 Parse `$ARGUMENTS` to determine the action:
 
-- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
+- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
 - If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
 - If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
 - If no arguments, run `nxv stats` to give the user a quick health check of their index.
@@ -66,7 +68,7 @@ export NXV_API_URL=http://gpu-host:8080
 nxv search rust 1.70
 ```
 
-If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv update` to download the latest published index on first use.
+If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv sync` to download the latest published index on first use.
 
 ## Search
 
@@ -214,24 +216,27 @@ inputs.nixpkgs-python27.url = "github:NixOS/nixpkgs/<commit>";
 
 Pick `first_commit_hash` for the canonical "introduced in" commit; pick `last_commit_hash` if you want the most recent commit that still shipped that version.
 
-## Index Management
+## Application and Index Management
 
 ```bash
-nxv update                               # Refresh index + check for newer nxv binary
-nxv update --force                       # Force full re-download of the index
-nxv update --no-self-update              # Only refresh the index, leave binary alone
-nxv update --skip-verify                 # Skip minisign signature check (INSECURE)
-nxv update --public-key /path/key.pub    # Use a custom public key (self-hosted index)
-nxv update --manifest-url <URL>          # Use a custom manifest (self-hosted index)
+nxv update                               # Update the nxv application only
+nxv sync                                 # Download or refresh the package index only
+nxv sync --force                         # Force full re-download of the index
+nxv sync --skip-verify                   # Skip minisign signature check (INSECURE)
+nxv sync --public-key /path/key.pub      # Use a custom public key (self-hosted index)
+nxv sync --manifest-url <URL>            # Use a custom manifest (self-hosted index)
 nxv stats                                # Index size, commit range, last update
 ```
 
-`nxv update` always refreshes the package index first. Then it checks GitHub for a newer nxv release:
+`nxv update` only checks GitHub for the latest nxv release:
 
 - **Local install** (install.sh / manual download): downloads the platform binary, verifies SHA-256, atomically swaps the running executable.
 - **Nix / cargo / Homebrew**: prints the matching upgrade hint (e.g. `brew upgrade nxv`) and exits successfully.
 
-Set `NXV_NO_SELF_UPDATE=1` for CI/systemd timers that should only refresh the index.
+`nxv sync` independently refreshes the SQLite index and bloom filter. It never
+checks for or replaces the application. If a published index requires a newer
+schema, run `nxv update` (or the printed package-manager command) and retry
+`nxv sync`.
 
 ## API Server
 
@@ -300,8 +305,10 @@ This metadata is additive; package rows and the CLI JSON array are unchanged.
 nxv can install this very skill for any major AI coding agent — the binary embeds the SKILL.md and writes it where each agent looks, per the [Agent Skills standard](https://agentskills.io):
 
 ```bash
-nxv skill install                        # Install user-wide for detected agents
-nxv skill install --project              # Install into the current project (.claude + .agents)
+nxv skill install codex                  # Install user-wide for one agent
+nxv skill install --detected             # Explicitly install for detected agents
+nxv skill install codex --project        # Install for Codex in the current project
+nxv skill install --detected --project   # Map detected agents to project paths
 nxv skill install claude codex           # Install for specific agents only
 nxv skill install --all                  # Install for every supported agent
 nxv skill install copilot --dir ~/repo   # Project install into another directory
@@ -329,7 +336,12 @@ The table shows each agent's primary directory — the one `nxv skill install <a
 
 Semantics:
 
-- With no agent arguments, a user-wide install targets the agents detected on the machine (their config dir exists), falling back to the generic `agents` directory if none are found. A project install (`--project` / `--dir`) defaults to the `.claude` + `.agents` pair — per the read paths above, every supported agent picks up one of the two.
+- Installation requires one explicit target mode: one or more agent names,
+  `--detected`, or `--all`. With no target, nxv exits without writing anything.
+- `--detected` checks user configuration directories. With `--project` / `--dir`,
+  those detected agents are mapped to their corresponding project paths. No
+  detected agents is an error; use the explicit `agents` target for the generic
+  Agent Skills directory.
 - Agents sharing a directory (e.g. codex/cursor/gemini at project level) are deduplicated into a single write.
 - Install overwrites `skills/nxv/SKILL.md` unconditionally and never touches other files; uninstall removes only that file (and the `nxv/` directory if it is then empty).
 
@@ -365,7 +377,7 @@ Every recorded commit is a real, Hydra-built channel commit — `nix shell` comm
 
 Retired commands: `nxv backfill` and `nxv reset` are gone — snapshots carry complete metadata (source_path, homepage, known_vulnerabilities), and there is no checkout to reset.
 
-Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
+Most users never need these — they consume a pre-built published index via `nxv sync`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
 
 ## Key Environment Variables
 
@@ -374,11 +386,10 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_API_URL`        | Point CLI at a remote `nxv serve` instead of the local DB              |
 | `NXV_DB_PATH`        | Override local SQLite path                                             |
 | `NXV_API_TIMEOUT`    | HTTP client timeout in seconds (default 30)                            |
-| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv update`                         |
+| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv sync`                           |
 | `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
 | `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
 | `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
-| `NXV_NO_SELF_UPDATE` | Skip the binary self-update check during `nxv update`                  |
 | `NXV_VERSION`        | Pin the version installed by `install.sh` (self-update targets latest) |
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
@@ -399,7 +410,7 @@ Files:
 - `index.db` — SQLite database with package versions
 - `bloom.bin` — Bloom filter sibling for fast negative lookups (loaded at search time)
 
-Safe to delete; `nxv update` will rebuild from the published manifest.
+Safe to delete; `nxv sync` will rebuild from the published manifest.
 
 ## Agent Patterns
 
@@ -445,7 +456,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Version searches use the closest attribute tier**: nested package-set members do not fill a direct-package miss. Inspect API `meta.resolution` or CLI stderr for suggestions, query the package-set prefix directly, or opt into `--all-depths` / `all_depths=true`.
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
-- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
+- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv sync` rejects the signature.
 - **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in a recent release.
 - **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
@@ -456,17 +467,18 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Use `--exact`** when one exact attribute is required. Default version searches stay within the shallowest matching tier; use `--all-depths` only when nested variants are intentional.
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
 - **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.
-- **Update regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv update` pulls the latest.
-- **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
+- **Sync regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv sync` pulls the latest.
+- **For CI**: run `nxv sync`; it never checks for or replaces the application.
 
 ## Updating This Skill
 
 This skill is generated by the nxv binary itself. To refresh it after upgrading nxv:
 
 ```bash
-nxv update                               # Get the latest nxv (also refreshes the index)
-nxv skill install                        # Rewrite user-wide installs from the new binary
-nxv skill install --project              # ...or refresh a project-level install
+nxv update                               # Get the latest nxv application
+nxv skill install codex                  # Rewrite one user-wide install
+nxv skill install --detected             # ...or explicitly refresh detected agents
+nxv skill install codex --project        # Refresh one project-level install
 ```
 
 Without an nxv binary on hand, fetch the canonical copy from the repository:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ nix run .#nxv-indexer            # Run with indexer feature
 
 ### Data Flow
 
-1. **Index Download** (`remote/`): User runs `nxv update` → downloads compressed SQLite DB + bloom filter from remote manifest
+1. **Index Download** (`remote/`): User runs `nxv sync` → downloads compressed SQLite DB + bloom filter from remote manifest
 2. **Search** (`db/queries.rs`): Queries go through bloom filter first (fast negative lookup), then SQLite with FTS5
 3. **Output** (`output/`): Results formatted as table (default), JSON, or plain text
 
@@ -60,7 +60,7 @@ The CLI transparently runs against either a local index or a remote `nxv serve` 
 
 ### Self-Update (`self_update.rs`)
 
-There is no standalone `self-update` subcommand — `nxv update` refreshes the index first, then checks GitHub for a newer nxv release. On local installs (install.sh, manual download) the binary is replaced atomically after SHA-256 verification against the release's SHA256SUMS.txt; on managed installs (Nix, cargo, Homebrew — detected from the executable path) it only prints the matching upgrade command. If the index refresh fails with an incompatible-index (schema too new) error, the self-update check still runs before exiting so users can recover. Skip with `--no-self-update` or `NXV_NO_SELF_UPDATE`. Note: `NXV_VERSION` is read only by `install.sh` to pin the installer download — the binary's self-update always targets the latest release.
+`nxv update` only checks for and installs the latest nxv application release. On local installs (install.sh, manual download) the binary is replaced atomically after SHA-256 verification against the release's SHA256SUMS.txt; on managed installs (Nix, cargo, Homebrew — detected from the executable path) it only prints the matching upgrade command. `nxv sync` independently downloads or refreshes the package index and never updates the application. An incompatible index tells users to update the application and retry the sync. Note: `NXV_VERSION` is read only by `install.sh` to pin the installer download — the binary's application update always targets the latest release.
 
 ### API Server (`server/`)
 
@@ -118,10 +118,9 @@ Most are also exposed as CLI flags (see `src/cli.rs`); env vars are useful for t
 - `NXV_API_URL` — point the CLI at a remote `nxv serve` instead of the local DB
 - `NXV_API_TIMEOUT` — HTTP client timeout in seconds (default 30)
 - `NXV_DB_PATH` — override local SQLite path
-- `NXV_MANIFEST_URL` — override the manifest URL for `nxv update`
+- `NXV_MANIFEST_URL` — override the manifest URL for `nxv sync`
 - `NXV_SKIP_VERIFY` — skip minisign verification of the manifest
 - `NXV_PUBLIC_KEY` — override the embedded minisign public key
-- `NXV_NO_SELF_UPDATE` — make `nxv update` only refresh the index, skipping the binary check
 - `NXV_VERSION` — pin the version `install.sh` downloads (not read by the binary itself)
 - `NXV_HOST`, `NXV_PORT`, `NXV_RATE_LIMIT`, `NXV_RATE_LIMIT_BURST` — `nxv serve` bind/host/rate-limit
 - `NXV_MAX_DB_CONNECTIONS`, `NXV_DB_TIMEOUT_SECS` — `nxv serve` DB concurrency cap (default 32) and per-operation timeout (default 30s)

--- a/README.md
+++ b/README.md
@@ -152,15 +152,14 @@ nix run nixpkgs/e4a45f9#python
 ### Keeping nxv up to date
 
 ```bash
-nxv update                    # Refresh the index, then check for a newer nxv release
-nxv update --force            # Force a full re-download of the index
-nxv update --no-self-update   # Only refresh the index; skip the binary check
+nxv update                    # Update the nxv application
+nxv sync                      # Download or refresh the package index
+nxv sync --force              # Force a full re-download of the index
 nxv stats                     # Show index statistics
 ```
 
-`nxv update` always refreshes the package index first. Afterwards it
-checks GitHub for a newer nxv release and behaves according to how nxv
-was installed:
+`nxv update` only checks GitHub for the latest nxv release and behaves
+according to how nxv was installed:
 
 - **Local install** (from `install.sh` or a manual download) — downloads
   the platform binary, verifies its SHA-256 against `SHA256SUMS.txt`, and
@@ -169,9 +168,9 @@ was installed:
   matching upgrade command (e.g. `brew upgrade nxv`,
   `cargo install --locked nxv`).
 
-Set `NXV_NO_SELF_UPDATE=1` or pass `--no-self-update` to skip the binary
-check entirely (useful for CI or systemd timer units that only want to
-refresh the index).
+`nxv sync` independently refreshes the local SQLite index and bloom filter.
+It never checks for or replaces the nxv application, so it is the command to
+use in CI and systemd timers.
 
 ## API Server
 
@@ -384,18 +383,18 @@ Clients can then verify using your public key:
 
 ```bash
 # Via CLI flag
-nxv update --manifest-url https://your-server/manifest.json \
-           --public-key /path/to/nxv.pub
+nxv sync --manifest-url https://your-server/manifest.json \
+         --public-key /path/to/nxv.pub
 
 # Or via environment variable
 export NXV_PUBLIC_KEY=/path/to/nxv.pub
-nxv update --manifest-url https://your-server/manifest.json
+nxv sync --manifest-url https://your-server/manifest.json
 ```
 
 To skip verification (not recommended for production):
 
 ```bash
-nxv update --manifest-url https://your-server/manifest.json --skip-verify
+nxv sync --manifest-url https://your-server/manifest.json --skip-verify
 ```
 
 ### Hosting Your Own Index
@@ -488,7 +487,7 @@ Clients download the index once and query locally. Low server load, works offlin
 
 ```bash
 # One-time download
-nxv update --manifest-url https://your-server.com/nxv/manifest.json
+nxv sync --manifest-url https://your-server.com/nxv/manifest.json
 
 # Or set permanently
 export NXV_MANIFEST_URL=https://your-server.com/nxv/manifest.json
@@ -558,7 +557,6 @@ The `manifest.json` format:
 | `NXV_SECRET_KEY` | Secret key for manifest signing (path or raw key content) |
 | `NXV_SKIP_VERIFY` | Skip manifest signature verification (set to any value) |
 | `NXV_API_TIMEOUT` | API request timeout in seconds (default: 30) |
-| `NXV_NO_SELF_UPDATE` | Skip the binary self-update check in `nxv update` |
 | `NO_COLOR` | Disable colored output |
 | `NXV_HOST` | `nxv serve` bind address (default: `127.0.0.1`) |
 | `NXV_PORT` | `nxv serve` port (default: `8080`) |
@@ -598,7 +596,7 @@ src/
 ├── output/          # Table/JSON/plain formatters
 ├── bloom.rs         # Bloom filter
 ├── search.rs        # Search/filter/sort logic
-├── self_update.rs   # Binary self-update (part of nxv update)
+├── self_update.rs   # Application update used by nxv update
 ├── skill/           # Agent skill install/list/uninstall (nxv skill ...)
 ├── version.rs       # Version/long-version string helpers
 ├── paths.rs         # Platform-specific paths
@@ -621,8 +619,9 @@ API on your behalf without extra setup. The binary embeds the skill and
 installs it where each agent looks:
 
 ```bash
-nxv skill install              # Install user-wide for detected agents
-nxv skill install --project    # Install into the current project
+nxv skill install codex        # Install user-wide for one agent
+nxv skill install --detected   # Explicitly target detected agents
+nxv skill install codex --project # Install for Codex in this project
 nxv skill list                 # Show agents, paths, install status
 ```
 

--- a/docs/indexer-rewrite/DESIGN.md
+++ b/docs/indexer-rewrite/DESIGN.md
@@ -356,9 +356,9 @@ hidden no-op with a deprecation warning for one release cycle.
    the code passes None — publishing v4 ungated would let every old
    client's `nxv sync` overwrite its working v3 index and then fail to
    open it: verified landmine L1).
-2. **cmd_update fix**: on IncompatibleIndex, still run the self-update
-   check before propagating, so old local-install binaries are told to (and
-   can) upgrade in one step.
+2. **Sync compatibility guidance**: on IncompatibleIndex, `nxv sync`
+   directs users to run `nxv update` (or the printed package-manager command)
+   and then retry `nxv sync`; it never checks the release API itself.
 3. **Release the new binary first** (reads v3 and v4; index format
    unchanged at this point). Wait an adoption window (1–2 weeks).
 4. **Initial v4 full rebuild runs out-of-band** (locally — hours for the

--- a/docs/indexer-rewrite/DESIGN.md
+++ b/docs/indexer-rewrite/DESIGN.md
@@ -178,7 +178,7 @@ CREATE INDEX idx_packages_search_nocase ON package_versions(
 - **meta**: `schema_version=4`. The indexer **keeps writing**
   `last_indexed_commit` (= newest ingested release commit) and
   `last_indexed_date` — they are load-bearing for `manifest.latest_commit`,
-  the `nxv update` UpToDate check, `/health`, `/api/v1/stats`, and the
+  the `nxv sync` UpToDate check, `/health`, `/api/v1/stats`, and the
   frontend stats panel. Planning watermarks derive from `releases`.
 - **Migration v3→v4 (local DBs)**: `dedupe_ranges()` (production DB has
   1,073 duplicate (attr,version) groups; without dedupe the new upsert fails
@@ -354,7 +354,7 @@ hidden no-op with a deprecation warning for one release cycle.
    `min_version` to SCHEMA_VERSION and refuses to publish a schema-4 DB
    with min_version unset or < 4** (today the doc claims this default but
    the code passes None — publishing v4 ungated would let every old
-   client's `nxv update` overwrite its working v3 index and then fail to
+   client's `nxv sync` overwrite its working v3 index and then fail to
    open it: verified landmine L1).
 2. **cmd_update fix**: on IncompatibleIndex, still run the self-update
    check before propagating, so old local-install binaries are told to (and

--- a/install.sh
+++ b/install.sh
@@ -220,7 +220,7 @@ main() {
 
     printf '\n%bInstallation complete!%b\n' "$GREEN" "$NC"
     printf "Run '%bnxv --help%b' to get started.\n" "$BOLD" "$NC"
-    printf "Run '%bnxv update%b' to download the package index.\n\n" "$BOLD" "$NC"
+    printf "Run '%bnxv sync%b' to download the package index.\n\n" "$BOLD" "$NC"
 }
 
 main "$@"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use crate::paths;
 use crate::search::SortOrder;
 use crate::skill::Agent;
 use crate::version;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use std::path::PathBuf;
 
@@ -44,17 +44,19 @@ pub enum Commands {
     /// Search for package versions.
     Search(SearchArgs),
 
-    /// Update the package index, then check for a newer nxv release.
+    /// Update nxv to the latest application release.
     ///
-    /// This runs the index refresh first. Afterwards it checks GitHub
-    /// for a newer nxv binary. On a local install (install.sh, manual
-    /// download) the new binary is downloaded, its SHA-256 is verified
-    /// against SHA256SUMS.txt, and the running executable is replaced
-    /// atomically. On managed installs (Nix, cargo, Homebrew) the
-    /// binary is left alone and the matching upgrade command is
-    /// printed instead. Pass `--no-self-update` to skip the binary
-    /// check entirely and only refresh the index.
+    /// On a local install (install.sh, manual download), the latest binary
+    /// is downloaded, verified, and replaced atomically. Managed installs
+    /// (Nix, cargo, Homebrew) print the matching upgrade command instead.
+    /// Use `nxv sync` to download or refresh the package index.
     Update(UpdateArgs),
+
+    /// Download or refresh the local package index.
+    ///
+    /// Synchronizes the SQLite index and bloom filter from the configured
+    /// manifest. This command never checks for or installs nxv releases.
+    Sync(SyncArgs),
 
     /// Show detailed information about a package.
     ///
@@ -162,13 +164,11 @@ pub enum SkillCommands {
     /// List supported agents, their skill paths, and install status.
     List(SkillListArgs),
 
-    /// Install the nxv skill (user-wide by default, --project for project-level).
+    /// Install the nxv skill for explicitly selected agents.
     ///
-    /// With no agent arguments, a user-wide install targets the agents
-    /// detected on this machine (their config directory exists), falling
-    /// back to the generic `agents` directory when none are found. A
-    /// project install defaults to the `.claude` + `.agents` pair, which
-    /// every supported agent reads.
+    /// Name one or more agents, or explicitly pass `--detected` or `--all`.
+    /// Nothing is installed when no target mode is supplied. User-wide is
+    /// the default scope; use `--project` or `--dir` for project-level paths.
     Install(SkillInstallArgs),
 
     /// Remove installed nxv skills.
@@ -192,9 +192,14 @@ pub struct SkillListArgs {
 
 /// Arguments for `skill install`.
 #[derive(Parser, Debug)]
+#[command(group(
+    ArgGroup::new("targets")
+        .required(true)
+        .multiple(false)
+        .args(["agents", "detected", "all"])
+))]
 pub struct SkillInstallArgs {
-    /// Agents to install for (default: detected agents, or claude + agents
-    /// for project installs).
+    /// Agents to install for.
     #[arg(value_enum)]
     pub agents: Vec<Agent>,
 
@@ -207,8 +212,15 @@ pub struct SkillInstallArgs {
     #[arg(long, value_name = "PATH")]
     pub dir: Option<PathBuf>,
 
+    /// Install for agents detected from user configuration directories.
+    ///
+    /// With --project or --dir, detected agents are mapped to their
+    /// corresponding project-level skill paths.
+    #[arg(long)]
+    pub detected: bool,
+
     /// Install for all supported agents regardless of detection.
-    #[arg(long, conflicts_with = "agents")]
+    #[arg(long)]
     pub all: bool,
 }
 
@@ -307,15 +319,46 @@ impl SearchArgs {
     }
 }
 
-/// Arguments for the update command.
+/// Arguments retained only to give users of the former combined update
+/// command an actionable migration error. They stay hidden from help and
+/// never trigger index or application updates.
 #[derive(Parser, Debug)]
 pub struct UpdateArgs {
+    #[arg(short = 'f', long = "force", hide = true)]
+    pub legacy_force: bool,
+
+    #[arg(long = "manifest-url", hide = true)]
+    pub legacy_manifest_url: Option<String>,
+
+    #[arg(long = "skip-verify", hide = true)]
+    pub legacy_skip_verify: bool,
+
+    #[arg(long = "public-key", hide = true)]
+    pub legacy_public_key: Option<String>,
+
+    #[arg(long = "no-self-update", hide = true)]
+    pub legacy_no_self_update: bool,
+}
+
+impl UpdateArgs {
+    pub fn has_legacy_index_options(&self) -> bool {
+        self.legacy_force
+            || self.legacy_manifest_url.is_some()
+            || self.legacy_skip_verify
+            || self.legacy_public_key.is_some()
+            || self.legacy_no_self_update
+    }
+}
+
+/// Arguments for the sync command.
+#[derive(Parser, Debug)]
+pub struct SyncArgs {
     /// Force full re-download of the index.
     #[arg(short, long)]
     pub force: bool,
 
-    /// Custom manifest URL (for testing or alternate index sources).
-    #[arg(long, env = "NXV_MANIFEST_URL", hide = true)]
+    /// Custom manifest URL for alternate or self-hosted indexes.
+    #[arg(long, env = "NXV_MANIFEST_URL")]
     pub manifest_url: Option<String>,
 
     /// Skip manifest signature verification (INSECURE - use only for development/testing).
@@ -326,14 +369,6 @@ pub struct UpdateArgs {
     /// Can be the raw key (RW...) or path to a .pub file.
     #[arg(long, env = "NXV_PUBLIC_KEY")]
     pub public_key: Option<String>,
-
-    /// Skip the binary self-update check after the index refresh.
-    ///
-    /// By default, `nxv update` also checks GitHub for a newer nxv release
-    /// and updates the binary (for local installs) or prints a hint (for
-    /// managed installs). Pass this flag to only refresh the index.
-    #[arg(long, env = "NXV_NO_SELF_UPDATE")]
-    pub no_self_update: bool,
 }
 
 /// Arguments for the history command.
@@ -720,55 +755,76 @@ mod tests {
         let args = Cli::try_parse_from(["nxv", "update"]).unwrap();
         match args.command {
             Commands::Update(update) => {
-                assert!(!update.force);
+                assert!(!update.has_legacy_index_options());
             }
             _ => panic!("Expected Update command"),
         }
     }
 
     #[test]
-    fn test_update_force() {
+    fn test_update_retains_legacy_force_for_migration_error() {
         let args = Cli::try_parse_from(["nxv", "update", "--force"]).unwrap();
         match args.command {
             Commands::Update(update) => {
-                assert!(update.force);
+                assert!(update.has_legacy_index_options());
             }
             _ => panic!("Expected Update command"),
         }
     }
 
     #[test]
-    fn test_update_public_key() {
-        let args = Cli::try_parse_from(["nxv", "update", "--public-key", "RWTest123"]).unwrap();
+    fn test_sync_command() {
+        let args = Cli::try_parse_from(["nxv", "sync"]).unwrap();
         match args.command {
-            Commands::Update(update) => {
-                assert_eq!(update.public_key, Some("RWTest123".to_string()));
-                assert!(!update.skip_verify);
+            Commands::Sync(sync) => {
+                assert!(!sync.force);
+                assert!(!sync.skip_verify);
             }
-            _ => panic!("Expected Update command"),
+            _ => panic!("Expected Sync command"),
         }
     }
 
     #[test]
-    fn test_update_public_key_file() {
-        let args =
-            Cli::try_parse_from(["nxv", "update", "--public-key", "/path/to/key.pub"]).unwrap();
+    fn test_sync_force() {
+        let args = Cli::try_parse_from(["nxv", "sync", "--force"]).unwrap();
         match args.command {
-            Commands::Update(update) => {
-                assert_eq!(update.public_key, Some("/path/to/key.pub".to_string()));
+            Commands::Sync(sync) => {
+                assert!(sync.force);
             }
-            _ => panic!("Expected Update command"),
+            _ => panic!("Expected Sync command"),
         }
     }
 
     #[test]
-    fn test_update_no_self_update_flag() {
-        let args = Cli::try_parse_from(["nxv", "update", "--no-self-update"]).unwrap();
+    fn test_sync_public_key() {
+        let args = Cli::try_parse_from(["nxv", "sync", "--public-key", "RWTest123"]).unwrap();
         match args.command {
-            Commands::Update(u) => {
-                assert!(u.no_self_update);
+            Commands::Sync(sync) => {
+                assert_eq!(sync.public_key, Some("RWTest123".to_string()));
+                assert!(!sync.skip_verify);
             }
-            _ => panic!("Expected Update command"),
+            _ => panic!("Expected Sync command"),
+        }
+    }
+
+    #[test]
+    fn test_skill_install_requires_explicit_target_mode() {
+        assert!(Cli::try_parse_from(["nxv", "skill", "install"]).is_err());
+    }
+
+    #[test]
+    fn test_skill_install_detected_mode() {
+        let args = Cli::try_parse_from(["nxv", "skill", "install", "--detected"]).unwrap();
+        match args.command {
+            Commands::Skill(skill) => match skill.command {
+                SkillCommands::Install(install) => {
+                    assert!(install.detected);
+                    assert!(!install.all);
+                    assert!(install.agents.is_empty());
+                }
+                _ => panic!("Expected Install command"),
+            },
+            _ => panic!("Expected Skill command"),
         }
     }
 
@@ -849,6 +905,7 @@ mod tests {
                     assert_eq!(install.agents, vec![Agent::Claude, Agent::Codex]);
                     assert!(install.project);
                     assert!(install.dir.is_none());
+                    assert!(!install.detected);
                     assert!(!install.all);
                 }
                 _ => panic!("Expected Install subcommand"),
@@ -861,6 +918,12 @@ mod tests {
     fn test_skill_install_all_conflicts_with_agents() {
         let result = Cli::try_parse_from(["nxv", "skill", "install", "claude", "--all"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_skill_install_detected_conflicts_with_other_targets() {
+        assert!(Cli::try_parse_from(["nxv", "skill", "install", "claude", "--detected"]).is_err());
+        assert!(Cli::try_parse_from(["nxv", "skill", "install", "--detected", "--all"]).is_err());
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,10 +9,10 @@ pub enum NxvError {
     #[error("Database error: {0}")]
     Database(#[from] rusqlite::Error),
 
-    #[error("No index found. Run 'nxv update' to download the package index.")]
+    #[error("No index found. Run 'nxv sync' to download the package index.")]
     NoIndex,
 
-    #[error("Index is corrupted: {0}. Run 'nxv update --force' to re-download.")]
+    #[error("Index is corrupted: {0}. Run 'nxv sync --force' to re-download.")]
     CorruptIndex(String),
 
     #[error("Incompatible index: {0}")]
@@ -73,7 +73,7 @@ mod tests {
     fn test_no_index_error_message() {
         let err = NxvError::NoIndex;
         let msg = err.to_string();
-        assert!(msg.contains("nxv update"));
+        assert!(msg.contains("nxv sync"));
         assert!(msg.contains("No index found"));
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -253,7 +253,7 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
     let bloom_path = crate::paths::get_bloom_path_for_db(&cli.db_path);
     save_bloom_filter(&db, &bloom_path)?;
 
-    // Watermarks: load-bearing for manifest.latest_commit, `nxv update`'s
+    // Watermarks: load-bearing for manifest.latest_commit, `nxv sync`'s
     // UpToDate check, /health, /api/v1/stats and the frontend stats panel.
     if let Some(newest) = db.newest_ingested_release(None)? {
         db.set_meta("last_indexed_commit", &newest.commit_hash)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
     let result = match &cli.command {
         Commands::Search(args) => cmd_search(&cli, args),
         Commands::Update(args) => cmd_update(&cli, args),
+        Commands::Sync(args) => cmd_sync(&cli, args),
         Commands::Info(args) => cmd_pkg_info(&cli, args),
         Commands::Stats => cmd_stats(&cli),
         Commands::History(args) => cmd_history(&cli, args),
@@ -191,18 +192,15 @@ fn get_backend_with_prompt(cli: &Cli) -> Result<backend::Backend> {
                 let input = input.trim().to_lowercase();
 
                 if input.is_empty() || input == "y" || input == "yes" {
-                    // Run the update command. Skip the binary self-update check —
-                    // the user invoked search/info/etc., not an explicit update,
-                    // and we don't want to surprise them by replacing the binary
-                    // mid-session.
-                    let update_args = cli::UpdateArgs {
+                    // Download only the index. A first-run search must never
+                    // replace the application binary as a side effect.
+                    let sync_args = cli::SyncArgs {
                         force: false,
                         manifest_url: None,
                         skip_verify: false,
                         public_key: None,
-                        no_self_update: true,
                     };
-                    cmd_update(cli, &update_args)?;
+                    cmd_sync(cli, &sync_args)?;
 
                     // Try to open the database again
                     let db = db::Database::open_readonly(&cli.db_path)?;
@@ -432,7 +430,40 @@ fn print_version_search_miss(package: &str, resolution: &crate::search::SearchRe
     }
 }
 
-/// Updates the local package index from the configured manifest or remote API.
+/// Update the nxv application to the latest release.
+fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
+    if args.has_legacy_index_options() {
+        anyhow::bail!(
+            "index synchronization moved to `nxv sync`; re-run this command with `nxv sync`"
+        );
+    }
+
+    if legacy_no_self_update_enabled() {
+        anyhow::bail!(
+            "NXV_NO_SELF_UPDATE is retired: use `nxv sync` to refresh the index, or unset it to update nxv"
+        );
+    }
+
+    self_update::run(self_update::SelfUpdateOptions {
+        check: false,
+        force: false,
+        version: None,
+        connect_timeout_secs: cli.api_timeout,
+        show_progress: !cli.quiet,
+        quiet: cli.quiet,
+    })
+}
+
+fn legacy_no_self_update_enabled() -> bool {
+    std::env::var("NXV_NO_SELF_UPDATE").is_ok_and(|value| {
+        !matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        )
+    })
+}
+
+/// Updates the local package index from the configured manifest.
 ///
 /// Performs an update using the provided CLI context and update arguments, and prints
 /// user-facing progress and the final outcome (up-to-date, downloaded, delta applied,
@@ -446,16 +477,21 @@ fn print_version_search_miss(package: &str, resolution: &crate::search::SearchRe
 ///
 /// ```no_run
 /// # use anyhow::Result;
-/// # use crate::cli::{Cli, UpdateArgs};
+/// # use crate::cli::{Cli, SyncArgs};
 /// # fn example() -> Result<()> {
 /// // `cli` and `args` would typically come from CLI parsing.
 /// let cli = Cli::parse();
-/// let args = UpdateArgs { force: false, manifest_url: None };
-/// cmd_update(&cli, &args)?;
+/// let args = SyncArgs {
+///     force: false,
+///     manifest_url: None,
+///     skip_verify: false,
+///     public_key: None,
+/// };
+/// cmd_sync(&cli, &args)?;
 /// # Ok(())
 /// # }
 /// ```
-fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
+fn cmd_sync(cli: &Cli, args: &cli::SyncArgs) -> Result<()> {
     use crate::cli::Verbosity;
     use crate::remote::update::{UpdateStatus, perform_update};
 
@@ -488,33 +524,10 @@ fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
         Some(cli.api_timeout),
     ) {
         Ok(status) => status,
-        // An incompatible published index means this binary is too old. The
-        // self-update check is exactly what fixes that — run it before
-        // propagating, so old local installs can upgrade in one step
-        // instead of being told "please upgrade" with no way to do it.
         Err(e @ crate::error::NxvError::IncompatibleIndex(_)) => {
             eprintln!("{e}");
-            if !args.no_self_update {
-                eprintln!();
-                match self_update::run(self_update::SelfUpdateOptions {
-                    check: false,
-                    force: false,
-                    version: None,
-                    connect_timeout_secs: cli.api_timeout,
-                    show_progress,
-                    quiet: cli.quiet,
-                }) {
-                    Ok(()) => {
-                        eprintln!();
-                        eprintln!(
-                            "If the binary was updated, re-run `nxv update` to fetch the index."
-                        );
-                    }
-                    Err(update_err) => {
-                        eprintln!("Self-update failed: {update_err}");
-                        eprintln!("Upgrade nxv manually, then re-run `nxv update`.");
-                    }
-                }
+            if !cli.quiet {
+                eprintln!("Run `nxv update` to upgrade the application, then retry `nxv sync`.");
             }
             return Err(e.into());
         }
@@ -548,30 +561,6 @@ fn cmd_update(cli: &Cli, args: &cli::UpdateArgs) -> Result<()> {
             if verbosity >= Verbosity::Info {
                 eprintln!("Full commit hash: {}", commit);
             }
-        }
-    }
-
-    if !args.no_self_update {
-        if !cli.quiet {
-            eprintln!();
-        }
-        // Binary check is best-effort: a GitHub outage or rate limit should not
-        // fail the overall update (the index step already succeeded). Surface
-        // the error as a warning only.
-        let result = self_update::run(self_update::SelfUpdateOptions {
-            check: false,
-            force: false,
-            version: None,
-            // `api_timeout` is applied as a connect-timeout only; it does not
-            // bound the (potentially multi-MB) binary download.
-            connect_timeout_secs: cli.api_timeout,
-            show_progress,
-            quiet: cli.quiet,
-        });
-        if let Err(e) = result
-            && !cli.quiet
-        {
-            eprintln!("Skipping binary self-update check: {e}");
         }
     }
 
@@ -850,7 +839,7 @@ fn cmd_pkg_info(cli: &Cli, args: &cli::InfoArgs) -> Result<()> {
 /// index information (API endpoint or database path, index version, last indexed commit) and
 /// aggregate statistics (total version ranges, unique package names/versions, oldest/newest commit
 /// dates). If using a local backend, also prints the database file size and bloom filter status.
-/// If a local index is missing, prints guidance to run `nxv update` and returns without error.
+/// If a local index is missing, prints guidance to run `nxv sync` and returns without error.
 ///
 /// # Examples
 ///
@@ -872,7 +861,7 @@ fn cmd_stats(cli: &Cli) -> Result<()> {
                     .is_some_and(|e| matches!(e, error::NxvError::NoIndex))
             {
                 println!("No index found at {:?}", cli.db_path);
-                println!("Run 'nxv update' to download the package index.");
+                println!("Run 'nxv sync' to download the package index.");
                 return Ok(());
             }
             return Err(e);

--- a/src/remote/update.rs
+++ b/src/remote/update.rs
@@ -429,7 +429,7 @@ pub fn perform_update<P: AsRef<Path>>(
     )?;
 
     match &status {
-        // No output here: cmd_update reports the UpToDate status to the
+        // No output here: cmd_sync reports the UpToDate status to the
         // user (printing it here too produced a duplicate line).
         UpdateStatus::UpToDate { .. } => {}
         UpdateStatus::NoLocalIndex { .. } | UpdateStatus::FullDownloadNeeded { .. } => {

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,11 +1,9 @@
-//! Self-update support for `nxv update`.
+//! Application-update support for `nxv update`.
 //!
-//! There is no standalone `self-update` subcommand — `nxv update` refreshes
-//! the package index first and then delegates to [`run`] here to check for
-//! a newer `nxv` release. For a local install the running binary is
-//! replaced in place; for a managed install (Nix / cargo / Homebrew) the
-//! binary is left untouched and the correct package-manager hint is
-//! printed instead.
+//! `nxv update` delegates directly to [`run`] and never synchronizes the
+//! package index. For a local install the running binary is replaced in
+//! place; for a managed install (Nix / cargo / Homebrew) the binary is left
+//! untouched and the correct package-manager hint is printed instead.
 
 use std::path::Path;
 use std::time::Duration;

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -188,7 +188,7 @@ impl From<crate::error::NxvError> for ApiError {
     /// Convert an `NxvError` into an `ApiError` suitable for HTTP responses.
     ///
     /// Maps specific `NxvError` variants to HTTP statuses and descriptive messages:
-    /// - `NxvError::NoIndex` -> 503 Service Unavailable with guidance to run `nxv update`.
+    /// - `NxvError::NoIndex` -> 503 Service Unavailable with guidance to run `nxv sync`.
     /// - `NxvError::CorruptIndex(msg)` -> 503 Service Unavailable with `Corrupt index: {msg}`.
     /// - `NxvError::PackageNotFound(name)` -> 404 Not Found with `Package '{name}' not found`.
     /// - all other variants -> 500 Internal Server Error with the error's `to_string()` as the message.
@@ -207,7 +207,7 @@ impl From<crate::error::NxvError> for ApiError {
         use crate::error::NxvError;
         match err {
             NxvError::NoIndex => {
-                ApiError::unavailable("No package index found. Run 'nxv update' first.")
+                ApiError::unavailable("No package index found. Run 'nxv sync' first.")
             }
             NxvError::CorruptIndex(msg) => ApiError::unavailable(format!("Corrupt index: {}", msg)),
             NxvError::PackageNotFound(name) => {

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -21,11 +21,13 @@ nxv info python311 3.11.4                # Detailed info for specific version
 nxv history python311                    # Version timeline (first/last seen)
 nxv history python311 3.11.4             # When was 3.11.4 available?
 nxv stats                                # Index statistics
-nxv update                               # Refresh index + check for newer nxv binary
-nxv update --no-self-update              # Refresh index only (CI / systemd timers)
+nxv update                               # Update nxv itself to the latest release
+nxv sync                                 # Download or refresh the local package index
+nxv sync --force                         # Force a full index re-download
 nxv serve --host 0.0.0.0 --port 8080     # Start HTTP API + web UI
 nxv completions zsh                      # Generate shell completions
-nxv skill install                        # Install this skill for detected AI agents
+nxv skill install codex                  # Install this skill for one explicit agent
+nxv skill install --detected             # Install for detected AI agents
 nxv skill list                           # Agents, skill paths, install status
 ```
 
@@ -33,7 +35,7 @@ nxv skill list                           # Agents, skill paths, install status
 
 Parse `$ARGUMENTS` to determine the action:
 
-- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
+- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
 - If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
 - If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
 - If no arguments, run `nxv stats` to give the user a quick health check of their index.
@@ -66,7 +68,7 @@ export NXV_API_URL=http://gpu-host:8080
 nxv search rust 1.70
 ```
 
-If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv update` to download the latest published index on first use.
+If `NXV_API_URL` is unset, the CLI uses the local index at `~/Library/Application Support/nxv/index.db` (macOS) or `~/.local/share/nxv/index.db` (Linux). Run `nxv sync` to download the latest published index on first use.
 
 ## Search
 
@@ -214,24 +216,27 @@ inputs.nixpkgs-python27.url = "github:NixOS/nixpkgs/<commit>";
 
 Pick `first_commit_hash` for the canonical "introduced in" commit; pick `last_commit_hash` if you want the most recent commit that still shipped that version.
 
-## Index Management
+## Application and Index Management
 
 ```bash
-nxv update                               # Refresh index + check for newer nxv binary
-nxv update --force                       # Force full re-download of the index
-nxv update --no-self-update              # Only refresh the index, leave binary alone
-nxv update --skip-verify                 # Skip minisign signature check (INSECURE)
-nxv update --public-key /path/key.pub    # Use a custom public key (self-hosted index)
-nxv update --manifest-url <URL>          # Use a custom manifest (self-hosted index)
+nxv update                               # Update the nxv application only
+nxv sync                                 # Download or refresh the package index only
+nxv sync --force                         # Force full re-download of the index
+nxv sync --skip-verify                   # Skip minisign signature check (INSECURE)
+nxv sync --public-key /path/key.pub      # Use a custom public key (self-hosted index)
+nxv sync --manifest-url <URL>            # Use a custom manifest (self-hosted index)
 nxv stats                                # Index size, commit range, last update
 ```
 
-`nxv update` always refreshes the package index first. Then it checks GitHub for a newer nxv release:
+`nxv update` only checks GitHub for the latest nxv release:
 
 - **Local install** (install.sh / manual download): downloads the platform binary, verifies SHA-256, atomically swaps the running executable.
 - **Nix / cargo / Homebrew**: prints the matching upgrade hint (e.g. `brew upgrade nxv`) and exits successfully.
 
-Set `NXV_NO_SELF_UPDATE=1` for CI/systemd timers that should only refresh the index.
+`nxv sync` independently refreshes the SQLite index and bloom filter. It never
+checks for or replaces the application. If a published index requires a newer
+schema, run `nxv update` (or the printed package-manager command) and retry
+`nxv sync`.
 
 ## API Server
 
@@ -300,8 +305,10 @@ This metadata is additive; package rows and the CLI JSON array are unchanged.
 nxv can install this very skill for any major AI coding agent — the binary embeds the SKILL.md and writes it where each agent looks, per the [Agent Skills standard](https://agentskills.io):
 
 ```bash
-nxv skill install                        # Install user-wide for detected agents
-nxv skill install --project              # Install into the current project (.claude + .agents)
+nxv skill install codex                  # Install user-wide for one agent
+nxv skill install --detected             # Explicitly install for detected agents
+nxv skill install codex --project        # Install for Codex in the current project
+nxv skill install --detected --project   # Map detected agents to project paths
 nxv skill install claude codex           # Install for specific agents only
 nxv skill install --all                  # Install for every supported agent
 nxv skill install copilot --dir ~/repo   # Project install into another directory
@@ -329,7 +336,12 @@ The table shows each agent's primary directory — the one `nxv skill install <a
 
 Semantics:
 
-- With no agent arguments, a user-wide install targets the agents detected on the machine (their config dir exists), falling back to the generic `agents` directory if none are found. A project install (`--project` / `--dir`) defaults to the `.claude` + `.agents` pair — per the read paths above, every supported agent picks up one of the two.
+- Installation requires one explicit target mode: one or more agent names,
+  `--detected`, or `--all`. With no target, nxv exits without writing anything.
+- `--detected` checks user configuration directories. With `--project` / `--dir`,
+  those detected agents are mapped to their corresponding project paths. No
+  detected agents is an error; use the explicit `agents` target for the generic
+  Agent Skills directory.
 - Agents sharing a directory (e.g. codex/cursor/gemini at project level) are deduplicated into a single write.
 - Install overwrites `skills/nxv/SKILL.md` unconditionally and never touches other files; uninstall removes only that file (and the `nxv/` directory if it is then empty).
 
@@ -365,7 +377,7 @@ Every recorded commit is a real, Hydra-built channel commit — `nix shell` comm
 
 Retired commands: `nxv backfill` and `nxv reset` are gone — snapshots carry complete metadata (source_path, homepage, known_vulnerabilities), and there is no checkout to reset.
 
-Most users never need these — they consume a pre-built published index via `nxv update`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
+Most users never need these — they consume a pre-built published index via `nxv sync`. Only run these when self-hosting an index. Use `--artifact-name-prefix` for mutable stores such as GitHub Releases so payload assets can be uploaded under immutable names before replacing `manifest.json`.
 
 ## Key Environment Variables
 
@@ -374,11 +386,10 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_API_URL`        | Point CLI at a remote `nxv serve` instead of the local DB              |
 | `NXV_DB_PATH`        | Override local SQLite path                                             |
 | `NXV_API_TIMEOUT`    | HTTP client timeout in seconds (default 30)                            |
-| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv update`                         |
+| `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv sync`                           |
 | `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
 | `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
 | `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
-| `NXV_NO_SELF_UPDATE` | Skip the binary self-update check during `nxv update`                  |
 | `NXV_VERSION`        | Pin the version installed by `install.sh` (self-update targets latest) |
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
@@ -399,7 +410,7 @@ Files:
 - `index.db` — SQLite database with package versions
 - `bloom.bin` — Bloom filter sibling for fast negative lookups (loaded at search time)
 
-Safe to delete; `nxv update` will rebuild from the published manifest.
+Safe to delete; `nxv sync` will rebuild from the published manifest.
 
 ## Agent Patterns
 
@@ -445,7 +456,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Version searches use the closest attribute tier**: nested package-set members do not fill a direct-package miss. Inspect API `meta.resolution` or CLI stderr for suggestions, query the package-set prefix directly, or opt into `--all-depths` / `all_depths=true`.
 - **Bloom filter gives instant negatives**: a search for a nonsense package name returns in <1 ms because the bloom filter rejects it before SQLite is touched. False positives are possible but rare.
 - **Coverage starts in September 2016**: nixpkgs commits before then are not indexed. Anything older needs raw git spelunking.
-- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv update` rejects the signature.
+- **Self-hosted indexes need a public key**: pass `--public-key` or set `NXV_PUBLIC_KEY` when consuming a manifest you signed yourself, otherwise `nxv sync` rejects the signature.
 - **`--format json` shape is stable**: safe to pipe to `jq`. Breaking shape changes would be a semver bump — `license`/`maintainers`/`platforms`/`known_vulnerabilities` changed from stringified JSON to real arrays in a recent release.
 - **Install with `attribute_path`, never `name`**: they differ often (`"name": "python3"` vs `"attribute_path": "python312"`). `name` is the upstream derivation name and is not a valid flake attribute on its own.
 - **`/api/v1` data responses always wrap in `{data, meta}` (or `{data}` for single items)**: do `jq '.data'` first. Exceptions: the operational `/health` and `/metrics` endpoints are unwrapped.
@@ -456,17 +467,18 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 - **Use `--exact`** when one exact attribute is required. Default version searches stay within the shallowest matching tier; use `--all-depths` only when nested variants are intentional.
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
 - **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.
-- **Update regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv update` pulls the latest.
-- **For CI**: pin to `NXV_NO_SELF_UPDATE=1 nxv update` so the runner refreshes the index but never tries to swap its own binary.
+- **Sync regularly**: the public index is republished every 6 hours (`publish-index.yml`); `nxv sync` pulls the latest.
+- **For CI**: run `nxv sync`; it never checks for or replaces the application.
 
 ## Updating This Skill
 
 This skill is generated by the nxv binary itself. To refresh it after upgrading nxv:
 
 ```bash
-nxv update                               # Get the latest nxv (also refreshes the index)
-nxv skill install                        # Rewrite user-wide installs from the new binary
-nxv skill install --project              # ...or refresh a project-level install
+nxv update                               # Get the latest nxv application
+nxv skill install codex                  # Rewrite one user-wide install
+nxv skill install --detected             # ...or explicitly refresh detected agents
+nxv skill install codex --project        # Refresh one project-level install
 ```
 
 Without an nxv binary on hand, fetch the canonical copy from the repository:

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -251,36 +251,25 @@ pub fn cmd_install(cli: &Cli, args: &SkillInstallArgs) -> Result<()> {
 
     let agents: Vec<Agent> = if !args.agents.is_empty() {
         args.agents.clone()
+    } else if args.detected {
+        let home = dirs::home_dir().ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not determine the home directory needed for --detected; name agents explicitly instead"
+            )
+        })?;
+        let detected: Vec<Agent> = AGENTS
+            .iter()
+            .map(|spec| spec.agent)
+            .filter(|agent| *agent != Agent::Agents && agent.is_detected(&home))
+            .collect();
+        if detected.is_empty() {
+            anyhow::bail!("no supported agents were detected; name agents explicitly or use --all");
+        }
+        detected
     } else if args.all {
         AGENTS.iter().map(|s| s.agent).collect()
     } else {
-        match &scope {
-            Scope::User(home) => {
-                let detected: Vec<Agent> = AGENTS
-                    .iter()
-                    .map(|s| s.agent)
-                    .filter(|a| *a != Agent::Agents && a.is_detected(home))
-                    .collect();
-                if detected.is_empty() {
-                    if !cli.quiet {
-                        eprintln!(
-                            "No agents detected; installing to the generic ~/.agents/skills \
-                             directory. Pass agent names or --all to target specific agents."
-                        );
-                    }
-                    vec![Agent::Agents]
-                } else {
-                    detected
-                }
-            }
-            // The pair covers every supported agent at project level: the
-            // table above holds each agent's PRIMARY directory, but Copilot
-            // also reads .claude/skills and .agents/skills in a repository
-            // (docs.github.com "about-agent-skills") and Pi also reads
-            // .agents/skills (pi-mono docs/skills.md); everything else
-            // already points at .claude or .agents.
-            Scope::Project(_) => vec![Agent::Claude, Agent::Agents],
-        }
+        anyhow::bail!("name at least one agent, or pass --detected or --all");
     };
 
     let targets = dedupe_targets(&scope, &agents);

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -263,7 +263,9 @@ pub fn cmd_install(cli: &Cli, args: &SkillInstallArgs) -> Result<()> {
             .filter(|agent| *agent != Agent::Agents && agent.is_detected(&home))
             .collect();
         if detected.is_empty() {
-            anyhow::bail!("no supported agents were detected; name agents explicitly or use --all");
+            anyhow::bail!(
+                "no supported agents were detected; name agents explicitly, use `agents` for the generic Agent Skills directory, or use --all"
+            );
         }
         detected
     } else if args.all {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2750,7 +2750,7 @@ fn test_temp_files_cleaned_up_on_failure() {
 /// 3. Apply delta sync
 /// 4. Verify search returns both old and new packages
 #[test]
-fn test_full_delta_update_workflow() {
+fn test_full_delta_sync_workflow() {
     use sha2::{Digest, Sha256};
 
     let dir = tempdir().unwrap();
@@ -4057,6 +4057,9 @@ fn test_skill_install_detected_with_no_agents_fails_without_writes() {
         .failure()
         .stderr(predicate::str::contains(
             "no supported agents were detected",
+        ))
+        .stderr(predicate::str::contains(
+            "use `agents` for the generic Agent Skills directory",
         ));
     assert!(!home.path().join(".agents").exists());
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -126,6 +126,7 @@ fn test_help_displays() {
         .stdout(predicate::str::contains("Nix Version Index"))
         .stdout(predicate::str::contains("search"))
         .stdout(predicate::str::contains("update"))
+        .stdout(predicate::str::contains("sync"))
         .stdout(predicate::str::contains("info"))
         .stdout(predicate::str::contains("stats"))
         .stdout(predicate::str::contains("history"))
@@ -133,15 +134,76 @@ fn test_help_displays() {
 }
 
 #[test]
-fn test_update_help_mentions_self_update() {
-    // `nxv update` is one command: it refreshes the index and then checks for
-    // a newer binary. Verify the help surface exposes the opt-out flag.
+fn test_update_help_is_application_only() {
     nxv()
         .args(["update", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--no-self-update"))
-        .stdout(predicate::str::contains("--force"));
+        .stdout(predicate::str::contains("latest application release"))
+        .stdout(predicate::str::contains("nxv sync"))
+        .stdout(predicate::str::contains("--force").not());
+}
+
+#[test]
+fn test_sync_help_owns_index_options() {
+    nxv()
+        .args(["sync", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("package index"))
+        .stdout(predicate::str::contains("--force"))
+        .stdout(predicate::str::contains("--manifest-url"))
+        .stdout(predicate::str::contains("--skip-verify"))
+        .stdout(predicate::str::contains("--public-key"));
+}
+
+#[test]
+fn test_update_rejects_legacy_index_flags_with_sync_guidance() {
+    nxv()
+        .args(["update", "--force"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("nxv sync"));
+}
+
+#[test]
+fn test_update_rejects_retired_no_self_update_environment() {
+    nxv()
+        .arg("update")
+        .env("NXV_NO_SELF_UPDATE", "1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("NXV_NO_SELF_UPDATE is retired"))
+        .stderr(predicate::str::contains("nxv sync"));
+}
+
+#[test]
+fn test_update_checks_application_release_without_touching_index() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("index.db");
+    std::fs::write(&db_path, b"index sentinel").unwrap();
+
+    let mut server = mockito::Server::new();
+    let release = serde_json::json!({
+        "tag_name": format!("v{}", env!("CARGO_PKG_VERSION")),
+        "assets": []
+    });
+    let _release_mock = server
+        .mock("GET", "/repos/utensils/nxv/releases/latest")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(release.to_string())
+        .create();
+
+    nxv()
+        .args(["--db-path", db_path.to_str().unwrap(), "update"])
+        .env("NXV_GITHUB_API_BASE", server.url())
+        .env("NXV_NO_SELF_UPDATE", "0")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Already up to date"));
+
+    assert_eq!(std::fs::read(&db_path).unwrap(), b"index sentinel");
 }
 
 #[test]
@@ -1148,16 +1210,16 @@ fn test_verbose_debug_level() {
 // ============================================================================
 
 #[test]
-fn test_search_no_index_suggests_update() {
+fn test_search_no_index_suggests_sync() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("nonexistent.db");
 
-    // When there's no index, suggest running 'nxv update'
+    // When there's no index, suggest running 'nxv sync'.
     nxv()
         .args(["--db-path", db_path.to_str().unwrap(), "search", "python"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("nxv update"));
+        .stderr(predicate::str::contains("nxv sync"));
 }
 
 #[test]
@@ -1189,7 +1251,7 @@ fn test_error_messages_have_error_prefix() {
         .args(["--db-path", db_path.to_str().unwrap(), "search", "python"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error:").and(predicate::str::contains("nxv update")));
+        .stderr(predicate::str::contains("error:").and(predicate::str::contains("nxv sync")));
 }
 
 #[test]
@@ -1209,7 +1271,7 @@ fn test_error_messages_no_color() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("error:").and(predicate::str::contains("nxv update")));
+        .stderr(predicate::str::contains("error:").and(predicate::str::contains("nxv sync")));
 }
 
 // ============================================================================
@@ -1697,7 +1759,7 @@ fn create_test_bloom_filter() -> (Vec<u8>, String) {
 }
 
 #[test]
-fn test_update_with_mock_http_server() {
+fn test_sync_with_mock_http_server() {
     // Create test artifacts
     let (compressed_db, db_hash) = create_compressed_test_db();
     let (bloom_data, bloom_hash) = create_test_bloom_filter();
@@ -1745,6 +1807,12 @@ fn test_update_with_mock_http_server() {
         .with_body(bloom_data)
         .create();
 
+    let _release_mock = server
+        .mock("GET", "/repos/utensils/nxv/releases/latest")
+        .with_status(500)
+        .expect(0)
+        .create();
+
     // Create temp directory for test database
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("index.db");
@@ -1753,17 +1821,19 @@ fn test_update_with_mock_http_server() {
     // Set environment variable for manifest URL
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command
+    // Run sync command
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
         ])
         .env("NXV_BLOOM_PATH", bloom_path.to_str().unwrap())
+        .env("NXV_GITHUB_API_BASE", server.url())
+        .env("NXV_API_URL", "http://127.0.0.1:1")
         .assert()
         .success()
         .stderr(predicate::str::contains("Downloading").or(predicate::str::contains("up to date")));
@@ -1794,7 +1864,7 @@ fn test_update_with_mock_http_server() {
 }
 
 #[test]
-fn test_update_already_up_to_date() {
+fn test_sync_already_up_to_date() {
     // Create test artifacts
     let (compressed_db, db_hash) = create_compressed_test_db();
     let (bloom_data, bloom_hash) = create_test_bloom_filter();
@@ -1849,12 +1919,12 @@ fn test_update_already_up_to_date() {
     // Set environment variable for manifest URL
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command - should report up to date
+    // Run sync command - should report up to date
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -1865,7 +1935,7 @@ fn test_update_already_up_to_date() {
 }
 
 #[test]
-fn test_update_delta_available() {
+fn test_sync_delta_available() {
     use sha2::{Digest, Sha256};
 
     // Create test artifacts
@@ -1989,12 +2059,12 @@ COMMIT;
     // Set environment variable for manifest URL
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command - should apply delta
+    // Run sync command - should apply delta
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2035,7 +2105,7 @@ COMMIT;
 }
 
 #[test]
-fn test_update_network_error_handling() {
+fn test_sync_network_error_handling() {
     // Start mock server that returns errors
     let mut server = mockito::Server::new();
 
@@ -2051,12 +2121,12 @@ fn test_update_network_error_handling() {
 
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command - should fail gracefully
+    // Run sync command - should fail gracefully
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2067,7 +2137,7 @@ fn test_update_network_error_handling() {
 }
 
 #[test]
-fn test_update_checksum_mismatch() {
+fn test_sync_checksum_mismatch() {
     // Create test artifacts with wrong hash
     let (compressed_db, _) = create_compressed_test_db();
     let (bloom_data, bloom_hash) = create_test_bloom_filter();
@@ -2114,12 +2184,12 @@ fn test_update_checksum_mismatch() {
 
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command - should fail due to checksum mismatch
+    // Run sync command - should fail due to checksum mismatch
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2134,7 +2204,7 @@ fn test_update_checksum_mismatch() {
 }
 
 #[test]
-fn test_update_unreachable_server() {
+fn test_sync_unreachable_server() {
     // Use a URL that points to a non-existent/unreachable host
     // Using localhost with a port that's unlikely to be in use
     let manifest_url = "http://127.0.0.1:59999/manifest.json";
@@ -2143,12 +2213,12 @@ fn test_update_unreachable_server() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("index.db");
 
-    // Run update command - should fail gracefully with network error
+    // Run sync command - should fail gracefully with network error
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             manifest_url,
@@ -2158,14 +2228,63 @@ fn test_update_unreachable_server() {
         .stderr(predicate::str::contains("error"));
 }
 
+#[test]
+fn test_sync_incompatible_index_guides_app_update_without_calling_release_api() {
+    let mut server = mockito::Server::new();
+    let manifest = serde_json::json!({
+        "version": 1,
+        "min_version": 999,
+        "latest_commit": "abc123",
+        "latest_commit_date": "2024-01-15T12:00:00Z",
+        "full_index": {
+            "url": format!("{}/index.db.zst", server.url()),
+            "size_bytes": 1,
+            "sha256": "00"
+        },
+        "bloom_filter": {
+            "url": format!("{}/index.bloom", server.url()),
+            "size_bytes": 1,
+            "sha256": "00"
+        },
+        "deltas": []
+    });
+    let _manifest_mock = server
+        .mock("GET", "/manifest.json")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(manifest.to_string())
+        .create();
+    let _release_mock = server
+        .mock("GET", "/repos/utensils/nxv/releases/latest")
+        .with_status(500)
+        .expect(0)
+        .create();
+
+    let dir = tempdir().unwrap();
+    nxv()
+        .args([
+            "--db-path",
+            dir.path().join("index.db").to_str().unwrap(),
+            "sync",
+            "--skip-verify",
+            "--manifest-url",
+            &format!("{}/manifest.json", server.url()),
+        ])
+        .env("NXV_GITHUB_API_BASE", server.url())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Run `nxv update`"))
+        .stderr(predicate::str::contains("retry `nxv sync`"));
+}
+
 // ============================================================================
 // Signature Verification Tests
 // ============================================================================
 
 #[test]
-fn test_update_fails_without_signature_when_verify_enabled() {
+fn test_sync_fails_without_signature_when_verify_enabled() {
     // This test verifies that manifest signature verification is enforced by default.
-    // When no signature file is available, the update should fail unless --skip-verify is used.
+    // When no signature file is available, sync should fail unless --skip-verify is used.
 
     // Create test artifacts
     let (compressed_db, db_hash) = create_compressed_test_db();
@@ -2216,13 +2335,13 @@ fn test_update_fails_without_signature_when_verify_enabled() {
     let db_path = dir.path().join("index.db");
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Update should FAIL because signature verification is enabled by default
+    // Sync should FAIL because signature verification is enabled by default
     // and no signature is available
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--manifest-url",
             &manifest_url,
         ])
@@ -2241,7 +2360,7 @@ fn test_update_fails_without_signature_when_verify_enabled() {
 }
 
 #[test]
-fn test_update_skip_verify_shows_warning() {
+fn test_sync_skip_verify_shows_warning() {
     // This test verifies that --skip-verify allows updates but shows a warning
 
     // Create test artifacts
@@ -2307,7 +2426,7 @@ fn test_update_skip_verify_shows_warning() {
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2377,7 +2496,7 @@ fn test_clear_error_message_no_index() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("No index found"))
-        .stderr(predicate::str::contains("nxv update"));
+        .stderr(predicate::str::contains("nxv sync"));
 }
 
 #[test]
@@ -2418,7 +2537,7 @@ fn test_clear_error_message_invalid_manifest_version() {
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2524,12 +2643,12 @@ fn test_no_data_corruption_on_failed_download() {
 
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command - should fail
+    // Run sync command - should fail
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2598,12 +2717,12 @@ fn test_temp_files_cleaned_up_on_failure() {
 
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run update command - should fail
+    // Run sync command - should fail
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2625,10 +2744,10 @@ fn test_temp_files_cleaned_up_on_failure() {
     );
 }
 
-/// Full delta update workflow test:
+/// Full delta sync workflow test:
 /// 1. Initial download creates index with initial packages
 /// 2. New delta becomes available with new packages
-/// 3. Apply delta update
+/// 3. Apply delta sync
 /// 4. Verify search returns both old and new packages
 #[test]
 fn test_full_delta_update_workflow() {
@@ -2742,13 +2861,13 @@ fn test_full_delta_update_workflow() {
 
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Run initial update
+    // Run initial sync
     nxv()
         .env("NXV_BLOOM_PATH", bloom_path.to_str().unwrap())
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -2773,7 +2892,7 @@ fn test_full_delta_update_workflow() {
         .success()
         .stderr(predicate::str::contains("not found").or(predicate::str::contains("No packages")));
 
-    // --- PHASE 2: Delta update ---
+    // --- PHASE 2: Delta sync ---
 
     // Create delta SQL that adds nodejs
     let delta_sql = r#"
@@ -2853,13 +2972,13 @@ UPDATE meta SET value = 'delta789012345678901234567890abcdef12' WHERE key = 'las
         .with_body(updated_bloom_data)
         .create();
 
-    // Run delta update
+    // Run delta sync
     nxv()
         .env("NXV_BLOOM_PATH", bloom_path.to_str().unwrap())
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--skip-verify",
             "--manifest-url",
             &manifest_url,
@@ -3808,12 +3927,12 @@ fn test_end_to_end_signed_manifest_verification() {
 
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Step 5: Update using the public key - this should SUCCEED
+    // Step 5: Sync using the public key - this should SUCCEED
     nxv()
         .args([
             "--db-path",
             client_db_path.to_str().unwrap(),
-            "update",
+            "sync",
             "--manifest-url",
             &manifest_url,
             "--public-key",
@@ -3826,7 +3945,7 @@ fn test_end_to_end_signed_manifest_verification() {
     // Verify the database was created
     assert!(
         client_db_path.exists(),
-        "Database should be created after successful signed update"
+        "Database should be created after successful signed sync"
     );
 
     // Step 6: Try with WRONG public key - this should FAIL
@@ -3850,7 +3969,7 @@ fn test_end_to_end_signed_manifest_verification() {
         .args([
             "--db-path",
             client_db_path2.to_str().unwrap(),
-            "update",
+            "sync",
             "--manifest-url",
             &manifest_url,
             "--public-key",
@@ -3912,12 +4031,12 @@ fn test_skill_install_user_scope_explicit_agent() {
 
 #[cfg(unix)]
 #[test]
-fn test_skill_install_defaults_to_detected_agents() {
+fn test_skill_install_detected_agents_requires_explicit_flag() {
     let home = tempdir().unwrap();
     std::fs::create_dir(home.path().join(".codex")).unwrap();
     nxv()
         .env("HOME", home.path())
-        .args(["skill", "install"])
+        .args(["skill", "install", "--detected"])
         .assert()
         .success()
         .stderr(predicate::str::contains(".codex"));
@@ -3929,26 +4048,71 @@ fn test_skill_install_defaults_to_detected_agents() {
 
 #[cfg(unix)]
 #[test]
-fn test_skill_install_falls_back_to_generic_agents_dir() {
+fn test_skill_install_detected_with_no_agents_fails_without_writes() {
     let home = tempdir().unwrap();
     nxv()
         .env("HOME", home.path())
-        .args(["skill", "install"])
+        .args(["skill", "install", "--detected"])
         .assert()
-        .success()
-        .stderr(predicate::str::contains("No agents detected"));
-    assert!(home.path().join(".agents/skills/nxv/SKILL.md").exists());
+        .failure()
+        .stderr(predicate::str::contains(
+            "no supported agents were detected",
+        ));
+    assert!(!home.path().join(".agents").exists());
 }
 
 #[test]
-fn test_skill_install_project_default_pair() {
+fn test_skill_install_project_without_target_fails_without_writes() {
     let proj = tempdir().unwrap();
     nxv()
         .args(["skill", "install", "--dir", proj.path().to_str().unwrap()])
         .assert()
+        .failure()
+        .stderr(predicate::str::contains("required"));
+    assert!(!proj.path().join(".claude").exists());
+    assert!(!proj.path().join(".agents").exists());
+}
+
+#[test]
+fn test_skill_install_project_all_is_explicitly_broad() {
+    let proj = tempdir().unwrap();
+    nxv()
+        .args([
+            "skill",
+            "install",
+            "--all",
+            "--dir",
+            proj.path().to_str().unwrap(),
+        ])
+        .assert()
         .success();
     assert!(proj.path().join(".claude/skills/nxv/SKILL.md").exists());
     assert!(proj.path().join(".agents/skills/nxv/SKILL.md").exists());
+    assert!(proj.path().join(".pi/skills/nxv/SKILL.md").exists());
+    assert!(proj.path().join(".github/skills/nxv/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn test_skill_install_project_detected_maps_only_detected_agents() {
+    let home = tempdir().unwrap();
+    let proj = tempdir().unwrap();
+    std::fs::create_dir(home.path().join(".codex")).unwrap();
+    nxv()
+        .env("HOME", home.path())
+        .args([
+            "skill",
+            "install",
+            "--detected",
+            "--dir",
+            proj.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("codex"));
+    assert!(proj.path().join(".agents/skills/nxv/SKILL.md").exists());
+    assert!(!proj.path().join(".claude").exists());
+    assert!(!proj.path().join(".github").exists());
 }
 
 #[test]
@@ -4014,7 +4178,7 @@ fn test_skill_uninstall_removes_only_nxv() {
     let dir_arg = proj.path().to_str().unwrap();
 
     nxv()
-        .args(["skill", "install", "--dir", dir_arg])
+        .args(["skill", "install", "--all", "--dir", dir_arg])
         .assert()
         .success();
 

--- a/website/advanced/indexer-cli.md
+++ b/website/advanced/indexer-cli.md
@@ -6,7 +6,7 @@ available when nxv is built with the `indexer` feature.
 ::: warning Feature-Gated
 
 These commands require `nxv-indexer` or building with `--features indexer`. Most
-users should use `nxv update` to download the pre-built index instead.
+users should use `nxv sync` to download the pre-built index instead.
 
 :::
 

--- a/website/advanced/indexer.md
+++ b/website/advanced/indexer.md
@@ -9,7 +9,7 @@ snapshots. This is an advanced topic for users who want to:
 
 ::: tip Most Users
 
-If you just want to use nxv, run `nxv update` to download the pre-built index. A
+If you just want to use nxv, run `nxv sync` to download the pre-built index. A
 full rebuild from scratch streams ~15 GB of snapshots and takes a few hours.
 
 :::
@@ -173,7 +173,7 @@ Users can then configure their nxv to use your index:
 ```bash
 export NXV_MANIFEST_URL="https://example.com/nxv/manifest.json"
 export NXV_PUBLIC_KEY="RWTxxxxxxxx..."
-nxv update
+nxv sync
 ```
 
 ## Architecture Deep Dive
@@ -316,7 +316,7 @@ If the database becomes corrupted after a crash:
 rm ~/.local/share/nxv/index.db  # Linux
 rm ~/Library/Application\ Support/nxv/index.db  # macOS
 
-# Re-run indexing (or `nxv update` to re-download the pre-built index)
+# Re-run indexing (or `nxv sync` to re-download the pre-built index)
 nxv index
 ```
 

--- a/website/advanced/troubleshooting.md
+++ b/website/advanced/troubleshooting.md
@@ -25,9 +25,9 @@ Common issues and solutions when using nxv.
    nxv search "image editor" --desc
    ```
 
-4. **Update index**: Your index might be outdated
+4. **Sync index**: Your index might be outdated
    ```bash
-   nxv update
+   nxv sync
    ```
 
 ### Search is slow
@@ -38,18 +38,18 @@ searches are fast. If searches remain slow:
 1. Check disk I/O (SSD recommended)
 2. Check `NXV_DB_PATH` isn't on a network drive
 
-## Update Issues
+## Sync Issues
 
 ### Download fails
 
 1. **Check network**: Ensure GitHub is accessible
 2. **Retry**: Transient failures are common
    ```bash
-   nxv update
+   nxv sync
    ```
 3. **Force full download**: Skip delta updates
    ```bash
-   nxv update --force
+   nxv sync --force
    ```
 
 ### Signature verification failed
@@ -57,7 +57,7 @@ searches are fast. If searches remain slow:
 1. **Check clock**: Signature validation requires accurate time
 2. **Skip verification** (not recommended for production):
    ```bash
-   NXV_SKIP_VERIFY=1 nxv update
+   NXV_SKIP_VERIFY=1 nxv sync
    ```
 
 ### Incompatible index
@@ -66,17 +66,13 @@ searches are fast. If searches remain slow:
 Incompatible index: index requires schema version N but this build only supports up to M
 ```
 
-This means your nxv binary is too old for the published index. `nxv update`
-handles it automatically: on this error it runs the binary self-update check
-before exiting.
+This means your nxv application is too old for the published index. `nxv sync`
+stops without modifying either the existing index or the application.
 
-- **Local installs** (install.sh, manual download): the binary is replaced in
-  place after SHA-256 verification — re-run `nxv update` to fetch the index.
+- **Local installs** (install.sh, manual download): run `nxv update` to replace
+  the binary after SHA-256 verification, then re-run `nxv sync`.
 - **Managed installs** (Nix, cargo, Homebrew): the matching upgrade command is
-  printed instead; run it, then re-run `nxv update`.
-
-Pass `--no-self-update` (or set `NXV_NO_SELF_UPDATE`) to skip the binary check
-if updates are managed externally.
+  printed by `nxv update`; run it, then re-run `nxv sync`.
 
 ### Disk full
 

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -143,25 +143,12 @@ nxv history python311
 
 ### update
 
-Refresh the package index, then check for a newer nxv binary and update it (or
-print a hint for managed installs).
+Update the nxv application to the latest release. This command never downloads
+or modifies the package index.
 
 ```bash
-nxv update [options]
+nxv update
 ```
-
-**Options:**
-
-| Flag                 | Description                                               |
-| -------------------- | --------------------------------------------------------- |
-| `-f, --force`        | Force full re-download of the index                       |
-| `--skip-verify`      | Skip manifest signature verification                      |
-| `--public-key <KEY>` | Custom public key for verification                        |
-| `--no-self-update`   | Skip the binary self-update check; only refresh the index |
-
-`--no-self-update` also honours the `NXV_NO_SELF_UPDATE` environment variable,
-which is useful for CI or systemd timer units that should only refresh the
-index.
 
 **Binary-update behaviour by install method:**
 
@@ -174,22 +161,40 @@ index.
 
 Set `GITHUB_TOKEN` to avoid unauthenticated rate limits when calling the GitHub
 API. If GitHub rejects the token (401 — e.g. a stale token exported by a dev
-shell), the check is retried without it. If the binary check fails (e.g.,
-network or rate limit), `nxv update` prints a warning but still reports the
-index update as successful.
+shell), the check is retried without it. Release lookup, download, verification,
+or replacement failures cause the command to fail.
 
-**Examples:**
+Legacy index flags are rejected with guidance to use `nxv sync`. The retired
+`NXV_NO_SELF_UPDATE` variable is likewise rejected when truthy so an old
+configuration cannot unexpectedly replace the application.
+
+### sync
+
+Download or refresh the local package index without checking for application
+updates.
 
 ```bash
-# Refresh the index and update the binary (or print an upgrade hint)
-nxv update
-
-# Just refresh the index — don't touch the binary
-nxv update --no-self-update
-
-# Force full re-download of the index
-nxv update --force
+nxv sync [options]
 ```
+
+**Options:**
+
+| Flag                   | Description                          |
+| ---------------------- | ------------------------------------ |
+| `-f, --force`          | Force full re-download of the index  |
+| `--manifest-url <URL>` | Custom or self-hosted index manifest |
+| `--skip-verify`        | Skip manifest signature verification |
+| `--public-key <KEY>`   | Custom public key for verification   |
+
+```bash
+nxv sync
+nxv sync --force
+nxv sync --manifest-url https://example.com/manifest.json --public-key ./nxv.pub
+```
+
+`sync` is safe for CI and timers because it never updates the application. If
+the published index requires a newer nxv schema, run `nxv update` (or the
+printed managed-install command) and retry `nxv sync`.
 
 ### serve
 
@@ -375,6 +380,7 @@ agents (the generic cross-agent `.agents/skills` directory)
 | -------------- | --------------------------------------------------------- |
 | `--project`    | Use project-level skill directories under the current dir |
 | `--dir <PATH>` | Project directory to operate on (implies `--project`)     |
+| `--detected`   | Install for agents detected from user configuration       |
 | `--all`        | Install for all supported agents (install only)           |
 
 **List options:**
@@ -386,18 +392,21 @@ agents (the generic cross-agent `.agents/skills` directory)
 **Examples:**
 
 ```bash
-# Install user-wide for every agent detected on this machine
-nxv skill install
+# Install user-wide for one agent
+nxv skill install codex
 
-# Install into the current project (.claude/skills + .agents/skills)
-nxv skill install --project
+# Explicitly install for detected agents
+nxv skill install --detected
 
-# Install for specific agents
-nxv skill install claude codex
+# Map detected agents to their project paths
+nxv skill install --detected --project
 
 # See where the skill is (or would be) installed
 nxv skill list
 ```
+
+Install requires agent names, `--detected`, or `--all`; supplying no target is
+an error and writes nothing. Shared project paths are deduplicated.
 
 ## Output Formats
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -24,16 +24,14 @@ the index.
 
 ### Index Updates
 
-| Variable             | Description                                       | Default         |
-| -------------------- | ------------------------------------------------- | --------------- |
-| `NXV_MANIFEST_URL`   | Custom manifest URL for index downloads           | GitHub releases |
-| `NXV_PUBLIC_KEY`     | Custom public key for manifest verification       | Built-in key    |
-| `NXV_SKIP_VERIFY`    | Skip manifest signature verification              | `false`         |
-| `NXV_NO_SELF_UPDATE` | Skip the binary self-update check in `nxv update` | Not set         |
+| Variable           | Description                                 | Default         |
+| ------------------ | ------------------------------------------- | --------------- |
+| `NXV_MANIFEST_URL` | Custom manifest URL for index downloads     | GitHub releases |
+| `NXV_PUBLIC_KEY`   | Custom public key for manifest verification | Built-in key    |
+| `NXV_SKIP_VERIFY`  | Skip manifest signature verification        | `false`         |
 
-By default, `nxv update` checks GitHub for a newer nxv release after refreshing
-the index. Set `NXV_NO_SELF_UPDATE` (or pass `--no-self-update`) to only refresh
-the index.
+These index variables apply to `nxv sync`. `nxv update` only updates the
+application and does not read index configuration.
 
 ### Server
 
@@ -95,5 +93,5 @@ nxv search python --version 3.11
 
 ```bash
 export NXV_DB_PATH="/data/nxv/index.db"
-nxv update
+nxv sync
 ```

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -26,8 +26,8 @@ nix run github:utensils/nxv -- search python
 # One-liner install (downloads static binary)
 curl -fsSL https://raw.githubusercontent.com/utensils/nxv/main/install.sh | sh
 
-# Update the package index (downloads ~220MB)
-nxv update
+# Download the package index (downloads ~220MB)
+nxv sync
 
 # Search for a package
 nxv search python

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -127,7 +127,7 @@ cargo build --release
 After installation, download the package index:
 
 ```bash
-nxv update
+nxv sync
 ```
 
 This downloads ~220MB of compressed data to your local data directory:
@@ -135,11 +135,10 @@ This downloads ~220MB of compressed data to your local data directory:
 - **Linux**: `~/.local/share/nxv/`
 - **macOS**: `~/Library/Application Support/nxv/`
 
-The index is republished every 6 hours. Run `nxv update` periodically to get the
+The index is republished every 6 hours. Run `nxv sync` periodically to get the
 latest packages.
 
-After refreshing the index, `nxv update` also checks GitHub for a newer nxv
-release. Local installs (install.sh, manual download) are upgraded in place
-after SHA-256 verification; managed installs (Nix, cargo, Homebrew) just get the
-matching upgrade command printed. Pass `--no-self-update` to skip the binary
-check.
+Run `nxv update` separately to update the application. Local installs
+(install.sh, manual download) are upgraded in place after SHA-256 verification;
+managed installs (Nix, cargo, Homebrew) receive the matching upgrade command.
+Neither command implicitly runs the other.

--- a/website/guide/skill.md
+++ b/website/guide/skill.md
@@ -21,12 +21,14 @@ The `nxv skill` subcommand generates and installs the skill from a single
 embedded template:
 
 ```bash
-# Install user-wide for every agent detected on this machine
-nxv skill install
+# Install user-wide for one agent
+nxv skill install codex
 
-# Install into the current project (.claude/skills + .agents/skills,
-# which every supported agent reads at project level)
-nxv skill install --project
+# Explicitly install for agents detected on this machine
+nxv skill install --detected
+
+# Map detected agents to their project-level paths
+nxv skill install --detected --project
 
 # Install for specific agents only
 nxv skill install claude codex
@@ -38,8 +40,11 @@ nxv skill install --all
 nxv skill list
 ```
 
-A user-wide install (the default) targets agents whose config directory exists
-under your home directory. Per agent, the skill lands in
+Installation requires one explicit target mode: agent names, `--detected`, or
+`--all`. Supplying no target is an error and writes nothing. `--detected` checks
+agent configuration under your home directory; with `--project` or `--dir`,
+those agents are mapped to their project-level paths. No detected agents is an
+error rather than an implicit generic install. Per agent, the skill lands in
 `<skills dir>/nxv/SKILL.md`:
 
 | Agent      | User-wide                 | Project-level     |
@@ -56,15 +61,13 @@ under your home directory. Per agent, the skill lands in
 | `agents`   | `~/.agents/skills/`       | `.agents/skills/` |
 
 The `agents` target is the generic cross-agent directory from the Agent Skills
-standard — most tools read it, so it also serves as the fallback when no agents
-are detected.
+standard. Select it explicitly with `nxv skill install agents`.
 
 The table shows each agent's primary directory — the one
 `nxv skill install <agent>` writes to. Several agents read additional locations:
 Copilot reads `.github/skills/`, `.claude/skills/`, or `.agents/skills/` in a
-repository, and Pi reads `.agents/skills/` as well as `.pi/skills/`. That is why
-the default project install writes only the `.claude` + `.agents` pair: every
-supported agent picks up one of the two.
+repository, and Pi reads `.agents/skills/` as well as `.pi/skills/`. Agents that
+share a selected project path are deduplicated into one write.
 
 To remove installed skills:
 
@@ -151,8 +154,9 @@ The installed skill is byte-identical to the template embedded in your nxv
 binary, so refreshing it is just upgrading nxv and reinstalling:
 
 ```bash
-nxv update           # Get the latest nxv (also refreshes the index)
-nxv skill install    # Rewrite the installed skills from the new binary
+nxv update                  # Get the latest nxv application
+nxv skill install codex     # Rewrite one explicit installation
+nxv skill install --detected # Or explicitly refresh detected agents
 ```
 
 ## Skill source


### PR DESCRIPTION
## Summary

- make `nxv update` exclusively update the nxv application to the latest release
- add `nxv sync` as the dedicated local index download and refresh command
- require `nxv skill install` callers to select agent names, `--detected`, or `--all`
- synchronize CLI help, runtime errors, API-facing guidance, installer output, documentation, and generated skill templates

## Why

`nxv update` previously combined two unrelated operations: refreshing the package database and checking for a newer application release. That made automation and failure handling ambiguous. Skill installation also defaulted to a broad set of destinations, which could modify more agent configuration than users intended.

The new command model separates those responsibilities and makes skill installation scope explicit.

## User impact

This is a breaking CLI change:

- use `nxv update` to update the application
- use `nxv sync` to download or refresh the package index
- old index-related `nxv update` flags are rejected with migration guidance
- truthy `NXV_NO_SELF_UPDATE` values are rejected because the variable is retired
- use `nxv skill install <agents>`, `nxv skill install --detected`, or `nxv skill install --all`

First-run index setup now invokes the sync path directly and cannot replace the application as a side effect. An incompatible index directs users to update the application and then retry sync, without making a release API request from `nxv sync`.

The REST response shapes and routes are unchanged. Server-side missing-index guidance and the embedded agent skill documentation now use the new command contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features indexer -- -D warnings`
- `cargo test --features indexer` (406 unit tests and 103 integration tests passed)
- VitePress production build
- generated skill-template parity checks
- `git diff --check`
- `nix flake check` passed before the rebase; post-rebase conflicts were documentation-only
