### PR TITLE
chore(release): carry breaking-change details into the changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,3 +20,39 @@ features_always_increment_minor = true
 # nxv is a CLI; the library target is an implementation detail, not a semver
 # contract worth a cargo-semver-checks baseline build on every release PR.
 semver_check = false
+
+[changelog]
+trim = true
+
+# Squash merges put each branch commit in the body as a "* type: subject"
+# bullet; strip those so breaking-change bodies render as clean prose.
+# Setting commit_preprocessors REPLACES release-plz's defaults, so the
+# default PR-link processor must be re-declared (second entry).
+commit_preprocessors = [
+  { pattern = '(?m)^\* (?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\([^)]*\))?!?: .*\n?', replace = "" },
+  { pattern = '\(#([0-9]+)\)', replace = "([#${1}](https://github.com/utensils/nxv/pull/${1}))" },
+]
+
+# release-plz's default body template, extended so breaking commits carry
+# their details into the changelog: the BREAKING CHANGE footer when one
+# exists, otherwise the commit body — rendered as an indented continuation
+# of the list item. The default template drops both (v0.5.0's #56 lost its
+# migration note that way).
+body = """
+## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+
+{% for commit in commits %}
+{%- if commit.scope -%}
+- *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+{% else -%}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+{% endif -%}
+{%- if commit.breaking and commit.breaking_description and commit.breaking_description != commit.message -%}
+{{ "  " }}{{ commit.breaking_description | trim | indent(prefix="  ") }}
+{% elif commit.breaking and commit.body -%}
+{{ "  " }}{{ commit.body | trim | indent(prefix="  ") }}
+{% endif -%}
+{% endfor -%}
+{% endfor %}"""


### PR DESCRIPTION
## Summary

- add a `[changelog]` section to `release-plz.toml` extending the default body template: breaking commits now render their `BREAKING CHANGE:` footer (or commit body as fallback) as an indented continuation of the changelog entry
- strip GitHub squash-merge `* type: subject` bullet lines from commit bodies via `commit_preprocessors` so the rendered details are clean prose
- re-declare the default PR-link preprocessor, since setting `commit_preprocessors` replaces release-plz's defaults instead of extending them

## Why

The default release-plz template renders only commit headlines. Both recent breaking changes lost their user-facing details:

- v0.5.0's #56 had a full `BREAKING CHANGE:` footer (JSON-array migration note) that never reached the changelog
- v0.6.0's #67 (current release PR #68) is reduced to a single line with no migration guidance

## Validation

Rendered with git-cliff 2.13.1 (the engine release-plz embeds) using a config replicating release-plz's defaults plus this template:

- v0.4.3..v0.4.4 (no breaking commits): output identical to the existing changelog section
- v0.4.4..v0.5.0: #56's breaking footer renders indented under its entry
- unreleased (v0.6.0): #67's body renders under its entry, squash bullets stripped

Merging this to main re-triggers the release-plz workflow, which force-pushes release PR #68 with the regenerated changelog.