### PR TITLE
fix(cli): accept conventional boolean environment values

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -53,7 +53,7 @@ Every CLI invocation accepts:
 | `--db-path <PATH>`     | Path to the index database (default: platform data dir)     |
 | `-v, --verbose`        | `-v` info, `-vv` debug (SQL queries, HTTP requests)         |
 | `-q, --quiet`          | Suppress all output except errors                           |
-| `--no-color`           | Disable colored output (also honors `NO_COLOR`)             |
+| `--no-color`           | Disable colored output (also honors any non-empty `NO_COLOR`) |
 | `--api-timeout <SECS>` | API request timeout when using remote backend (default: 30) |
 
 ## Local vs Remote Backend
@@ -435,14 +435,14 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv sync`                           |
 | `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
 | `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
-| `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
+| `NXV_SKIP_VERIFY`    | `1`/`true`/`yes`/`on` skip; `0`/`false`/`no`/`off` do not (INSECURE)   |
 | `NXV_VERSION`        | Pin the version installed by `install.sh` (self-update targets latest) |
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
 | `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
 | `NXV_RATE_LIMIT_BURST` | `nxv serve` per-IP rate-limit burst size (default: 2x rate_limit)    |
 | `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
-| `NO_COLOR`           | Disable ANSI colors                                                    |
+| `NO_COLOR`           | Disable ANSI colors when set to any non-empty value                    |
 
 ## Data Paths
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -53,7 +53,7 @@ Every CLI invocation accepts:
 | `--db-path <PATH>`     | Path to the index database (default: platform data dir)     |
 | `-v, --verbose`        | `-v` info, `-vv` debug (SQL queries, HTTP requests)         |
 | `-q, --quiet`          | Suppress all output except errors                           |
-| `--no-color`           | Disable colored output (also honors `NO_COLOR`)             |
+| `--no-color`           | Disable colored output (also honors any non-empty `NO_COLOR`) |
 | `--api-timeout <SECS>` | API request timeout when using remote backend (default: 30) |
 
 ## Local vs Remote Backend
@@ -435,14 +435,14 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv sync`                           |
 | `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
 | `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
-| `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
+| `NXV_SKIP_VERIFY`    | `1`/`true`/`yes`/`on` skip; `0`/`false`/`no`/`off` do not (INSECURE)   |
 | `NXV_VERSION`        | Pin the version installed by `install.sh` (self-update targets latest) |
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
 | `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
 | `NXV_RATE_LIMIT_BURST` | `nxv serve` per-IP rate-limit burst size (default: 2x rate_limit)    |
 | `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
-| `NO_COLOR`           | Disable ANSI colors                                                    |
+| `NO_COLOR`           | Disable ANSI colors when set to any non-empty value                    |
 
 ## Data Paths
 

--- a/README.md
+++ b/README.md
@@ -571,9 +571,9 @@ The `manifest.json` format:
 | `NXV_MANIFEST_URL` | Custom manifest URL for index downloads |
 | `NXV_PUBLIC_KEY` | Custom public key for manifest verification (path or raw key) |
 | `NXV_SECRET_KEY` | Secret key for manifest signing (path or raw key content) |
-| `NXV_SKIP_VERIFY` | Skip manifest signature verification (set to any value) |
+| `NXV_SKIP_VERIFY` | Skip signature verification with `1`/`true`/`yes`/`on`; `0`/`false`/`no`/`off` keep it enabled |
 | `NXV_API_TIMEOUT` | API request timeout in seconds (default: 30) |
