### PR TITLE
fix(nix): use `nxv sync` to refresh the index in the NixOS module

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -295,7 +295,7 @@ in
           manifestArgs = lib.optionalString (cfg.manifestUrl != null) "--manifest-url ${cfg.manifestUrl}";
           publicKeyArgs = lib.optionalString (cfg.publicKey != null) "--public-key ${toString cfg.publicKey}";
           skipVerifyArgs = lib.optionalString cfg.skipVerify "--skip-verify";
-          updateArgs = lib.concatStringsSep " " (
+          syncArgs = lib.concatStringsSep " " (
             lib.filter (s: s != "") [
               manifestArgs
               publicKeyArgs
@@ -317,7 +317,7 @@ in
           ExecStartPre = pkgs.writeShellScript "nxv-bootstrap" ''
             if [ ! -f "${cfg.dataDir}/index.db" ]; then
               echo "Database not found, downloading index..."
-              ${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db update ${updateArgs}
+              ${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db sync ${syncArgs}
             fi
           '';
           ExecStart = ''
@@ -369,7 +369,7 @@ in
           manifestArgs = lib.optionalString (cfg.manifestUrl != null) "--manifest-url ${cfg.manifestUrl}";
           publicKeyArgs = lib.optionalString (cfg.publicKey != null) "--public-key ${toString cfg.publicKey}";
           skipVerifyArgs = lib.optionalString cfg.skipVerify "--skip-verify";
-          updateArgs = lib.concatStringsSep " " (
+          syncArgs = lib.concatStringsSep " " (
             lib.filter (s: s != "") [
               manifestArgs
               publicKeyArgs
@@ -381,7 +381,8 @@ in
           Type = "oneshot";
           User = cfg.user;
           Group = cfg.group;
-          ExecStart = "${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db update ${updateArgs}";
+          # `nxv update` self-updates the binary; `nxv sync` refreshes the index.
+          ExecStart = "${cfg.package}/bin/nxv --db-path ${cfg.dataDir}/index.db sync ${syncArgs}";
 
           # Hardening options
           NoNewPrivileges = true;


### PR DESCRIPTION
`nxv update` now only self-updates the application; `nxv sync` refreshes the package index. The NixOS module was never updated for that split, so:

- `systemd.services.nxv-update` (hourly timer) ran `nxv … update`, which on a Nix install prints "installed via Nix / a newer release is available" and exits **0**. The unit stayed green forever while the index went stale.
- The `nxv-bootstrap` `ExecStartPre` had the same bug, so a fresh deploy would never download an initial index.
- `--manifest-url` / `--public-key` / `--skip-verify` were spliced into `update`, which does not accept them — setting `manifestUrl` or `publicKey` would have made the unit fail on unknown args.

Observed on nxv.urandom.io: index last refreshed 2026-07-23 while the timer reported success every hour for 18 days.

Renames `updateArgs` -> `syncArgs` to match.