### PR TITLE
feat(cli): add run shell helper

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -16,6 +16,8 @@ nxv search python                        # All python packages (most recent per 
 nxv search python 2.7                    # Filter by version (prefix match)
 nxv search python --exact                # Exact attribute name only
 nxv search "json parser" --desc          # Full-text search package descriptions
+nxv run python 2.7                       # Resolve and open a pinned shell
+nxv run python 3.11 --with nodejs@20     # Multi-package shell
 nxv info python311                       # Detailed info for current version
 nxv info python311 3.11.4                # Detailed info for specific version
 nxv history python311                    # Version timeline (first/last seen)
@@ -35,7 +37,7 @@ nxv skill list                           # Agents, skill paths, install status
 
 Parse `$ARGUMENTS` to determine the action:
 
-- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
+- If arguments look like a **subcommand** (`search`, `run`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
 - If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
 - If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
 - If no arguments, run `nxv stats` to give the user a quick health check of their index.
@@ -201,7 +203,22 @@ Note the field names differ from search (`first_seen`/`last_seen`, not `first_co
 
 ## Using a Found Version
 
-The whole point. Take a `first_commit_hash` (or `last_commit_hash`) from search/history output and feed it to Nix:
+The quickest interactive path is `nxv run`, which resolves the same package and
+version query as `search` and opens one pinned shell:
+
+```bash
+nxv run python 2.7
+nxv run python 3.11 --with nodejs@20 --with jq
+```
+
+Additional `--with` values use `PACKAGE@VERSION` when a version is needed.
+nxv resolves every query before launch, chooses the first deterministic
+relevance-ranked match, and uses each result's latest observed commit. Modern
+revisions are combined in one `nix shell`; if any result predates flakes, nxv
+uses one compatible `nix-shell -p` environment instead.
+
+For manual command construction, take a `first_commit_hash` (or
+`last_commit_hash`) from search/history output and feed it to Nix:
 
 ```bash
 # Drop into a shell with that exact version
@@ -490,7 +507,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 
 ## Practical Tips
 
-- **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python`.
+- **Just want a python 2.7 shell?** Run `nxv run python 2.7`; nxv resolves the best match and handles old pre-flake revisions automatically.
 - **Use `--exact`** when one exact attribute is required. Default version searches stay within the shallowest matching tier; use `--all-depths` only when nested variants are intentional.
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
 - **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.

--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -212,10 +212,12 @@ nxv run python 3.11 --with nodejs@20 --with jq
 ```
 
 Additional `--with` values use `PACKAGE@VERSION` when a version is needed.
-nxv resolves every query before launch, chooses the first deterministic
-relevance-ranked match, and uses each result's latest observed commit. Modern
-revisions are combined in one `nix shell`; if any result predates flakes, nxv
-uses one compatible `nix-shell -p` environment instead.
+nxv resolves every query before launch, prefers an exact attribute match before
+falling back to search's deterministic relevance rules, and uses each result's
+latest observed commit. Modern revisions are combined in one `nix shell`; if
+any result predates flakes, nxv uses one compatible `nix-shell -p` environment
+instead. On Apple Silicon, the pre-flake fallback evaluates packages as
+`x86_64-darwin` and requires Rosetta.
 
 For manual command construction, take a `first_commit_hash` (or
 `last_commit_hash`) from search/history output and feed it to Nix:

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -16,6 +16,8 @@ nxv search python                        # All python packages (most recent per 
 nxv search python 2.7                    # Filter by version (prefix match)
 nxv search python --exact                # Exact attribute name only
 nxv search "json parser" --desc          # Full-text search package descriptions
+nxv run python 2.7                       # Resolve and open a pinned shell
+nxv run python 3.11 --with nodejs@20     # Multi-package shell
 nxv info python311                       # Detailed info for current version
 nxv info python311 3.11.4                # Detailed info for specific version
 nxv history python311                    # Version timeline (first/last seen)
@@ -35,7 +37,7 @@ nxv skill list                           # Agents, skill paths, install status
 
 Parse `$ARGUMENTS` to determine the action:
 
-- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
+- If arguments look like a **subcommand** (`search`, `run`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
 - If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
 - If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
 - If no arguments, run `nxv stats` to give the user a quick health check of their index.
@@ -201,7 +203,22 @@ Note the field names differ from search (`first_seen`/`last_seen`, not `first_co
 
 ## Using a Found Version
 
-The whole point. Take a `first_commit_hash` (or `last_commit_hash`) from search/history output and feed it to Nix:
+The quickest interactive path is `nxv run`, which resolves the same package and
+version query as `search` and opens one pinned shell:
+
+```bash
+nxv run python 2.7
+nxv run python 3.11 --with nodejs@20 --with jq
+```
+
+Additional `--with` values use `PACKAGE@VERSION` when a version is needed.
+nxv resolves every query before launch, chooses the first deterministic
+relevance-ranked match, and uses each result's latest observed commit. Modern
+revisions are combined in one `nix shell`; if any result predates flakes, nxv
+uses one compatible `nix-shell -p` environment instead.
+
+For manual command construction, take a `first_commit_hash` (or
+`last_commit_hash`) from search/history output and feed it to Nix:
 
 ```bash
 # Drop into a shell with that exact version
@@ -490,7 +507,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 
 ## Practical Tips
 
-- **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python`.
+- **Just want a python 2.7 shell?** Run `nxv run python 2.7`; nxv resolves the best match and handles old pre-flake revisions automatically.
 - **Use `--exact`** when one exact attribute is required. Default version searches stay within the shallowest matching tier; use `--all-depths` only when nested variants are intentional.
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
 - **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -212,10 +212,12 @@ nxv run python 3.11 --with nodejs@20 --with jq
 ```
 
 Additional `--with` values use `PACKAGE@VERSION` when a version is needed.
-nxv resolves every query before launch, chooses the first deterministic
-relevance-ranked match, and uses each result's latest observed commit. Modern
-revisions are combined in one `nix shell`; if any result predates flakes, nxv
-uses one compatible `nix-shell -p` environment instead.
+nxv resolves every query before launch, prefers an exact attribute match before
+falling back to search's deterministic relevance rules, and uses each result's
+latest observed commit. Modern revisions are combined in one `nix shell`; if
+any result predates flakes, nxv uses one compatible `nix-shell -p` environment
+instead. On Apple Silicon, the pre-flake fallback evaluates packages as
+`x86_64-darwin` and requires Rosetta.
 
 For manual command construction, take a `first_commit_hash` (or
 `last_commit_hash`) from search/history output and feed it to Nix:

--- a/README.md
+++ b/README.md
@@ -141,10 +141,12 @@ nxv run python 3.11 --with jq        # Add the latest jq
 nxv run python 3.11 --with nodejs@20 # Pin multiple package versions
 ```
 
-`nxv run` uses the same package/version matching as `search`, selects the best
-relevance-ranked result for each query, and opens one shell with every resolved
-package. Modern revisions use `nix shell`; environments containing a pre-flake
-revision automatically use a compatible pinned `nix-shell` expression.
+`nxv run` prefers an exact attribute match, then falls back to the same
+package/version scope and relevance rules as `search`. It opens one shell with
+every resolved package. Modern revisions use `nix shell`; environments
+containing a pre-flake revision automatically use a compatible pinned
+`nix-shell` expression. On Apple Silicon, that fallback evaluates packages as
+`x86_64-darwin` and requires Rosetta.
 
 ### Package Info & History
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Or visit **<https://nxv.urandom.io>** to search in your browser.
 ## Features
 
 - **Fast search** — Bloom filter for instant "not found" responses, SQLite FTS5 for full-text search
+- **Instant environments** — Resolve historical versions and jump straight into a pinned shell
 - **Version history** — See when each version was introduced and when it was superseded
 - **Multiple interfaces** — CLI tool, HTTP API server with web UI, or query via remote API
 - **NixOS module** — Run as a systemd service with automatic index updates
@@ -131,6 +132,19 @@ nxv search python --exact            # Exact name match only
 nxv search "json parser" --desc      # Search descriptions (FTS)
 nxv search python --format json      # JSON output
 ```
+
+### Jump Into a Package Shell
+
+```bash
+nxv run python 2.7                   # Resolve Python 2.7 and open a shell
+nxv run python 3.11 --with jq        # Add the latest jq
+nxv run python 3.11 --with nodejs@20 # Pin multiple package versions
+```
+
+`nxv run` uses the same package/version matching as `search`, selects the best
+relevance-ranked result for each query, and opens one shell with every resolved
+package. Modern revisions use `nix shell`; environments containing a pre-flake
+revision automatically use a compatible pinned `nix-shell` expression.
 
 ### Package Info & History
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 
 use crate::output::OutputFormat;
 use crate::paths;
+use crate::run::PackageSpec;
 use crate::search::SortOrder;
 use crate::skill::Agent;
 use crate::version;
@@ -43,6 +44,9 @@ pub struct Cli {
 pub enum Commands {
     /// Search for package versions.
     Search(SearchArgs),
+
+    /// Open a shell with resolved package versions.
+    Run(RunArgs),
 
     /// Update nxv to the latest application release.
     ///
@@ -316,6 +320,51 @@ impl SearchArgs {
     /// Get the version filter from either positional or option argument.
     pub fn get_version(&self) -> Option<&str> {
         self.version.as_deref().or(self.version_opt.as_deref())
+    }
+}
+
+/// Arguments for the run command.
+#[derive(Parser, Debug)]
+pub struct RunArgs {
+    /// Package name or attribute path to resolve.
+    pub package: String,
+
+    /// Version to filter by (positional, prefix match).
+    #[arg(conflicts_with = "version_opt")]
+    pub version: Option<String>,
+
+    /// Filter by version (prefix match, alternative to positional).
+    #[arg(short = 'V', long = "version", conflicts_with = "version")]
+    pub version_opt: Option<String>,
+
+    /// Add another package, optionally with an @VERSION suffix.
+    #[arg(long = "with", value_name = "PACKAGE[@VERSION]")]
+    pub additional: Vec<PackageSpec>,
+
+    /// Perform exact attribute-path matching.
+    #[arg(short, long)]
+    pub exact: bool,
+
+    /// Include nested attribute-path depths in version searches.
+    #[arg(long, conflicts_with = "exact")]
+    pub all_depths: bool,
+}
+
+impl RunArgs {
+    /// Get the primary package version from either positional or option argument.
+    pub fn get_version(&self) -> Option<&str> {
+        self.version.as_deref().or(self.version_opt.as_deref())
+    }
+
+    /// Return the primary query followed by all `--with` queries.
+    pub fn package_specs(&self) -> Vec<PackageSpec> {
+        let mut specs = Vec::with_capacity(1 + self.additional.len());
+        specs.push(PackageSpec::new(
+            self.package.clone(),
+            self.get_version().map(str::to_string),
+        ));
+        specs.extend(self.additional.iter().cloned());
+        specs
     }
 }
 
@@ -748,6 +797,50 @@ mod tests {
         // Cannot use both positional version and -V/--version option
         let result = Cli::try_parse_from(["nxv", "search", "python", "2.7", "-V", "3.11"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_run_command_with_additional_packages() {
+        let args = Cli::try_parse_from([
+            "nxv",
+            "run",
+            "python",
+            "2.7",
+            "--with",
+            "nodejs@15",
+            "--with",
+            "jq",
+            "--all-depths",
+        ])
+        .unwrap();
+
+        match args.command {
+            Commands::Run(run) => {
+                assert_eq!(run.package, "python");
+                assert_eq!(run.get_version(), Some("2.7"));
+                assert_eq!(
+                    run.additional,
+                    [
+                        PackageSpec::new("nodejs".to_string(), Some("15".to_string())),
+                        PackageSpec::new("jq".to_string(), None),
+                    ]
+                );
+                assert!(run.all_depths);
+                assert!(!run.exact);
+            }
+            _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_run_version_option_and_positional_conflict() {
+        assert!(Cli::try_parse_from(["nxv", "run", "python", "2.7", "-V", "3.11"]).is_err());
+    }
+
+    #[test]
+    fn test_run_rejects_malformed_additional_specs() {
+        assert!(Cli::try_parse_from(["nxv", "run", "python", "--with", "@15"]).is_err());
+        assert!(Cli::try_parse_from(["nxv", "run", "python", "--with", "nodejs@"]).is_err());
     }
 
     #[test]

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -54,7 +54,7 @@ _nxv_with_packages() {
 
     # Check if we're completing a package name argument
     case "${words[1]}" in
-        search|info|history)
+        search|info|history|run)
             # First positional argument after the command is the package name
             if [[ $cword -eq 2 ]] && [[ "$cur" != -* ]]; then
                 _nxv_complete_packages
@@ -62,6 +62,12 @@ _nxv_with_packages() {
             fi
             ;;
     esac
+
+    # Every --with value on `nxv run` starts another package query.
+    if [[ "${words[1]}" == "run" ]] && [[ "$prev" == "--with" ]] && [[ "$cur" != -* ]]; then
+        _nxv_complete_packages
+        return
+    fi
 
     # Fall back to default completion
     _nxv
@@ -119,9 +125,15 @@ _nxv_enhanced() {
     local curcontext="$curcontext" state line
     typeset -A opt_args
 
-    # Check if we're completing a package name argument for search/info/history
+    # Check if we're completing a package name argument for search/info/history/run
     # words[1] = command, words[2] = subcommand, words[3] = package argument
-    if [[ ${words[2]} == (search|info|history) ]] && [[ $CURRENT -eq 3 ]]; then
+    if [[ ${words[2]} == (search|info|history|run) ]] && [[ $CURRENT -eq 3 ]]; then
+        _nxv_packages
+        return
+    fi
+
+    # Every --with value on `nxv run` starts another package query.
+    if [[ ${words[2]} == run ]] && [[ ${words[CURRENT-1]} == --with ]]; then
         _nxv_packages
         return
     fi
@@ -154,10 +166,22 @@ function __nxv_complete_packages
     $cmd complete-package "$token" --limit 100 2>/dev/null
 end
 
+function __nxv_run_primary_package
+    set -l tokens (commandline -opc)
+    test (count $tokens) -eq 2; and test "$tokens[2]" = run
+end
+
+function __nxv_run_with_package
+    set -l tokens (commandline -opc)
+    test (count $tokens) -ge 3; and test "$tokens[2]" = run; and test "$tokens[-1]" = --with
+end
+
 # Add package completions for search, info, and history commands
 complete -c nxv -n "__fish_seen_subcommand_from search" -f -a "(__nxv_complete_packages)"
 complete -c nxv -n "__fish_seen_subcommand_from info" -f -a "(__nxv_complete_packages)"
 complete -c nxv -n "__fish_seen_subcommand_from history" -f -a "(__nxv_complete_packages)"
+complete -c nxv -n "__nxv_run_primary_package" -f -a "(__nxv_complete_packages)"
+complete -c nxv -n "__nxv_run_with_package" -f -a "(__nxv_complete_packages)"
 "#,
     )
 }
@@ -177,6 +201,8 @@ mod tests {
         // Should contain custom package completion
         assert!(output.contains("_nxv_complete_packages"));
         assert!(output.contains("complete-package"));
+        assert!(output.contains("search|info|history|run"));
+        assert!(output.contains(r#""$prev" == "--with""#));
     }
 
     #[test]
@@ -190,6 +216,8 @@ mod tests {
         // Should contain custom package completion
         assert!(output.contains("_nxv_packages"));
         assert!(output.contains("complete-package"));
+        assert!(output.contains("(search|info|history|run)"));
+        assert!(output.contains("words[CURRENT-1]"));
     }
 
     #[test]
@@ -203,5 +231,7 @@ mod tests {
         // Should contain custom package completion
         assert!(output.contains("__nxv_complete_packages"));
         assert!(output.contains("complete-package"));
+        assert!(output.contains("__nxv_run_primary_package"));
+        assert!(output.contains("__nxv_run_with_package"));
     }
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -52,11 +52,22 @@ _nxv_with_packages() {
     local cur prev words cword
     _init_completion || return
 
+    local subcommand="" subcommand_index=-1 i
+    for ((i = 1; i < cword; i++)); do
+        case "${words[i]}" in
+            search|info|history|run)
+                subcommand="${words[i]}"
+                subcommand_index=$i
+                break
+                ;;
+        esac
+    done
+
     # Check if we're completing a package name argument
-    case "${words[1]}" in
+    case "$subcommand" in
         search|info|history|run)
             # First positional argument after the command is the package name
-            if [[ $cword -eq 2 ]] && [[ "$cur" != -* ]]; then
+            if [[ $cword -eq $((subcommand_index + 1)) ]] && [[ "$cur" != -* ]]; then
                 _nxv_complete_packages
                 return
             fi
@@ -64,7 +75,7 @@ _nxv_with_packages() {
     esac
 
     # Every --with value on `nxv run` starts another package query.
-    if [[ "${words[1]}" == "run" ]] && [[ "$prev" == "--with" ]] && [[ "$cur" != -* ]]; then
+    if [[ "$subcommand" == "run" ]] && [[ "$prev" == "--with" ]] && [[ "$cur" != -* ]]; then
         _nxv_complete_packages
         return
     fi
@@ -124,16 +135,24 @@ _nxv_packages() {
 _nxv_enhanced() {
     local curcontext="$curcontext" state line
     typeset -A opt_args
+    local subcommand="" subcommand_index=0 i
+
+    for ((i = 2; i < CURRENT; i++)); do
+        if [[ ${words[i]} == (search|info|history|run) ]]; then
+            subcommand="${words[i]}"
+            subcommand_index=$i
+            break
+        fi
+    done
 
     # Check if we're completing a package name argument for search/info/history/run
-    # words[1] = command, words[2] = subcommand, words[3] = package argument
-    if [[ ${words[2]} == (search|info|history|run) ]] && [[ $CURRENT -eq 3 ]]; then
+    if [[ -n "$subcommand" ]] && [[ $CURRENT -eq $((subcommand_index + 1)) ]]; then
         _nxv_packages
         return
     fi
 
     # Every --with value on `nxv run` starts another package query.
-    if [[ ${words[2]} == run ]] && [[ ${words[CURRENT-1]} == --with ]]; then
+    if [[ "$subcommand" == run ]] && [[ ${words[CURRENT-1]} == --with ]]; then
         _nxv_packages
         return
     fi
@@ -152,8 +171,22 @@ compdef _nxv_enhanced nxv-indexer
 
 /// Generate fish completions with dynamic package completion.
 fn generate_fish<W: Write>(buf: &mut W, base: &str) -> std::io::Result<()> {
-    // Write base completions first
-    buf.write_all(base.as_bytes())?;
+    // Attach dynamic candidates directly to clap's required `--with` value.
+    // Fish suppresses general argument completions while satisfying an option
+    // marked `--require-parameter`, so a separate completion rule is not enough.
+    let modified_base = base
+        .lines()
+        .map(|line| {
+            if line.contains("__fish_nxv_using_subcommand run") && line.contains("-l with ") {
+                format!("{line} -f -a \"(__nxv_complete_packages)\"")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    buf.write_all(modified_base.as_bytes())?;
+    buf.write_all(b"\n")?;
 
     // Add custom package completion function
     buf.write_all(
@@ -168,12 +201,8 @@ end
 
 function __nxv_run_primary_package
     set -l tokens (commandline -opc)
-    test (count $tokens) -eq 2; and test "$tokens[2]" = run
-end
-
-function __nxv_run_with_package
-    set -l tokens (commandline -opc)
-    test (count $tokens) -ge 3; and test "$tokens[2]" = run; and test "$tokens[-1]" = --with
+    set -l run_index (contains -i -- run $tokens)
+    test -n "$run_index"; and test (count $tokens) -eq $run_index
 end
 
 # Add package completions for search, info, and history commands
@@ -181,7 +210,6 @@ complete -c nxv -n "__fish_seen_subcommand_from search" -f -a "(__nxv_complete_p
 complete -c nxv -n "__fish_seen_subcommand_from info" -f -a "(__nxv_complete_packages)"
 complete -c nxv -n "__fish_seen_subcommand_from history" -f -a "(__nxv_complete_packages)"
 complete -c nxv -n "__nxv_run_primary_package" -f -a "(__nxv_complete_packages)"
-complete -c nxv -n "__nxv_run_with_package" -f -a "(__nxv_complete_packages)"
 "#,
     )
 }
@@ -203,6 +231,7 @@ mod tests {
         assert!(output.contains("complete-package"));
         assert!(output.contains("search|info|history|run"));
         assert!(output.contains(r#""$prev" == "--with""#));
+        assert!(output.contains("subcommand_index"));
     }
 
     #[test]
@@ -218,6 +247,7 @@ mod tests {
         assert!(output.contains("complete-package"));
         assert!(output.contains("(search|info|history|run)"));
         assert!(output.contains("words[CURRENT-1]"));
+        assert!(output.contains("subcommand_index"));
     }
 
     #[test]
@@ -232,6 +262,8 @@ mod tests {
         assert!(output.contains("__nxv_complete_packages"));
         assert!(output.contains("complete-package"));
         assert!(output.contains("__nxv_run_primary_package"));
-        assert!(output.contains("__nxv_run_with_package"));
+        assert!(output.contains(r#"-l with -d 'Add another package"#));
+        assert!(output.contains(r#"-r -f -a "(__nxv_complete_packages)""#));
+        assert!(output.contains("contains -i -- run"));
     }
 }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -83,7 +83,7 @@ fn is_plain_nix_identifier(segment: &str) -> bool {
 /// Prepare an attribute path for command emission: re-quote segments that
 /// aren't valid bare Nix identifiers. Returns the printable path and whether
 /// any segment needed quoting (the caller must then shell-quote the ref).
-fn nix_attr_for_command(attr: &str) -> (String, bool) {
+pub(crate) fn nix_attr_for_command(attr: &str) -> (String, bool) {
     let mut quoted_any = false;
     let parts: Vec<String> = attr
         .split('.')

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -92,7 +92,13 @@ pub(crate) fn nix_attr_for_command(attr: &str) -> (String, bool) {
                 segment.to_string()
             } else {
                 quoted_any = true;
-                format!("\"{}\"", segment.replace('\\', "\\\\").replace('"', "\\\""))
+                format!(
+                    "\"{}\"",
+                    segment
+                        .replace('\\', "\\\\")
+                        .replace('"', "\\\"")
+                        .replace("${", "\\${")
+                )
             }
         })
         .collect();
@@ -2452,6 +2458,14 @@ mod tests {
         // 2023-11-14 - after flakes
         let pkg = make_test_package(Utc.timestamp_opt(1700000000, 0).unwrap(), None);
         assert!(!pkg.predates_flakes());
+    }
+
+    #[test]
+    fn test_nix_attr_for_command_escapes_string_interpolation() {
+        let (attribute, quoted) = nix_attr_for_command(r#"set.${builtins.readFile "/secret"}"#);
+
+        assert!(quoted);
+        assert_eq!(attribute, r#"set."\${builtins"."readFile \"/secret\"}""#);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod error;
 mod output;
 mod paths;
 mod remote;
+mod run;
 mod search;
 mod self_update;
 mod skill;
@@ -65,6 +66,7 @@ fn main() {
 
     let result = match &cli.command {
         Commands::Search(args) => cmd_search(&cli, args),
+        Commands::Run(args) => cmd_run(&cli, args),
         Commands::Update(args) => cmd_update(&cli, args),
         Commands::Sync(args) => cmd_sync(&cli, args),
         Commands::Info(args) => cmd_pkg_info(&cli, args),
@@ -109,6 +111,70 @@ fn main() {
         }
         std::process::exit(1);
     }
+}
+
+/// Resolve package queries and replace nxv with a pinned Nix shell.
+fn cmd_run(cli: &Cli, args: &cli::RunArgs) -> Result<()> {
+    use crate::search::{SearchOptions, SortOrder};
+
+    if args.all_depths && args.get_version().is_none() {
+        anyhow::bail!("--all-depths requires a version filter for the primary package");
+    }
+
+    let backend = get_backend_with_prompt(cli)?;
+    let specs = args.package_specs();
+    let mut packages = Vec::with_capacity(specs.len());
+
+    for spec in &specs {
+        let result = backend.search(&SearchOptions {
+            query: spec.package.clone(),
+            version: spec.version.clone(),
+            exact: args.exact,
+            all_depths: args.all_depths && spec.version.is_some(),
+            desc: false,
+            license: None,
+            sort: SortOrder::Relevance,
+            reverse: false,
+            full: false,
+            limit: 1,
+            offset: 0,
+        })?;
+
+        let Some(package) = result.data.into_iter().next() else {
+            if !cli.quiet {
+                if let Some(resolution) = result.resolution {
+                    print_version_search_miss(&spec.package, &resolution);
+                } else {
+                    eprintln!("No packages found matching '{}'", spec.package);
+                }
+            }
+            anyhow::bail!("unable to resolve package specification `{spec}`");
+        };
+
+        if !cli.quiet {
+            eprintln!(
+                "Resolved {} -> {} {} ({})",
+                spec,
+                package.attribute_path,
+                package.version,
+                package.last_commit_short()
+            );
+        }
+        packages.push(package);
+    }
+
+    let insecure: Vec<_> = packages
+        .iter()
+        .filter(|package| package.is_insecure())
+        .collect();
+    if !cli.quiet && !insecure.is_empty() {
+        eprintln!("Warning: selected package versions have known vulnerabilities:");
+        for package in insecure {
+            eprintln!("  {} {}", package.attribute_path, package.version);
+        }
+    }
+
+    run::ShellInvocation::from_packages(&packages)?.execute()
 }
 
 /// Selects and initializes the appropriate backend based on the `NXV_API_URL` environment variable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,11 +126,11 @@ fn cmd_run(cli: &Cli, args: &cli::RunArgs) -> Result<()> {
     let mut packages = Vec::with_capacity(specs.len());
 
     for spec in &specs {
-        let result = backend.search(&SearchOptions {
+        let search_options = |exact| SearchOptions {
             query: spec.package.clone(),
             version: spec.version.clone(),
-            exact: args.exact,
-            all_depths: args.all_depths && spec.version.is_some(),
+            exact,
+            all_depths: !exact && args.all_depths && spec.version.is_some(),
             desc: false,
             license: None,
             sort: SortOrder::Relevance,
@@ -138,7 +138,17 @@ fn cmd_run(cli: &Cli, args: &cli::RunArgs) -> Result<()> {
             full: false,
             limit: 1,
             offset: 0,
-        })?;
+        };
+
+        // An exact attribute is always the strongest relevance signal. Fall
+        // back to the normal scoped prefix search only when that attribute
+        // does not provide the requested version.
+        let exact_result = backend.search(&search_options(true))?;
+        let result = if args.exact || !exact_result.data.is_empty() {
+            exact_result
+        } else {
+            backend.search(&search_options(false))?
+        };
 
         let Some(package) = result.data.into_iter().next() else {
             if !cli.quiet {
@@ -172,6 +182,17 @@ fn cmd_run(cli: &Cli, args: &cli::RunArgs) -> Result<()> {
         for package in insecure {
             eprintln!("  {} {}", package.attribute_path, package.version);
         }
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    if !cli.quiet
+        && packages
+            .iter()
+            .any(crate::db::queries::PackageVersion::predates_flakes)
+    {
+        eprintln!(
+            "Note: pre-flake packages use x86_64-darwin on Apple Silicon and require Rosetta."
+        );
     }
 
     run::ShellInvocation::from_packages(&packages)?.execute()

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,221 @@
+//! Package-spec parsing and structured Nix shell invocation.
+
+use crate::db::queries::{PackageVersion, nix_attr_for_command};
+use anyhow::{Context, Result, bail};
+use std::fmt;
+use std::process::Command;
+use std::str::FromStr;
+
+/// One package query accepted by `nxv run`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageSpec {
+    pub package: String,
+    pub version: Option<String>,
+}
+
+impl PackageSpec {
+    pub fn new(package: String, version: Option<String>) -> Self {
+        Self { package, version }
+    }
+}
+
+impl fmt::Display for PackageSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.version {
+            Some(version) => write!(f, "{}@{}", self.package, version),
+            None => f.write_str(&self.package),
+        }
+    }
+}
+
+impl FromStr for PackageSpec {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        if value.is_empty() {
+            return Err("package specification cannot be empty".to_string());
+        }
+
+        match value.rsplit_once('@') {
+            Some(("", _)) => Err("package name before @ cannot be empty".to_string()),
+            Some((_, "")) => Err("version after @ cannot be empty".to_string()),
+            Some((package, version)) => {
+                Ok(Self::new(package.to_string(), Some(version.to_string())))
+            }
+            None => Ok(Self::new(value.to_string(), None)),
+        }
+    }
+}
+
+/// A shell command represented as an executable, argv, and environment.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ShellInvocation {
+    program: &'static str,
+    args: Vec<String>,
+    allow_insecure: bool,
+}
+
+impl ShellInvocation {
+    /// Build one shell invocation for all resolved packages.
+    pub fn from_packages(packages: &[PackageVersion]) -> Result<Self> {
+        if packages.is_empty() {
+            bail!("cannot launch a shell without packages");
+        }
+
+        let allow_insecure = packages.iter().any(PackageVersion::is_insecure);
+        let has_legacy = packages.iter().any(PackageVersion::predates_flakes);
+
+        if has_legacy {
+            let mut args = vec!["-p".to_string()];
+            args.extend(packages.iter().map(legacy_package_expression));
+            Ok(Self {
+                program: "nix-shell",
+                args,
+                allow_insecure,
+            })
+        } else {
+            let mut args = vec!["shell".to_string()];
+            if allow_insecure {
+                args.push("--impure".to_string());
+            }
+            args.extend(packages.iter().map(flake_installable));
+            Ok(Self {
+                program: "nix",
+                args,
+                allow_insecure,
+            })
+        }
+    }
+
+    /// Replace nxv with the selected Nix shell command on Unix.
+    pub fn execute(self) -> Result<()> {
+        let mut command = Command::new(self.program);
+        command.args(&self.args);
+        if self.allow_insecure {
+            command.env("NIXPKGS_ALLOW_INSECURE", "1");
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            let error = command.exec();
+            Err(error).with_context(|| format!("failed to execute `{}`", self.program))
+        }
+
+        #[cfg(not(unix))]
+        {
+            let status = command
+                .status()
+                .with_context(|| format!("failed to execute `{}`", self.program))?;
+            if !status.success() {
+                bail!("`{}` exited with {}", self.program, status);
+            }
+            Ok(())
+        }
+    }
+}
+
+fn flake_installable(package: &PackageVersion) -> String {
+    let (attribute, _) = nix_attr_for_command(&package.attribute_path);
+    format!("nixpkgs/{}#{}", package.last_commit_hash, attribute)
+}
+
+fn legacy_package_expression(package: &PackageVersion) -> String {
+    let (attribute, _) = nix_attr_for_command(&package.attribute_path);
+    format!(
+        "(import (builtins.fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{}.tar.gz\") {{}}).{}",
+        package.last_commit_hash, attribute
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn package(attribute_path: &str, hash: &str, timestamp: i64, insecure: bool) -> PackageVersion {
+        PackageVersion {
+            id: 1,
+            name: attribute_path.to_string(),
+            version: "1.0".to_string(),
+            first_commit_hash: hash.to_string(),
+            first_commit_date: Utc.timestamp_opt(timestamp, 0).unwrap(),
+            last_commit_hash: hash.to_string(),
+            last_commit_date: Utc.timestamp_opt(timestamp, 0).unwrap(),
+            attribute_path: attribute_path.to_string(),
+            description: None,
+            license: None,
+            homepage: None,
+            maintainers: None,
+            platforms: None,
+            source_path: None,
+            known_vulnerabilities: insecure.then(|| r#"["CVE-test"]"#.to_string()),
+        }
+    }
+
+    #[test]
+    fn parses_additional_package_specs() {
+        assert_eq!(
+            "nodejs@15".parse::<PackageSpec>().unwrap(),
+            PackageSpec::new("nodejs".to_string(), Some("15".to_string()))
+        );
+        assert_eq!(
+            "jq".parse::<PackageSpec>().unwrap(),
+            PackageSpec::new("jq".to_string(), None)
+        );
+        assert!("@15".parse::<PackageSpec>().is_err());
+        assert!("nodejs@".parse::<PackageSpec>().is_err());
+    }
+
+    #[test]
+    fn builds_modern_multi_package_invocation() {
+        let packages = [
+            package("python311", "python-hash", 1_700_000_000, false),
+            package("nodejs", "node-hash", 1_700_000_000, false),
+        ];
+        let invocation = ShellInvocation::from_packages(&packages).unwrap();
+
+        assert_eq!(invocation.program, "nix");
+        assert_eq!(
+            invocation.args,
+            [
+                "shell",
+                "nixpkgs/python-hash#python311",
+                "nixpkgs/node-hash#nodejs"
+            ]
+        );
+        assert!(!invocation.allow_insecure);
+    }
+
+    #[test]
+    fn builds_legacy_invocation_for_mixed_eras() {
+        let packages = [
+            package("python27", "old-hash", 1_500_000_000, false),
+            package("nodejs", "new-hash", 1_700_000_000, false),
+        ];
+        let invocation = ShellInvocation::from_packages(&packages).unwrap();
+
+        assert_eq!(invocation.program, "nix-shell");
+        assert_eq!(invocation.args[0], "-p");
+        assert!(invocation.args[1].contains("old-hash"));
+        assert!(invocation.args[1].ends_with(".python27"));
+        assert!(invocation.args[2].contains("new-hash"));
+        assert!(invocation.args[2].ends_with(".nodejs"));
+    }
+
+    #[test]
+    fn enables_insecure_packages_and_quotes_attribute_segments() {
+        let packages = [package(
+            "aspellDicts.or",
+            "secure-hash",
+            1_700_000_000,
+            true,
+        )];
+        let invocation = ShellInvocation::from_packages(&packages).unwrap();
+
+        assert_eq!(invocation.program, "nix");
+        assert_eq!(invocation.args[1], "--impure");
+        assert_eq!(invocation.args[2], "nixpkgs/secure-hash#aspellDicts.\"or\"");
+        assert!(invocation.allow_insecure);
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,8 +1,9 @@
 //! Package-spec parsing and structured Nix shell invocation.
 
 use crate::db::queries::{PackageVersion, nix_attr_for_command};
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use std::fmt;
+use std::io;
 use std::process::Command;
 use std::str::FromStr;
 
@@ -67,7 +68,12 @@ impl ShellInvocation {
 
         if has_legacy {
             let mut args = vec!["-p".to_string()];
-            args.extend(packages.iter().map(legacy_package_expression));
+            args.extend(
+                packages
+                    .iter()
+                    .map(legacy_package_expression)
+                    .collect::<Result<Vec<_>>>()?,
+            );
             Ok(Self {
                 program: "nix-shell",
                 args,
@@ -78,7 +84,12 @@ impl ShellInvocation {
             if allow_insecure {
                 args.push("--impure".to_string());
             }
-            args.extend(packages.iter().map(flake_installable));
+            args.extend(
+                packages
+                    .iter()
+                    .map(flake_installable)
+                    .collect::<Result<Vec<_>>>()?,
+            );
             Ok(Self {
                 program: "nix",
                 args,
@@ -99,14 +110,14 @@ impl ShellInvocation {
         {
             use std::os::unix::process::CommandExt;
             let error = command.exec();
-            Err(error).with_context(|| format!("failed to execute `{}`", self.program))
+            Err(execution_error(self.program, error))
         }
 
         #[cfg(not(unix))]
         {
             let status = command
                 .status()
-                .with_context(|| format!("failed to execute `{}`", self.program))?;
+                .map_err(|error| execution_error(self.program, error))?;
             if !status.success() {
                 bail!("`{}` exited with {}", self.program, status);
             }
@@ -115,17 +126,62 @@ impl ShellInvocation {
     }
 }
 
-fn flake_installable(package: &PackageVersion) -> String {
-    let (attribute, _) = nix_attr_for_command(&package.attribute_path);
-    format!("nixpkgs/{}#{}", package.last_commit_hash, attribute)
+fn execution_error(program: &str, error: io::Error) -> anyhow::Error {
+    if error.kind() == io::ErrorKind::NotFound {
+        anyhow!(
+            "cannot launch `{program}` because it was not found on PATH; install Nix from \
+             https://nixos.org/download/ or ensure `{program}` is available on PATH"
+        )
+    } else {
+        Err::<(), _>(error)
+            .with_context(|| format!("failed to execute `{program}`"))
+            .unwrap_err()
+    }
 }
 
-fn legacy_package_expression(package: &PackageVersion) -> String {
+fn validated_revision(package: &PackageVersion) -> Result<&str> {
+    let revision = package.last_commit_hash.as_str();
+    if revision.len() != 40 || !revision.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!(
+            "index returned invalid nixpkgs revision {:?} for {} {}; run `nxv sync` and retry",
+            revision,
+            package.attribute_path,
+            package.version
+        );
+    }
+    Ok(revision)
+}
+
+fn flake_installable(package: &PackageVersion) -> Result<String> {
+    let revision = validated_revision(package)?;
     let (attribute, _) = nix_attr_for_command(&package.attribute_path);
-    format!(
-        "(import (builtins.fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{}.tar.gz\") {{}}).{}",
-        package.last_commit_hash, attribute
-    )
+    Ok(format!("nixpkgs/{revision}#{attribute}"))
+}
+
+fn legacy_package_expression(package: &PackageVersion) -> Result<String> {
+    let revision = validated_revision(package)?;
+    let (attribute, _) = nix_attr_for_command(&package.attribute_path);
+    let import_args = legacy_import_args(package);
+    Ok(format!(
+        "(import (builtins.fetchTarball \"https://github.com/NixOS/nixpkgs/archive/{revision}.tar.gz\") {import_args}).{attribute}"
+    ))
+}
+
+fn legacy_import_args(package: &PackageVersion) -> &'static str {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        if package.predates_flakes() {
+            r#"{ system = "x86_64-darwin"; }"#
+        } else {
+            "{}"
+        }
+    }
+
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    {
+        let _ = package;
+        "{}"
+    }
 }
 
 #[cfg(test)]
@@ -170,8 +226,18 @@ mod tests {
     #[test]
     fn builds_modern_multi_package_invocation() {
         let packages = [
-            package("python311", "python-hash", 1_700_000_000, false),
-            package("nodejs", "node-hash", 1_700_000_000, false),
+            package(
+                "python311",
+                "0123456789abcdef0123456789abcdef01234567",
+                1_700_000_000,
+                false,
+            ),
+            package(
+                "nodejs",
+                "fedcba9876543210fedcba9876543210fedcba98",
+                1_700_000_000,
+                false,
+            ),
         ];
         let invocation = ShellInvocation::from_packages(&packages).unwrap();
 
@@ -180,8 +246,8 @@ mod tests {
             invocation.args,
             [
                 "shell",
-                "nixpkgs/python-hash#python311",
-                "nixpkgs/node-hash#nodejs"
+                "nixpkgs/0123456789abcdef0123456789abcdef01234567#python311",
+                "nixpkgs/fedcba9876543210fedcba9876543210fedcba98#nodejs"
             ]
         );
         assert!(!invocation.allow_insecure);
@@ -190,24 +256,38 @@ mod tests {
     #[test]
     fn builds_legacy_invocation_for_mixed_eras() {
         let packages = [
-            package("python27", "old-hash", 1_500_000_000, false),
-            package("nodejs", "new-hash", 1_700_000_000, false),
+            package(
+                "python27",
+                "0123456789abcdef0123456789abcdef01234567",
+                1_500_000_000,
+                false,
+            ),
+            package(
+                "nodejs",
+                "fedcba9876543210fedcba9876543210fedcba98",
+                1_700_000_000,
+                false,
+            ),
         ];
         let invocation = ShellInvocation::from_packages(&packages).unwrap();
 
         assert_eq!(invocation.program, "nix-shell");
         assert_eq!(invocation.args[0], "-p");
-        assert!(invocation.args[1].contains("old-hash"));
+        assert!(invocation.args[1].contains("0123456789abcdef"));
         assert!(invocation.args[1].ends_with(".python27"));
-        assert!(invocation.args[2].contains("new-hash"));
+        assert!(invocation.args[2].contains("fedcba9876543210"));
         assert!(invocation.args[2].ends_with(".nodejs"));
+        if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+            assert!(invocation.args[1].contains(r#"{ system = "x86_64-darwin"; }"#));
+            assert!(!invocation.args[2].contains("x86_64-darwin"));
+        }
     }
 
     #[test]
     fn enables_insecure_packages_and_quotes_attribute_segments() {
         let packages = [package(
             "aspellDicts.or",
-            "secure-hash",
+            "0123456789abcdef0123456789abcdef01234567",
             1_700_000_000,
             true,
         )];
@@ -215,7 +295,28 @@ mod tests {
 
         assert_eq!(invocation.program, "nix");
         assert_eq!(invocation.args[1], "--impure");
-        assert_eq!(invocation.args[2], "nixpkgs/secure-hash#aspellDicts.\"or\"");
+        assert_eq!(
+            invocation.args[2],
+            "nixpkgs/0123456789abcdef0123456789abcdef01234567#aspellDicts.\"or\""
+        );
         assert!(invocation.allow_insecure);
+    }
+
+    #[test]
+    fn rejects_invalid_index_revisions_before_launch() {
+        let package = package("python311", "not-a-revision", 1_700_000_000, false);
+        let error = ShellInvocation::from_packages(&[package]).unwrap_err();
+
+        assert!(error.to_string().contains("invalid nixpkgs revision"));
+        assert!(error.to_string().contains("nxv sync"));
+    }
+
+    #[test]
+    fn missing_nix_error_is_actionable() {
+        let error = execution_error("nix", io::Error::new(io::ErrorKind::NotFound, "missing"));
+        let message = error.to_string();
+
+        assert!(message.contains("not found on PATH"));
+        assert!(message.contains("install Nix"));
     }
 }

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -16,6 +16,8 @@ nxv search python                        # All python packages (most recent per 
 nxv search python 2.7                    # Filter by version (prefix match)
 nxv search python --exact                # Exact attribute name only
 nxv search "json parser" --desc          # Full-text search package descriptions
+nxv run python 2.7                       # Resolve and open a pinned shell
+nxv run python 3.11 --with nodejs@20     # Multi-package shell
 nxv info python311                       # Detailed info for current version
 nxv info python311 3.11.4                # Detailed info for specific version
 nxv history python311                    # Version timeline (first/last seen)
@@ -35,7 +37,7 @@ nxv skill list                           # Agents, skill paths, install status
 
 Parse `$ARGUMENTS` to determine the action:
 
-- If arguments look like a **subcommand** (`search`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
+- If arguments look like a **subcommand** (`search`, `run`, `info`, `history`, `stats`, `update`, `sync`, `serve`, `completions`, `skill`, and indexer-only `index`, `dedupe`, `publish`, `keygen`), run that subcommand.
 - If arguments look like a **package name** (e.g. `python`, `nodejs 15`, `ruby 2.6`), default to `nxv search`.
 - If arguments look like a **question** ("when was X added", "which commit has Y"), pick `search` or `history` accordingly.
 - If no arguments, run `nxv stats` to give the user a quick health check of their index.
@@ -201,7 +203,22 @@ Note the field names differ from search (`first_seen`/`last_seen`, not `first_co
 
 ## Using a Found Version
 
-The whole point. Take a `first_commit_hash` (or `last_commit_hash`) from search/history output and feed it to Nix:
+The quickest interactive path is `nxv run`, which resolves the same package and
+version query as `search` and opens one pinned shell:
+
+```bash
+nxv run python 2.7
+nxv run python 3.11 --with nodejs@20 --with jq
+```
+
+Additional `--with` values use `PACKAGE@VERSION` when a version is needed.
+nxv resolves every query before launch, chooses the first deterministic
+relevance-ranked match, and uses each result's latest observed commit. Modern
+revisions are combined in one `nix shell`; if any result predates flakes, nxv
+uses one compatible `nix-shell -p` environment instead.
+
+For manual command construction, take a `first_commit_hash` (or
+`last_commit_hash`) from search/history output and feed it to Nix:
 
 ```bash
 # Drop into a shell with that exact version
@@ -490,7 +507,7 @@ curl -s "https://nxv.urandom.io/api/v1/stats" | \
 
 ## Practical Tips
 
-- **Just want a python 2.7 shell?** `nxv search python 2.7 --exact --format json | jq -r '.[0].first_commit_hash'`, then `nix shell nixpkgs/<hash>#python`.
+- **Just want a python 2.7 shell?** Run `nxv run python 2.7`; nxv resolves the best match and handles old pre-flake revisions automatically.
 - **Use `--exact`** when one exact attribute is required. Default version searches stay within the shallowest matching tier; use `--all-depths` only when nested variants are intentional.
 - **Use `--desc`** for fuzzy intent ("a package that does X") instead of exact name searches.
 - **Set `NXV_API_URL=https://nxv.urandom.io`** to skip the ~220MB index download entirely if you only need occasional lookups.

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -212,10 +212,12 @@ nxv run python 3.11 --with nodejs@20 --with jq
 ```
 
 Additional `--with` values use `PACKAGE@VERSION` when a version is needed.
-nxv resolves every query before launch, chooses the first deterministic
-relevance-ranked match, and uses each result's latest observed commit. Modern
-revisions are combined in one `nix shell`; if any result predates flakes, nxv
-uses one compatible `nix-shell -p` environment instead.
+nxv resolves every query before launch, prefers an exact attribute match before
+falling back to search's deterministic relevance rules, and uses each result's
+latest observed commit. Modern revisions are combined in one `nix shell`; if
+any result predates flakes, nxv uses one compatible `nix-shell -p` environment
+instead. On Apple Silicon, the pre-flake fallback evaluates packages as
+`x86_64-darwin` and requires Rosetta.
 
 For manual command construction, take a `first_commit_hash` (or
 `last_commit_hash`) from search/history output and feed it to Nix:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -125,19 +125,23 @@ fn create_test_db(path: &std::path::Path) {
             (name, version, first_commit_hash, first_commit_date, last_commit_hash, last_commit_date,
              attribute_path, description, license, homepage)
         VALUES
-            ('python-3.11.0', '3.11.0', 'abc1234567890', 1700000000, 'def1234567890', 1700100000,
+            ('python-3.11.0', '3.11.0', 'abc1234567890', 1700000000, 'def1234567890000000000000000000000000000', 1700100000,
              'python', 'Python programming language', '["MIT"]', 'https://python.org'),
-            ('python-3.11.0', '3.11.0', 'abc1234567890', 1700000000, 'def1234567890', 1700100000,
+            ('python-3.11.0', '3.11.0', 'abc1234567890', 1700000000, 'def1234567890000000000000000000000000000', 1700100000,
              'python311', 'Python programming language', '["MIT"]', 'https://python.org'),
-            ('python-3.12.0', '3.12.0', 'ghi1234567890', 1701000000, 'jkl1234567890', 1701100000,
+            ('python-3.12.0', '3.12.0', 'ghi1234567890', 1701000000, 'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1', 1701100000,
              'python312', 'Python programming language', '["MIT"]', 'https://python.org'),
-            ('python2-2.7.18', '2.7.18', 'mno1234567890', 1600000000, 'pqr1234567890', 1600100000,
+            ('python2-2.7.18', '2.7.18', 'mno1234567890', 1600000000, 'b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2', 1600100000,
              'python2', 'Python 2 interpreter', '["PSF"]', 'https://python.org'),
-            ('nodejs-20.0.0', '20.0.0', 'stu1234567890', 1702000000, 'vwx1234567890', 1702100000,
+            ('nodejs-20.0.0', '20.0.0', 'stu1234567890', 1702000000, 'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3', 1702100000,
              'nodejs', 'Node.js JavaScript runtime', '["MIT"]', 'https://nodejs.org'),
-            ('firefox-120.0', '120.0', 'aaa1234567890', 1703000000, 'bbb1234567890', 1703100000,
+            ('jq-1.7.1', '1.7.1', 'eee1234567890', 1702000000, 'e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4', 1702100000,
+             'jq', 'Command-line JSON processor', '["MIT"]', 'https://jqlang.github.io/jq/'),
+            ('jquake-1.8.5', '1.8.5', 'fff1234567890', 1705000000, 'f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5', 1705100000,
+             'jquake', 'A newer prefix sibling', '["MIT"]', 'https://example.com/jquake'),
+            ('firefox-120.0', '120.0', 'aaa1234567890', 1703000000, 'bbb1234567890000000000000000000000000000', 1703100000,
              'firefox', 'Mozilla Firefox web browser', '["MPL-2.0"]', 'https://firefox.com'),
-            ('rustc-1.75.0', '1.75.0', 'ccc1234567890', 1704000000, 'ddd1234567890', 1704100000,
+            ('rustc-1.75.0', '1.75.0', 'ccc1234567890', 1704000000, 'ddd1234567890000000000000000000000000000', 1704100000,
              'rustc', 'The Rust compiler', '["MIT", "Apache-2.0"]', 'https://rust-lang.org');
         "#,
     )
@@ -214,8 +218,40 @@ fn test_run_launches_one_modern_shell_with_multiple_packages() {
     let capture = std::fs::read_to_string(capture_path).unwrap();
     assert!(capture.contains("program=nix\n"));
     assert!(capture.contains("arg=shell\n"));
-    assert!(capture.contains("arg=nixpkgs/def1234567890#python\n"));
-    assert!(capture.contains("arg=nixpkgs/vwx1234567890#nodejs\n"));
+    assert!(capture.contains("arg=nixpkgs/def1234567890000000000000000000000000000#python\n"));
+    assert!(capture.contains("arg=nixpkgs/c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3#nodejs\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_prefers_an_exact_attribute_over_newer_prefix_siblings() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bin_path = dir.path().join("bin");
+    let capture_path = dir.path().join("capture.txt");
+    create_test_db(&db_path);
+    std::fs::create_dir(&bin_path).unwrap();
+    install_fake_nix_commands(&bin_path);
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "python",
+            "3.11",
+            "--with",
+            "jq",
+        ])
+        .env("PATH", prepend_path(&bin_path))
+        .env("NXV_TEST_CAPTURE", &capture_path)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Resolved jq -> jq 1.7.1"));
+
+    let capture = std::fs::read_to_string(capture_path).unwrap();
+    assert!(capture.contains("arg=nixpkgs/e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4#jq\n"));
+    assert!(!capture.contains("jquake"));
 }
 
 #[cfg(unix)]
@@ -237,7 +273,7 @@ fn test_run_resolves_through_remote_backend() {
             "version": "3.11.9",
             "first_commit_hash": "remote-first",
             "first_commit_date": "2024-01-01T00:00:00Z",
-            "last_commit_hash": "remote-last",
+            "last_commit_hash": "0123456789abcdef0123456789abcdef01234567",
             "last_commit_date": "2024-02-01T00:00:00Z",
             "attribute_path": "python311",
             "description": "Python",
@@ -277,7 +313,7 @@ fn test_run_resolves_through_remote_backend() {
 
     let capture = std::fs::read_to_string(capture_path).unwrap();
     assert!(capture.contains("program=nix\n"));
-    assert!(capture.contains("arg=nixpkgs/remote-last#python311\n"));
+    assert!(capture.contains("arg=nixpkgs/0123456789abcdef0123456789abcdef01234567#python311\n"));
 }
 
 #[cfg(unix)]
@@ -296,7 +332,7 @@ fn test_run_uses_one_legacy_shell_for_mixed_eras() {
             "INSERT INTO package_versions
              (name, version, first_commit_hash, first_commit_date, last_commit_hash,
               last_commit_date, attribute_path, description)
-             VALUES ('legacy-1.0', '1.0', 'old-first', 1500000000, 'old-last',
+             VALUES ('legacy-1.0', '1.0', 'old-first', 1500000000, 'fedcba9876543210fedcba9876543210fedcba98',
                      1500000100, 'legacy', 'Legacy test package')",
             [],
         )
@@ -323,8 +359,8 @@ fn test_run_uses_one_legacy_shell_for_mixed_eras() {
     let capture = std::fs::read_to_string(capture_path).unwrap();
     assert!(capture.contains("program=nix-shell\n"));
     assert!(capture.contains("arg=-p\n"));
-    assert!(capture.contains("archive/old-last.tar.gz"));
-    assert!(capture.contains("archive/vwx1234567890.tar.gz"));
+    assert!(capture.contains("archive/fedcba9876543210fedcba9876543210fedcba98.tar.gz"));
+    assert!(capture.contains("archive/c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3.tar.gz"));
 }
 
 #[cfg(unix)]
@@ -401,6 +437,76 @@ fn test_run_propagates_shell_exit_status_and_insecure_environment() {
     let capture = std::fs::read_to_string(capture_path).unwrap();
     assert!(capture.contains("allow_insecure=1\n"));
     assert!(capture.contains("arg=--impure\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_reports_actionable_error_when_nix_is_unavailable() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let empty_path = dir.path().join("empty-bin");
+    create_test_db(&db_path);
+    std::fs::create_dir(&empty_path).unwrap();
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "python311",
+            "3.11",
+            "--exact",
+        ])
+        .env("PATH", &empty_path)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("`nix`")
+                .and(predicate::str::contains("not found on PATH"))
+                .and(predicate::str::contains("install Nix")),
+        );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_reports_actionable_error_when_nix_shell_is_unavailable() {
+    use rusqlite::Connection;
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let empty_path = dir.path().join("empty-bin");
+    create_test_db(&db_path);
+    Connection::open(&db_path)
+        .unwrap()
+        .execute(
+            "INSERT INTO package_versions
+             (name, version, first_commit_hash, first_commit_date, last_commit_hash,
+              last_commit_date, attribute_path, description)
+             VALUES ('legacy-1.0', '1.0', 'old-first', 1500000000,
+                     'fedcba9876543210fedcba9876543210fedcba98',
+                     1500000100, 'legacy', 'Legacy test package')",
+            [],
+        )
+        .unwrap();
+    std::fs::create_dir(&empty_path).unwrap();
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "legacy",
+            "1.0",
+            "--exact",
+        ])
+        .env("PATH", &empty_path)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("`nix-shell`")
+                .and(predicate::str::contains("not found on PATH"))
+                .and(predicate::str::contains("install Nix")),
+        );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,6 +12,37 @@ fn nxv() -> Command {
     Command::cargo_bin("nxv").unwrap()
 }
 
+#[cfg(unix)]
+fn install_fake_nix_commands(dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = r#"#!/bin/sh
+{
+  printf 'program=%s\n' "$(basename "$0")"
+  printf 'allow_insecure=%s\n' "${NIXPKGS_ALLOW_INSECURE:-}"
+  printf 'arg=%s\n' "$@"
+} > "$NXV_TEST_CAPTURE"
+exit "${NXV_TEST_EXIT_CODE:-0}"
+"#;
+
+    for program in ["nix", "nix-shell"] {
+        let path = dir.join(program);
+        std::fs::write(&path, script).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+}
+
+#[cfg(unix)]
+fn prepend_path(dir: &std::path::Path) -> std::ffi::OsString {
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    std::env::join_paths(paths).unwrap()
+}
+
 /// Creates a SQLite test database at the given path populated with a schema and sample package rows.
 ///
 /// The database will contain `meta` and `package_versions` tables, relevant indexes,
@@ -131,6 +162,245 @@ fn test_help_displays() {
         .stdout(predicate::str::contains("stats"))
         .stdout(predicate::str::contains("history"))
         .stdout(predicate::str::contains("completions"));
+}
+
+// ============================================================================
+// Run Command Tests
+// ============================================================================
+
+#[test]
+fn test_run_help_describes_shell_and_multi_package_options() {
+    nxv()
+        .args(["run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Open a shell"))
+        .stdout(predicate::str::contains("--version"))
+        .stdout(predicate::str::contains("--with"))
+        .stdout(predicate::str::contains("--all-depths"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_launches_one_modern_shell_with_multiple_packages() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bin_path = dir.path().join("bin");
+    let capture_path = dir.path().join("capture.txt");
+    create_test_db(&db_path);
+    std::fs::create_dir(&bin_path).unwrap();
+    install_fake_nix_commands(&bin_path);
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "python",
+            "3.11",
+            "--with",
+            "nodejs@20",
+        ])
+        .env("PATH", prepend_path(&bin_path))
+        .env("NXV_TEST_CAPTURE", &capture_path)
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("Resolved python@3.11 -> python 3.11.0").and(
+                predicate::str::contains("Resolved nodejs@20 -> nodejs 20.0.0"),
+            ),
+        );
+
+    let capture = std::fs::read_to_string(capture_path).unwrap();
+    assert!(capture.contains("program=nix\n"));
+    assert!(capture.contains("arg=shell\n"));
+    assert!(capture.contains("arg=nixpkgs/def1234567890#python\n"));
+    assert!(capture.contains("arg=nixpkgs/vwx1234567890#nodejs\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_resolves_through_remote_backend() {
+    use mockito::Matcher;
+
+    let dir = tempdir().unwrap();
+    let bin_path = dir.path().join("bin");
+    let capture_path = dir.path().join("capture.txt");
+    std::fs::create_dir(&bin_path).unwrap();
+    install_fake_nix_commands(&bin_path);
+
+    let mut server = mockito::Server::new();
+    let response = serde_json::json!({
+        "data": [{
+            "id": 1,
+            "name": "python3",
+            "version": "3.11.9",
+            "first_commit_hash": "remote-first",
+            "first_commit_date": "2024-01-01T00:00:00Z",
+            "last_commit_hash": "remote-last",
+            "last_commit_date": "2024-02-01T00:00:00Z",
+            "attribute_path": "python311",
+            "description": "Python",
+            "license": ["Python-2.0"],
+            "homepage": "https://python.org",
+            "maintainers": [],
+            "platforms": ["x86_64-linux"],
+            "source_path": null,
+            "known_vulnerabilities": null
+        }],
+        "meta": {
+            "total": 1,
+            "limit": 1,
+            "offset": 0,
+            "has_more": false
+        }
+    });
+    let _search_mock = server
+        .mock("GET", "/api/v1/search")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("q".into(), "python".into()),
+            Matcher::UrlEncoded("version".into(), "3.11".into()),
+            Matcher::UrlEncoded("limit".into(), "1".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(response.to_string())
+        .create();
+
+    nxv()
+        .args(["run", "python", "3.11"])
+        .env("NXV_API_URL", server.url())
+        .env("PATH", prepend_path(&bin_path))
+        .env("NXV_TEST_CAPTURE", &capture_path)
+        .assert()
+        .success();
+
+    let capture = std::fs::read_to_string(capture_path).unwrap();
+    assert!(capture.contains("program=nix\n"));
+    assert!(capture.contains("arg=nixpkgs/remote-last#python311\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_uses_one_legacy_shell_for_mixed_eras() {
+    use rusqlite::Connection;
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bin_path = dir.path().join("bin");
+    let capture_path = dir.path().join("capture.txt");
+    create_test_db(&db_path);
+    Connection::open(&db_path)
+        .unwrap()
+        .execute(
+            "INSERT INTO package_versions
+             (name, version, first_commit_hash, first_commit_date, last_commit_hash,
+              last_commit_date, attribute_path, description)
+             VALUES ('legacy-1.0', '1.0', 'old-first', 1500000000, 'old-last',
+                     1500000100, 'legacy', 'Legacy test package')",
+            [],
+        )
+        .unwrap();
+    std::fs::create_dir(&bin_path).unwrap();
+    install_fake_nix_commands(&bin_path);
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "legacy",
+            "1.0",
+            "--exact",
+            "--with",
+            "nodejs@20",
+        ])
+        .env("PATH", prepend_path(&bin_path))
+        .env("NXV_TEST_CAPTURE", &capture_path)
+        .assert()
+        .success();
+
+    let capture = std::fs::read_to_string(capture_path).unwrap();
+    assert!(capture.contains("program=nix-shell\n"));
+    assert!(capture.contains("arg=-p\n"));
+    assert!(capture.contains("archive/old-last.tar.gz"));
+    assert!(capture.contains("archive/vwx1234567890.tar.gz"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_resolves_all_packages_before_launching() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bin_path = dir.path().join("bin");
+    let capture_path = dir.path().join("capture.txt");
+    create_test_db(&db_path);
+    std::fs::create_dir(&bin_path).unwrap();
+    install_fake_nix_commands(&bin_path);
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "python",
+            "--with",
+            "definitely-missing",
+        ])
+        .env("PATH", prepend_path(&bin_path))
+        .env("NXV_TEST_CAPTURE", &capture_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unable to resolve package specification `definitely-missing`",
+        ));
+
+    assert!(
+        !capture_path.exists(),
+        "Nix launched before all queries resolved"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_propagates_shell_exit_status_and_insecure_environment() {
+    use rusqlite::Connection;
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let bin_path = dir.path().join("bin");
+    let capture_path = dir.path().join("capture.txt");
+    create_test_db(&db_path);
+    Connection::open(&db_path)
+        .unwrap()
+        .execute(
+            "UPDATE package_versions
+             SET known_vulnerabilities = '[\"CVE-test\"]'
+             WHERE attribute_path = 'firefox'",
+            [],
+        )
+        .unwrap();
+    std::fs::create_dir(&bin_path).unwrap();
+    install_fake_nix_commands(&bin_path);
+
+    nxv()
+        .args([
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "run",
+            "firefox",
+            "--exact",
+        ])
+        .env("PATH", prepend_path(&bin_path))
+        .env("NXV_TEST_CAPTURE", &capture_path)
+        .env("NXV_TEST_EXIT_CODE", "42")
+        .assert()
+        .code(42)
+        .stderr(predicate::str::contains("known vulnerabilities"));
+
+    let capture = std::fs::read_to_string(capture_path).unwrap();
+    assert!(capture.contains("allow_insecure=1\n"));
+    assert!(capture.contains("arg=--impure\n"));
 }
 
 #[test]

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -77,6 +77,47 @@ suggestions and indicate when deeper matches are available. Successful JSON
 searches keep returning an array of package rows; an empty miss emits no stdout.
 Diagnostics stay on stderr in either case.
 
+### run
+
+Resolve indexed package versions and open one interactive shell containing
+them.
+
+```bash
+nxv run <PACKAGE> [VERSION] [options]
+```
+
+**Options:**
+
+| Flag                         | Description                                   |
+| ---------------------------- | --------------------------------------------- |
+| `-V, --version <VERSION>`    | Primary version (alternative to positional)   |
+| `-e, --exact`                | Match exact attribute paths for every package |
+| `--all-depths`               | Include nested depths in version searches     |
+| `--with <PACKAGE[@VERSION]>` | Add another package; may be repeated           |
+
+**Examples:**
+
+```bash
+# Open a shell with the best Python 2.7 match
+nxv run python 2.7
+
+# Combine independently pinned package versions
+nxv run python 3.11 --with nodejs@20 --with jq
+
+# Require exact attribute paths
+nxv run python311 3.11 --exact --with nodejs@20
+```
+
+Each query uses the same relevance and shallowest-depth rules as
+[`search`](#search). nxv resolves every package before launching anything,
+selects the first deterministic match, and pins its latest observed commit.
+Modern revisions are passed as separate installables to one `nix shell`
+process. If any selected revision predates flakes, nxv instead creates one
+compatible `nix-shell -p` environment using pinned `fetchTarball` expressions.
+
+Known-insecure selections are called out before launch and automatically receive
+the Nix setting needed to evaluate them. If any query misses, no shell starts.
+
 ### info
 
 Show detailed information about a specific package version.

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -108,12 +108,14 @@ nxv run python 3.11 --with nodejs@20 --with jq
 nxv run python311 3.11 --exact --with nodejs@20
 ```
 
-Each query uses the same relevance and shallowest-depth rules as
-[`search`](#search). nxv resolves every package before launching anything,
-selects the first deterministic match, and pins its latest observed commit.
-Modern revisions are passed as separate installables to one `nix shell`
-process. If any selected revision predates flakes, nxv instead creates one
-compatible `nix-shell -p` environment using pinned `fetchTarball` expressions.
+Each query prefers an exact attribute match, then falls back to the same
+relevance and shallowest-depth rules as [`search`](#search). nxv resolves every
+package before launching anything, selects the first deterministic match, and
+pins its latest observed commit. Modern revisions are passed as separate
+installables to one `nix shell` process. If any selected revision predates
+flakes, nxv instead creates one compatible `nix-shell -p` environment using
+pinned `fetchTarball` expressions. On Apple Silicon, pre-flake environments are
+evaluated as `x86_64-darwin` and require Rosetta.
 
 Known-insecure selections are called out before launch and automatically receive
 the Nix setting needed to evaluate them. If any query misses, no shell starts.

--- a/website/guide/skill.md
+++ b/website/guide/skill.md
@@ -144,9 +144,11 @@ nxv run python 2.7
 nxv run python 3.11 --with nodejs@20 --with jq
 ```
 
-`run` resolves every query first, chooses the best deterministic search result,
-and launches one pinned shell. It also handles pre-flake revisions and known
-insecure packages using the appropriate Nix invocation.
+`run` resolves every query first, prefers an exact attribute before falling
+back to deterministic search relevance, and launches one pinned shell. It also
+handles pre-flake revisions and known insecure packages using the appropriate
+Nix invocation. On Apple Silicon, pre-flake shells use `x86_64-darwin` and
+require Rosetta.
 
 Example agent pattern — generate a `nix shell` invocation for a specific version
 directly from the public API:

--- a/website/guide/skill.md
+++ b/website/guide/skill.md
@@ -94,6 +94,8 @@ directly:
 ```
 /nxv search python 2.7
 /nxv search python 2.7.3 --all-depths
+/nxv run python 2.7
+/nxv run python 3.11 --with nodejs@20 --with jq
 /nxv info python311 3.11.4
 /nxv history nodejs-15_x
 ```
@@ -104,6 +106,8 @@ question matches its description:
 > "Which nixpkgs commit had python 2.7?"
 >
 > "Give me the `nix shell` command for nodejs 15.14."
+>
+> "Open a shell with Python 3.11 and Node.js 20."
 >
 > "When was ruby 2.6 last in nixpkgs?"
 
@@ -132,6 +136,17 @@ attribute-path tier first. If no version matches, API consumers should inspect
 `all_depths=true` only when nested package-set matches are intentional.
 Successful CLI JSON searches return an array; an empty miss emits no stdout,
 with the miss explanation written to stderr.
+
+For an interactive environment, agents can skip command construction entirely:
+
+```bash
+nxv run python 2.7
+nxv run python 3.11 --with nodejs@20 --with jq
+```
+
+`run` resolves every query first, chooses the best deterministic search result,
+and launches one pinned shell. It also handles pre-flake revisions and known
+insecure packages using the appropriate Nix invocation.
 
 Example agent pattern — generate a `nix shell` invocation for a specific version
 directly from the public API:


### PR DESCRIPTION
## Summary

- add `nxv run <PACKAGE> [VERSION]` with exact-first deterministic resolution, `--with` multi-package environments, and local/remote backend support
- launch modern packages with `nix shell` and historical or mixed-era packages with a single pinned `nix-shell`, including insecure-package handling and Apple Silicon Rosetta compatibility
- add dynamic Bash, Zsh, and Fish completion support plus CLI, README, website, and generated skill documentation
- harden launch errors, commit hash validation, quoted Nix attributes, and all-packages-before-launch behavior

## Validation

- `env -u NO_COLOR nix develop -c ci-local` — 416 unit tests passed, 1 ignored; 112 integration tests passed
- `nix flake check`
- `docs-build`
- generated skill mirror parity checks
- real Bash, Zsh, and Fish completion smoke tests, including repeated `--with` and global root options
- real modern shell smoke: Python 3.11 plus jq
- real historical shell smoke: Python 2.7 plus jq
- real pre-flake mixed shell smoke on Apple Silicon: jq 1.5 plus hello via Rosetta