-| `NO_COLOR` | Disable colored output |
+| `NO_COLOR` | Disable colored output when set to any non-empty value |
 | `NXV_HOST` | `nxv serve` bind address (default: `127.0.0.1`) |
 | `NXV_PORT` | `nxv serve` port (default: `8080`) |
 | `NXV_RATE_LIMIT` | `nxv serve` max requests per second per IP |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Cli {
     pub quiet: bool,
 
     /// Disable colored output.
-    #[arg(long, env = "NO_COLOR")]
+    #[arg(long)]
     pub no_color: bool,
 
     /// API request timeout in seconds (when using remote backend).
@@ -411,7 +411,12 @@ pub struct SyncArgs {
     pub manifest_url: Option<String>,
 
     /// Skip manifest signature verification (INSECURE - use only for development/testing).
-    #[arg(long, env = "NXV_SKIP_VERIFY")]
+    #[arg(
+        long,
+        env = "NXV_SKIP_VERIFY",
+        action = clap::ArgAction::SetTrue,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
     pub skip_verify: bool,
 
     /// Custom public key for manifest signature verification (for self-hosted indexes).
@@ -886,6 +891,45 @@ mod tests {
             }
             _ => panic!("Expected Sync command"),
         }
+    }
+
+    #[test]
+    fn test_sync_skip_verify_flag() {
+        let args = Cli::try_parse_from(["nxv", "sync", "--skip-verify"]).unwrap();
+        match args.command {
+            Commands::Sync(sync) => assert!(sync.skip_verify),
+            _ => panic!("Expected Sync command"),
+        }
+    }
+
+    #[test]
+    fn test_sync_skip_verify_boolish_value_parser() {
+        use clap::builder::TypedValueParser;
+
+        let command = clap::Command::new("nxv");
+        let parser = clap::builder::BoolishValueParser::new();
+        for (value, expected) in [
+            ("1", true),
+            ("true", true),
+            ("yes", true),
+            ("on", true),
+            ("0", false),
+            ("false", false),
+            ("no", false),
+            ("off", false),
+        ] {
+            assert_eq!(
+                parser
+                    .parse_ref(&command, None, std::ffi::OsStr::new(value))
+                    .unwrap(),
+                expected
+            );
+        }
+        assert!(
+            parser
+                .parse_ref(&command, None, std::ffi::OsStr::new("sometimes"))
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,10 @@ fn main() {
     // literal `~` directory.
     cli.db_path = paths::expand_tilde(&cli.db_path);
 
-    // Handle no-color flag
-    if cli.no_color {
+    // NO_COLOR follows the cross-CLI convention: any non-empty value disables
+    // color, regardless of its contents. Parse it separately from clap so
+    // conventional values such as NO_COLOR=1 are not treated as bool literals.
+    if cli.no_color || no_color_env_disables(std::env::var_os("NO_COLOR").as_deref()) {
         // Disable colors globally - this affects if_supports_color() calls
         owo_colors::set_override(false);
     }
@@ -111,6 +113,10 @@ fn main() {
         }
         std::process::exit(1);
     }
+}
+
+fn no_color_env_disables(value: Option<&std::ffi::OsStr>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
 }
 
 /// Resolve package queries and replace nxv with a pinned Nix shell.
@@ -1592,4 +1598,23 @@ fn cmd_serve(cli: &Cli, args: &cli::ServeArgs) -> Result<()> {
     rt.block_on(run_server(config))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod no_color_tests {
+    use super::no_color_env_disables;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn non_empty_no_color_values_disable_color_regardless_of_contents() {
+        for value in ["1", "0", "true", "false", "always"] {
+            assert!(no_color_env_disables(Some(OsStr::new(value))));
+        }
+    }
+
+    #[test]
+    fn missing_or_empty_no_color_does_not_disable_color() {
+        assert!(!no_color_env_disables(None));
+        assert!(!no_color_env_disables(Some(OsStr::new(""))));
+    }
 }

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -53,7 +53,7 @@ Every CLI invocation accepts:
 | `--db-path <PATH>`     | Path to the index database (default: platform data dir)     |
 | `-v, --verbose`        | `-v` info, `-vv` debug (SQL queries, HTTP requests)         |
 | `-q, --quiet`          | Suppress all output except errors                           |
-| `--no-color`           | Disable colored output (also honors `NO_COLOR`)             |
+| `--no-color`           | Disable colored output (also honors any non-empty `NO_COLOR`) |
 | `--api-timeout <SECS>` | API request timeout when using remote backend (default: 30) |
 
 ## Local vs Remote Backend
@@ -435,14 +435,14 @@ Most users never need these — they consume a pre-built published index via `nx
 | `NXV_MANIFEST_URL`   | Override the manifest URL used by `nxv sync`                           |
 | `NXV_PUBLIC_KEY`     | Public key for manifest verification (path or raw key)                 |
 | `NXV_SECRET_KEY`     | Secret key for `nxv publish --sign` (path or raw content)              |
-| `NXV_SKIP_VERIFY`    | Skip minisign signature check (INSECURE — dev/testing only)            |
+| `NXV_SKIP_VERIFY`    | `1`/`true`/`yes`/`on` skip; `0`/`false`/`no`/`off` do not (INSECURE)   |
 | `NXV_VERSION`        | Pin the version installed by `install.sh` (self-update targets latest) |
 | `NXV_HOST`           | `nxv serve` bind host                                                  |
 | `NXV_PORT`           | `nxv serve` listen port                                                |
 | `NXV_RATE_LIMIT`     | `nxv serve` per-IP rate limit (req/sec)                                |
 | `NXV_RATE_LIMIT_BURST` | `nxv serve` per-IP rate-limit burst size (default: 2x rate_limit)    |
 | `NXV_FRONTEND_DIR`   | `nxv serve` reads frontend assets from disk on every request (dev mode)|
-| `NO_COLOR`           | Disable ANSI colors                                                    |
+| `NO_COLOR`           | Disable ANSI colors when set to any non-empty value                    |
 
 ## Data Paths
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1533,6 +1533,20 @@ fn test_no_color_option() {
 }
 
 #[test]
+fn test_no_color_environment_accepts_conventional_value() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    create_test_db(&db_path);
+
+    nxv()
+        .args(["--db-path", db_path.to_str().unwrap(), "search", "python"])
+        .env("NO_COLOR", "1")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("python"));
+}
+
+#[test]
 fn test_verbose_conflicts_with_quiet() {
     nxv()
         .args(["-v", "-q", "stats"])
@@ -2721,6 +2735,7 @@ fn test_sync_fails_without_signature_when_verify_enabled() {
             "--manifest-url",
             &manifest_url,
         ])
+        .env("NXV_SKIP_VERIFY", "0")
         .assert()
         .failure()
         .stderr(
@@ -2797,17 +2812,17 @@ fn test_sync_skip_verify_shows_warning() {
     let bloom_path = dir.path().join("index.bloom");
     let manifest_url = format!("{}/manifest.json", server.url());
 
-    // Update with --skip-verify should succeed but show a warning
+    // NXV_SKIP_VERIFY=1 should succeed but show the same warning as --skip-verify.
     nxv()
         .args([
             "--db-path",
             db_path.to_str().unwrap(),
             "sync",
-            "--skip-verify",
             "--manifest-url",
             &manifest_url,
         ])
         .env("NXV_BLOOM_PATH", bloom_path.to_str().unwrap())
+        .env("NXV_SKIP_VERIFY", "1")
         .assert()
         .success()
         .stderr(predicate::str::contains(
@@ -2817,7 +2832,7 @@ fn test_sync_skip_verify_shows_warning() {
     // Database should be created
     assert!(
         db_path.exists(),
-        "Database should be created with --skip-verify"
+        "Database should be created with NXV_SKIP_VERIFY=1"
     );
 }
 

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -9,7 +9,7 @@ Complete documentation for all nxv commands and options.
 | `--db-path <DB_PATH>`  | Path to the index database (default: platform data dir) |
 | `-v, --verbose...`     | Enable verbose output (`-v` info, `-vv` debug)          |
 | `-q, --quiet`          | Suppress all output except errors                       |
-| `--no-color`           | Disable colored output (also: `NO_COLOR` env)           |
+| `--no-color`           | Disable colored output (also: any non-empty `NO_COLOR`) |
 | `--api-timeout <SECS>` | API request timeout in seconds (default: 30)            |
 | `-h, --help`           | Print help                                              |
 | `-V, --version`        | Print version                                           |

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -24,11 +24,11 @@ the index.
 
 ### Index Updates
 
-| Variable           | Description                                 | Default         |
-| ------------------ | ------------------------------------------- | --------------- |
-| `NXV_MANIFEST_URL` | Custom manifest URL for index downloads     | GitHub releases |
-| `NXV_PUBLIC_KEY`   | Custom public key for manifest verification | Built-in key    |
-| `NXV_SKIP_VERIFY`  | Skip manifest signature verification        | `false`         |
+| Variable           | Description                                                                                     | Default         |
+| ------------------ | ----------------------------------------------------------------------------------------------- | --------------- |
+| `NXV_MANIFEST_URL` | Custom manifest URL for index downloads                                                         | GitHub releases |
+| `NXV_PUBLIC_KEY`   | Custom public key for manifest verification                                                     | Built-in key    |
+| `NXV_SKIP_VERIFY`  | Skip manifest signature verification with `1`/`true`/`yes`/`on`; `0`/`false`/`no`/`off` keep verification enabled | `false`         |
 
 These index variables apply to `nxv sync`. `nxv update` only updates the
 application and does not read index configuration.
@@ -62,9 +62,9 @@ These only apply to builds with the `indexer` feature:
 
 ### Output
 
-| Variable   | Description            | Default |
-| ---------- | ---------------------- | ------- |
-| `NO_COLOR` | Disable colored output | Not set |
+| Variable   | Description                                            | Default |
+| ---------- | ------------------------------------------------------ | ------- |
+| `NO_COLOR` | Disable colored output when set to any non-empty value | Not set |
 
 ## Data Directories
 


### PR DESCRIPTION
## Summary

- honor the `NO_COLOR` convention by treating every non-empty value as disabling color
- accept `1`/`0`, `true`/`false`, `yes`/`no`, and `on`/`off` for `NXV_SKIP_VERIFY` while rejecting unknown values
- add unit and end-to-end regression coverage for the reported `NO_COLOR=1` failure and signature-verification behavior
- update the README, CLI/configuration guides, canonical agent skill, and generated skill mirrors

## Verification

- `NO_COLOR=1 nix develop -c ci-local`
  - 419 unit tests passed, 1 ignored
  - 113 integration tests passed
- `git diff --check`
- canonical/Claude/Agents skill copies byte-match
- independent subagent peer review completed; all findings addressed and final review clean