### PR TITLE
chore(repo): remove the vestigial nixpkgs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "nixpkgs"]
-	path = nixpkgs
-	url = https://github.com/NixOS/nixpkgs.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/utensils/nxv"
 keywords = ["nix", "nixpkgs", "package", "version"]
 categories = ["command-line-utilities"]
 exclude = [
-    "nixpkgs/",
     "publish/",
     "docs/",
     ".github/",


### PR DESCRIPTION
The snapshot-based indexer ingests channel releases from
releases.nixos.org and never reads a nixpkgs checkout; the 308 MB
submodule was a relic of the retired git-walking design. Nothing in the
code, tests, CI, or flake references it — only the Cargo package
exclude, removed alongside.
