### PR TITLE
fix: scope insecure flag by package name, not version string

### DIFF
--- a/.agents/skills/nxv/SKILL.md
+++ b/.agents/skills/nxv/SKILL.md
@@ -195,9 +195,17 @@ nxv history python311 --format json
   "version": "3.11.4",
   "first_seen": "2023-06-15T00:00:00+00:00",
   "last_seen": "2023-12-01T00:00:00+00:00",
-  "is_insecure": false
+  "is_insecure": false,
+  "known_vulnerabilities": null
 }
 ```
+
+`is_insecure` means nixpkgs reports a known advisory for that software version,
+resolved by package **name** so every attribute packaging the same build agrees
+(`emacs` and `emacs28` at 28.2 are both flagged). It does not tell you whether
+nix will refuse to build a specific attribute at a specific revision — for that,
+name the version (`nxv history <pkg> <version>`) and read its own
+`known_vulnerabilities`.
 
 Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Like the compact timeline, bare `--full` resolves the package by its exact installable `attribute_path`.
 

--- a/.claude/skills/nxv/SKILL.md
+++ b/.claude/skills/nxv/SKILL.md
@@ -195,9 +195,17 @@ nxv history python311 --format json
   "version": "3.11.4",
   "first_seen": "2023-06-15T00:00:00+00:00",
   "last_seen": "2023-12-01T00:00:00+00:00",
-  "is_insecure": false
+  "is_insecure": false,
+  "known_vulnerabilities": null
 }
 ```
+
+`is_insecure` means nixpkgs reports a known advisory for that software version,
+resolved by package **name** so every attribute packaging the same build agrees
+(`emacs` and `emacs28` at 28.2 are both flagged). It does not tell you whether
+nix will refuse to build a specific attribute at a specific revision — for that,
+name the version (`nxv history <pkg> <version>`) and read its own
+`known_vulnerabilities`.
 
 Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Like the compact timeline, bare `--full` resolves the package by its exact installable `attribute_path`.
 

--- a/docs/indexer-rewrite/DESIGN.md
+++ b/docs/indexer-rewrite/DESIGN.md
@@ -65,11 +65,16 @@ a commit that has version X" — always gets a true endpoint.
     typically **hours behind master** (measured 9h vs 1.4d for
     nixpkgs-unstable). Ingested from where its packages.json exists.
 - **Source selection is a per-release probe**: every release tries
-  `packages.json.br` first and falls back to nix-env on 404 — never decided
-  by date or prefix (the boundary is mid-`20.09pre`, and 198 releases were
-  renamed `21.03pre` before becoming `21.05pre`). The plan-time date guess
-  is only a worklist hint (`--backfill-evals` filtering); the ledger source
-  is corrected to the mechanism that actually produced the data.
+  `packages.json.br` first and, under `--backfill-evals`, falls back to
+  nix-env on 404 — never decided by date or prefix (the boundary is
+  mid-`20.09pre`, and 198 releases were renamed `21.03pre` before becoming
+  `21.05pre`). Without that flag a 404 parks the release as `skipped` rather
+  than starting an evaluation the run did not ask for. The plan-time date
+  guess is only a worklist hint, and it must stay permissive enough that the
+  probe actually runs: the filter excludes only releases dated before the
+  first known artifact (2020-03-27), not every date-guessed nix-env row.
+  The ledger source is corrected to the mechanism that actually produced the
+  data.
 - **Parsing requirements** (all verified the hard way):
   - Event-based XML parsing (quick-xml) per `<Contents>` block with
     optional elements — post-Feb-2025 objects embed

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -57,7 +57,7 @@
     health: null,
     reqSeq: 0,
     historyCache: new Map(),
-    firstHashCache: new Map(),
+    firstRowCache: new Map(),
     renderedRows: [], // cached for instant view-switch on toggle
     resolution: null,
   };
@@ -787,12 +787,16 @@
             : legacy
               ? ' text-[var(--color-amber-glow)]'
               : ' text-[var(--color-fog-0)]';
+          const vulns = parseJsonArrayOrString(v.vulnerabilities);
+          const vulnTitle = escapeHtml(
+            vulns.length ? vulns.join(' · ') : 'known vulnerabilities'
+          );
           return `
             <li class="grid grid-cols-[minmax(90px,auto)_1fr_auto] items-center gap-4 px-3 py-2 rounded-[7px] hover:bg-[var(--color-ink-2)] transition">
               <span class="mono text-[12.5px]${tag} tabular-nums">${escapeHtml(v.version)}</span>
               <span class="mono text-[11px] text-[var(--color-fog-3)] tabular-nums">${fmtDate(v.first_seen)}<span class="text-[var(--color-ink-4)] mx-2">→</span>${fmtDate(v.last_seen)}</span>
               <span class="flex items-center gap-2">
-                ${v.is_insecure ? '<span class="chip danger" style="font-size:10px; padding:1px 5px;">insecure</span>' : ''}
+                ${v.is_insecure ? `<span class="chip danger" style="font-size:10px; padding:1px 5px;" title="${vulnTitle}">insecure</span>` : ''}
                 ${legacy ? '<span class="chip warn" style="font-size:10px; padding:1px 5px;">pre-flakes</span>' : ''}
                 <button class="btn btn-ghost" data-history-copy="${idx}" title="copy flake ref">copy</button>
               </span>
@@ -806,12 +810,13 @@
           if (!v) return;
           b.textContent = '…';
           try {
-            const hash = await fetchFirstHash(r.attr, v.version);
+            const row = await fetchFirstOccurrence(r.attr, v.version);
+            const rowVulns = parseJsonArrayOrString(row.known_vulnerabilities);
             const synth = {
               attr: r.attr,
-              hash,
+              hash: row.first_commit_hash || '',
               last: v.last_seen,
-              insecure: v.is_insecure ? ['insecure'] : null,
+              insecure: rowVulns.length ? rowVulns : null,
               legacy: predatesFlakes(v.last_seen),
             };
             copy(buildFlakeCmd(synth));
@@ -849,15 +854,20 @@
     return versions;
   }
 
-  async function fetchFirstHash(attr, version) {
+  // Returns the first-occurrence row, not just its hash: the copied flake
+  // command needs this row's own known_vulnerabilities to decide on
+  // NIXPKGS_ALLOW_INSECURE. The history entry's `is_insecure` is a broader
+  // question (does this software version have an advisory at all), so it is the
+  // wrong input for a command that has to match what nix does at that revision.
+  async function fetchFirstOccurrence(attr, version) {
     const key = `${attr}::${version}`;
-    if (STATE.firstHashCache.has(key)) return STATE.firstHashCache.get(key);
+    if (STATE.firstRowCache.has(key)) return STATE.firstRowCache.get(key);
     const { json } = await api(
       `${API_BASE}/packages/${encodeURIComponent(attr)}/versions/${encodeURIComponent(version)}/first`
     );
-    const hash = json?.data?.first_commit_hash || '';
-    STATE.firstHashCache.set(key, hash);
-    return hash;
+    const row = json?.data || {};
+    STATE.firstRowCache.set(key, row);
+    return row;
   }
 
   function drawTimeline(history) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -815,6 +815,10 @@
             const synth = {
               attr: r.attr,
               hash: row.first_commit_hash || '',
+              // buildFlakeCmd prefers lastHash: first_commit_hash can predate
+              // flakes even when the version's last-seen commit does not
+              // (issue #21). The row carries it, so pass it through.
+              lastHash: row.last_commit_hash || '',
               last: v.last_seen,
               insecure: rowVulns.length ? rowVulns : null,
               legacy: predatesFlakes(v.last_seen),

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,12 @@ struct ApiVersionHistoryEntry {
     #[serde(default)]
     is_insecure: bool,
     /// The advisory JSON array, when the server reports one.
-    #[serde(default)]
+    ///
+    /// `deserialize_opt` accepts both the array a current server sends and the
+    /// bare string older fixtures carry. Without it `#[serde(default)]` covers
+    /// only a *missing* field, and every package with an advisory fails to
+    /// decode — taking the whole `nxv history` command down with it.
+    #[serde(default, deserialize_with = "crate::db::json_array::deserialize_opt")]
     vulnerabilities: Option<String>,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,9 +32,10 @@ struct PaginationMeta {
 
 /// Version history entry from API (for deserialization).
 ///
-/// Note: `is_insecure` uses `#[serde(default)]` to default to `false` when
-/// connecting to older API versions that don't include this field. This ensures
-/// backwards compatibility - older servers simply report all versions as secure.
+/// Note: both advisory fields use `#[serde(default)]` so older servers stay
+/// usable — they simply report every version as secure. `vulnerabilities` was
+/// added alongside the advisory-scope fix; a server that predates it still sends
+/// `is_insecure`, which is enough to render the flag without the advisory text.
 #[derive(Debug, Deserialize)]
 struct ApiVersionHistoryEntry {
     version: String,
@@ -44,6 +45,9 @@ struct ApiVersionHistoryEntry {
     /// for backwards compatibility with older API versions.
     #[serde(default)]
     is_insecure: bool,
+    /// The advisory JSON array, when the server reports one.
+    #[serde(default)]
+    vulnerabilities: Option<String>,
 }
 
 /// HTTP client for the nxv API.
@@ -345,15 +349,18 @@ impl ApiClient {
     ///
     /// # Returns
     ///
-    /// A vector of `VersionHistoryEntry` tuples in the form `(version, first_seen, last_seen, is_insecure)`.
+    /// A vector of `VersionHistoryEntry` records.
     ///
     /// # Examples
     ///
     /// ```
     /// let client = ApiClient::new("https://nxv.example.com").unwrap();
     /// let history = client.get_version_history("org/package").unwrap();
-    /// for (version, first_seen, last_seen, is_insecure) in history {
-    ///     println!("{}: {} - {} (insecure: {})", version, first_seen, last_seen, is_insecure);
+    /// for entry in history {
+    ///     println!(
+    ///         "{}: {} - {} (insecure: {})",
+    ///         entry.version, entry.first_seen, entry.last_seen, entry.is_insecure()
+    ///     );
     /// }
     /// ```
     pub fn get_version_history(&self, attr: &str) -> Result<Vec<VersionHistoryEntry>> {
@@ -367,7 +374,18 @@ impl ApiClient {
             Ok(response) => Ok(response
                 .data
                 .into_iter()
-                .map(|e| (e.version, e.first_seen, e.last_seen, e.is_insecure))
+                .map(|e| {
+                    let mut entry = VersionHistoryEntry::from_advisory(
+                        e.version,
+                        e.first_seen,
+                        e.last_seen,
+                        e.vulnerabilities,
+                    );
+                    // A server predating the advisory field sends `is_insecure`
+                    // alone; keep the flag rather than silently dropping it.
+                    entry.insecure |= e.is_insecure;
+                    entry
+                })
                 .collect()),
             Err(NxvError::PackageNotFound(_)) => Ok(Vec::new()),
             Err(e) => Err(e),

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -305,11 +305,16 @@ impl PackageVersion {
 /// Whether a stored `known_vulnerabilities` value represents a real advisory.
 ///
 /// The column holds a JSON array, but nixpkgs eras and ingestion paths spell "no
-/// advisory" three different ways — SQL `NULL`, the empty string, `[]`, and the
-/// literal `null`. This is the single definition of "insecure"; the SQL in
-/// [`get_version_history`] mirrors it with matching `NOT IN` predicates.
+/// advisory" several ways — SQL `NULL`, the empty string, whitespace, `[]`, and
+/// the `null` / `None` sentinels. Deferring to [`json_array::parse`] keeps this
+/// answer identical to what the value actually renders as, so a version can
+/// never be flagged insecure and then display an empty advisory list.
+///
+/// This is the single definition of "insecure". The SQL in
+/// [`get_version_history`] approximates it with `NOT IN ('', '[]', 'null')` as a
+/// cheap pre-filter; anything that slips through is dropped here.
 pub fn has_vulnerabilities(value: Option<&str>) -> bool {
-    value.is_some_and(|v| !v.is_empty() && v != "[]" && v != "null")
+    value.is_some_and(|v| !super::json_array::parse(v).is_empty())
 }
 
 /// Per-channel snapshot ingestion coverage (schema v4 indexes).
@@ -902,7 +907,9 @@ pub fn get_version_history(
                          AND iv.version = pv.version
                          AND iv.known_vulnerabilities IS NOT NULL
                          AND iv.known_vulnerabilities NOT IN ('', '[]', 'null')
-                       ORDER BY iv.last_commit_date DESC
+                       -- attribute_path breaks last_commit_date ties so the
+                       -- same index always answers with the same advisory.
+                       ORDER BY iv.last_commit_date DESC, iv.attribute_path ASC
                        LIMIT 1
                    )
                ) as vulnerabilities
@@ -961,23 +968,37 @@ fn get_version_history_grouped(
     // Pre-v4 indexes hold several rows per (attribute_path, version), so the advisory
     // is aggregated rather than read off a single row. Scoped by (name, version) for
     // the same reasons as the v4 query above.
+    //
+    // The CTE is restricted to the names this attribute path actually uses. Without
+    // that it groups the whole table on every call — the partial vulnerability index
+    // is keyed on version alone, so adding `name` forces a full materialization
+    // (measured: 19 s per call on a 1.8M-row index, against 0.4 s restricted).
+    //
+    // MAX() picks lexicographically when one (name, version) carries several
+    // distinct advisory texts. That is deterministic but not the newest-wins rule
+    // the v4 query uses; the two can only disagree on a genuine tie, and pre-v4
+    // indexes are read-only legacy.
     let sql = if has_vulnerabilities_column {
         r#"
         WITH insecure_packages AS (
             SELECT name, version, MAX(known_vulnerabilities) as vulnerabilities
             FROM package_versions
-            WHERE known_vulnerabilities IS NOT NULL
+            WHERE name IN (SELECT name FROM package_versions WHERE attribute_path = ?1)
+              AND known_vulnerabilities IS NOT NULL
               AND known_vulnerabilities NOT IN ('', '[]', 'null')
             GROUP BY name, version
         )
         SELECT pv.version,
                MIN(pv.first_commit_date) as first_seen,
                MAX(pv.last_commit_date) as last_seen,
-               MAX(iv.vulnerabilities) as vulnerabilities
+               COALESCE(
+                   MAX(NULLIF(NULLIF(NULLIF(pv.known_vulnerabilities, ''), '[]'), 'null')),
+                   MAX(iv.vulnerabilities)
+               ) as vulnerabilities
         FROM package_versions pv
         LEFT JOIN insecure_packages iv
                ON iv.name = pv.name AND iv.version = pv.version
-        WHERE pv.attribute_path = ?
+        WHERE pv.attribute_path = ?1
         GROUP BY pv.version
         ORDER BY first_seen DESC
         "#
@@ -1979,6 +2000,31 @@ mod tests {
             let history = get_version_history(&conn, attr).unwrap();
             assert!(!history[0].is_insecure(), "{attr} should read as clean");
         }
+    }
+
+    /// `has_vulnerabilities` must agree with what the value actually renders
+    /// as, or a version gets a red flag and an empty advisory list under it.
+    #[test]
+    fn test_has_vulnerabilities_matches_rendered_output() {
+        for clean in [None, Some(""), Some("  "), Some("[]"), Some("null")] {
+            assert!(!has_vulnerabilities(clean), "{clean:?} should read clean");
+        }
+        // Sentinels json_array::parse discards must not count as advisories.
+        for sentinel in ["None", " null ", "\n"] {
+            assert!(!has_vulnerabilities(Some(sentinel)), "{sentinel:?}");
+            assert!(super::super::json_array::parse(sentinel).is_empty());
+        }
+        assert!(has_vulnerabilities(Some(r#"["CVE-1"]"#)));
+
+        // Whatever the predicate accepts must render as something.
+        let entry = VersionHistoryEntry::from_advisory(
+            "1.0".to_string(),
+            Utc.timestamp_opt(1, 0).unwrap(),
+            Utc.timestamp_opt(2, 0).unwrap(),
+            Some("None".to_string()),
+        );
+        assert!(!entry.is_insecure());
+        assert!(entry.vulnerability_list().is_empty());
     }
 
     /// Same two cases against the pre-v4 grouped query, which aggregates several

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -318,6 +318,11 @@ pub struct ChannelCoverageStat {
     pub channel: String,
     pub releases_ingested: i64,
     pub releases_pending: i64,
+    /// Of `releases_pending`, those from the pre-2020 nix-env era. Ordinary
+    /// runs never retry these — they are only ingested under
+    /// `nxv index --backfill-evals`, which needs `nix` on the machine.
+    #[serde(default)]
+    pub releases_pending_eval_era: i64,
     pub releases_failed: i64,
     pub releases_skipped: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1173,6 +1178,8 @@ fn get_channel_coverage(conn: &rusqlite::Connection) -> Result<Vec<ChannelCovera
         SELECT r.channel,
                SUM(r.status = 'ingested'),
                SUM(r.status = 'pending'),
+               SUM(r.status = 'pending' AND r.source = 'nix_env'
+                   AND r.release_date < ?1),
                SUM(r.status = 'failed'),
                SUM(r.status = 'skipped'),
                (SELECT release_name FROM releases n
@@ -1184,16 +1191,17 @@ fn get_channel_coverage(conn: &rusqlite::Connection) -> Result<Vec<ChannelCovera
           FROM releases r GROUP BY r.channel ORDER BY r.channel
         "#,
     )?;
-    let rows = stmt.query_map([], |row| {
+    let rows = stmt.query_map([super::releases::eval_era_before().timestamp()], |row| {
         Ok(ChannelCoverageStat {
             channel: row.get(0)?,
             releases_ingested: row.get::<_, Option<i64>>(1)?.unwrap_or(0),
             releases_pending: row.get::<_, Option<i64>>(2)?.unwrap_or(0),
-            releases_failed: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
-            releases_skipped: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
-            newest_release: row.get(5)?,
+            releases_pending_eval_era: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
+            releases_failed: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
+            releases_skipped: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
+            newest_release: row.get(6)?,
             newest_release_date: row
-                .get::<_, Option<i64>>(6)?
+                .get::<_, Option<i64>>(7)?
                 .and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
         })
     })?;

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -290,9 +290,7 @@ impl PackageVersion {
 
     /// Check if the package has known vulnerabilities.
     pub fn is_insecure(&self) -> bool {
-        self.known_vulnerabilities
-            .as_ref()
-            .is_some_and(|v| !v.is_empty() && v != "[]" && v != "null")
+        has_vulnerabilities(self.known_vulnerabilities.as_deref())
     }
 
     /// Get parsed known vulnerabilities as a vector of strings.
@@ -302,6 +300,16 @@ impl PackageVersion {
             .map(super::json_array::parse)
             .unwrap_or_default()
     }
+}
+
+/// Whether a stored `known_vulnerabilities` value represents a real advisory.
+///
+/// The column holds a JSON array, but nixpkgs eras and ingestion paths spell "no
+/// advisory" three different ways — SQL `NULL`, the empty string, `[]`, and the
+/// literal `null`. This is the single definition of "insecure"; the SQL in
+/// [`get_version_history`] mirrors it with matching `NOT IN` predicates.
+pub fn has_vulnerabilities(value: Option<&str>) -> bool {
+    value.is_some_and(|v| !v.is_empty() && v != "[]" && v != "null")
 }
 
 /// Per-channel snapshot ingestion coverage (schema v4 indexes).
@@ -771,32 +779,93 @@ pub fn get_last_occurrence(
     }
 }
 
-/// Version history entry: (version, first_seen, last_seen, is_insecure).
-pub type VersionHistoryEntry = (String, DateTime<Utc>, DateTime<Utc>, bool);
+/// One version in a package's history, with the advisory that applies to it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionHistoryEntry {
+    pub version: String,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    /// Whether nixpkgs reports a known advisory for this version.
+    pub insecure: bool,
+    /// The advisory JSON array covering this version, or `None` when clean.
+    ///
+    /// Sourced from this `(attribute_path, version)` row when it carries one,
+    /// otherwise from the newest sibling attribute packaging the same `name` at
+    /// the same `version` — see [`get_version_history`] for why.
+    ///
+    /// `None` while `insecure` is `true` only happens against a remote server
+    /// that predates this field and sends the flag by itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vulnerabilities: Option<String>,
+}
+
+impl VersionHistoryEntry {
+    /// Build an entry from a stored `known_vulnerabilities` value, deriving the
+    /// flag so the two can never disagree.
+    pub fn from_advisory(
+        version: String,
+        first_seen: DateTime<Utc>,
+        last_seen: DateTime<Utc>,
+        vulnerabilities: Option<String>,
+    ) -> Self {
+        let vulnerabilities = vulnerabilities.filter(|v| has_vulnerabilities(Some(v)));
+        Self {
+            version,
+            first_seen,
+            last_seen,
+            insecure: vulnerabilities.is_some(),
+            vulnerabilities,
+        }
+    }
+
+    /// Whether this version has a known advisory in nixpkgs.
+    pub fn is_insecure(&self) -> bool {
+        self.insecure
+    }
+
+    /// Advisory strings for display, empty when none are known.
+    pub fn vulnerability_list(&self) -> Vec<String> {
+        self.vulnerabilities
+            .as_deref()
+            .map(super::json_array::parse)
+            .unwrap_or_default()
+    }
+}
 
 /// Retrieves the version history for a package attribute path.
 ///
 /// Returns each distinct version for the given `package` (matched against `attribute_path`)
 /// along with the earliest `first_commit_date`, the latest `last_commit_date` for that version,
-/// and a flag indicating if any record for that version has known vulnerabilities.
-/// Results are ordered by `first_seen` (earliest first_commit_date) descending.
+/// and the advisory that applies to it. Results are ordered by `first_seen` descending.
+///
+/// # Advisory scope
+///
+/// The advisory is looked up by `(name, version)` — the package's pname and version,
+/// **not** the attribute path and **not** the version string alone.
+///
+/// Matching on the version string alone is wrong: `nxv` 0.7.1 is unrelated to
+/// `zeronet` 0.7.1, and flagging one because of the other tainted 125k rows (issue #80).
+///
+/// Matching on the attribute path alone is also wrong: nixpkgs packages the same
+/// software under several attributes, and `known_vulnerabilities` follows the newest
+/// observation of each `(attribute_path, version)` row without being backfilled. So
+/// `emacs` 28.2 retired in 2023 holding `NULL` while `emacs28` 28.2 carried the same
+/// build until 2025 and picked up CVE-2024-53920. The `name` scope recovers those.
 ///
 /// # Arguments
 ///
 /// * `package` - The package attribute path to filter versions by.
-///
-/// # Returns
-///
-/// A `Vec<VersionHistoryEntry>` where each entry is `(version, first_seen, last_seen, is_insecure)`,
-/// and `first_seen` / `last_seen` are `DateTime<Utc>` values.
 ///
 /// # Examples
 ///
 /// ```
 /// // assumes `conn` is an open rusqlite::Connection
 /// let history = get_version_history(&conn, "python").unwrap();
-/// for (version, first_seen, last_seen, is_insecure) in history {
-///     println!("{}: {} - {} (insecure: {})", version, first_seen, last_seen, is_insecure);
+/// for entry in history {
+///     println!(
+///         "{}: {} - {} (insecure: {})",
+///         entry.version, entry.first_seen, entry.last_seen, entry.is_insecure()
+///     );
 /// }
 /// ```
 pub fn get_version_history(
@@ -811,53 +880,34 @@ pub fn get_version_history(
     }
 
     // Schema v4 stores one row per (attribute_path, version), so the historical
-    // GROUP BY/MIN/MAX query is redundant. Keep the cross-attribute security
-    // semantics by checking the partial vulnerability index per returned row.
+    // GROUP BY/MIN/MAX query is redundant. Prefer this row's own advisory and fall
+    // back to the newest sibling attribute packaging the same name at the same
+    // version (see "Advisory scope" above).
     let mut stmt = conn.prepare(
         r#"
         SELECT pv.version,
                pv.first_commit_date as first_seen,
                pv.last_commit_date as last_seen,
-               EXISTS (
-                   SELECT 1
-                   FROM package_versions iv
-                   WHERE iv.version = pv.version
-                     AND iv.known_vulnerabilities IS NOT NULL
-                     AND iv.known_vulnerabilities != ''
-                     AND iv.known_vulnerabilities != '[]'
-                     AND iv.known_vulnerabilities != 'null'
-                   LIMIT 1
-               ) as is_insecure
+               COALESCE(
+                   NULLIF(NULLIF(NULLIF(pv.known_vulnerabilities, ''), '[]'), 'null'),
+                   (
+                       SELECT iv.known_vulnerabilities
+                       FROM package_versions iv
+                       WHERE iv.name = pv.name
+                         AND iv.version = pv.version
+                         AND iv.known_vulnerabilities IS NOT NULL
+                         AND iv.known_vulnerabilities NOT IN ('', '[]', 'null')
+                       ORDER BY iv.last_commit_date DESC
+                       LIMIT 1
+                   )
+               ) as vulnerabilities
         FROM package_versions pv
         WHERE pv.attribute_path = ?
         ORDER BY pv.first_commit_date DESC
         "#,
     )?;
 
-    let rows = stmt.query_map([package], |row| {
-        let version: String = row.get(0)?;
-        let first_ts: i64 = row.get(1)?;
-        let last_ts: i64 = row.get(2)?;
-        let is_insecure: i64 = row.get(3)?;
-
-        let first_seen = Utc.timestamp_opt(first_ts, 0).single().ok_or_else(|| {
-            rusqlite::Error::FromSqlConversionFailure(
-                1,
-                rusqlite::types::Type::Integer,
-                format!("Invalid first_seen timestamp: {}", first_ts).into(),
-            )
-        })?;
-
-        let last_seen = Utc.timestamp_opt(last_ts, 0).single().ok_or_else(|| {
-            rusqlite::Error::FromSqlConversionFailure(
-                2,
-                rusqlite::types::Type::Integer,
-                format!("Invalid last_seen timestamp: {}", last_ts).into(),
-            )
-        })?;
-
-        Ok((version, first_seen, last_seen, is_insecure != 0))
-    })?;
+    let rows = stmt.query_map([package], version_history_row)?;
 
     let mut results = Vec::new();
     for row in rows {
@@ -866,28 +916,62 @@ pub fn get_version_history(
     Ok(results)
 }
 
+/// Shared row mapper for both version-history query shapes.
+fn version_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<VersionHistoryEntry> {
+    let version: String = row.get(0)?;
+    let first_ts: i64 = row.get(1)?;
+    let last_ts: i64 = row.get(2)?;
+    let vulnerabilities: Option<String> = row.get(3)?;
+
+    let first_seen = Utc.timestamp_opt(first_ts, 0).single().ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            1,
+            rusqlite::types::Type::Integer,
+            format!("Invalid first_seen timestamp: {}", first_ts).into(),
+        )
+    })?;
+
+    let last_seen = Utc.timestamp_opt(last_ts, 0).single().ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            2,
+            rusqlite::types::Type::Integer,
+            format!("Invalid last_seen timestamp: {}", last_ts).into(),
+        )
+    })?;
+
+    Ok(VersionHistoryEntry::from_advisory(
+        version,
+        first_seen,
+        last_seen,
+        vulnerabilities,
+    ))
+}
+
 fn get_version_history_grouped(
     conn: &rusqlite::Connection,
     package: &str,
 ) -> Result<Vec<VersionHistoryEntry>> {
     let has_vulnerabilities_column =
         table_has_column(conn, "package_versions", "known_vulnerabilities")?;
+    // Pre-v4 indexes hold several rows per (attribute_path, version), so the advisory
+    // is aggregated rather than read off a single row. Scoped by (name, version) for
+    // the same reasons as the v4 query above.
     let sql = if has_vulnerabilities_column {
         r#"
-        WITH insecure_versions AS (
-            SELECT DISTINCT version
+        WITH insecure_packages AS (
+            SELECT name, version, MAX(known_vulnerabilities) as vulnerabilities
             FROM package_versions
             WHERE known_vulnerabilities IS NOT NULL
-              AND known_vulnerabilities != ''
-              AND known_vulnerabilities != '[]'
-              AND known_vulnerabilities != 'null'
+              AND known_vulnerabilities NOT IN ('', '[]', 'null')
+            GROUP BY name, version
         )
         SELECT pv.version,
                MIN(pv.first_commit_date) as first_seen,
                MAX(pv.last_commit_date) as last_seen,
-               CASE WHEN iv.version IS NOT NULL THEN 1 ELSE 0 END as is_insecure
+               MAX(iv.vulnerabilities) as vulnerabilities
         FROM package_versions pv
-        LEFT JOIN insecure_versions iv ON pv.version = iv.version
+        LEFT JOIN insecure_packages iv
+               ON iv.name = pv.name AND iv.version = pv.version
         WHERE pv.attribute_path = ?
         GROUP BY pv.version
         ORDER BY first_seen DESC
@@ -897,7 +981,7 @@ fn get_version_history_grouped(
         SELECT version,
                MIN(first_commit_date) as first_seen,
                MAX(last_commit_date) as last_seen,
-               0 as is_insecure
+               NULL as vulnerabilities
         FROM package_versions
         WHERE attribute_path = ?
         GROUP BY version
@@ -906,30 +990,7 @@ fn get_version_history_grouped(
     };
     let mut stmt = conn.prepare(sql)?;
 
-    let rows = stmt.query_map([package], |row| {
-        let version: String = row.get(0)?;
-        let first_ts: i64 = row.get(1)?;
-        let last_ts: i64 = row.get(2)?;
-        let is_insecure: i64 = row.get(3)?;
-
-        let first_seen = Utc.timestamp_opt(first_ts, 0).single().ok_or_else(|| {
-            rusqlite::Error::FromSqlConversionFailure(
-                1,
-                rusqlite::types::Type::Integer,
-                format!("Invalid first_seen timestamp: {}", first_ts).into(),
-            )
-        })?;
-
-        let last_seen = Utc.timestamp_opt(last_ts, 0).single().ok_or_else(|| {
-            rusqlite::Error::FromSqlConversionFailure(
-                2,
-                rusqlite::types::Type::Integer,
-                format!("Invalid last_seen timestamp: {}", last_ts).into(),
-            )
-        })?;
-
-        Ok((version, first_seen, last_seen, is_insecure != 0))
-    })?;
+    let rows = stmt.query_map([package], version_history_row)?;
 
     let mut results = Vec::new();
     for row in rows {
@@ -1797,8 +1858,171 @@ mod tests {
         let history = get_version_history(db.connection(), "python").unwrap();
         assert_eq!(history.len(), 2);
         // Should be ordered by first_seen DESC, so 3.12.0 first
-        assert_eq!(history[0].0, "3.12.0");
-        assert_eq!(history[1].0, "3.11.0");
+        assert_eq!(history[0].version, "3.12.0");
+        assert_eq!(history[1].version, "3.11.0");
+    }
+
+    /// Build a v4 index holding just the rows a test cares about.
+    fn advisory_test_db(rows: &str) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(&format!(
+            r#"
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO meta (key, value) VALUES ('schema_version', '4');
+            CREATE TABLE package_versions (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                first_commit_hash TEXT NOT NULL,
+                first_commit_date INTEGER NOT NULL,
+                last_commit_hash TEXT NOT NULL,
+                last_commit_date INTEGER NOT NULL,
+                attribute_path TEXT NOT NULL,
+                description TEXT,
+                license TEXT,
+                homepage TEXT,
+                maintainers TEXT,
+                platforms TEXT,
+                source_path TEXT,
+                known_vulnerabilities TEXT,
+                UNIQUE(attribute_path, version)
+            );
+            INSERT INTO package_versions
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path,
+                 known_vulnerabilities)
+            VALUES {rows};
+            "#
+        ))
+        .unwrap();
+        conn
+    }
+
+    /// Regression for issue #80: `nxv` 0.7.1 was flagged insecure because
+    /// `zeronet` 0.7.1 carries an advisory. A shared version string is not a
+    /// shared package — this tainted 125k rows across 72k attribute paths.
+    #[test]
+    fn test_version_history_ignores_unrelated_package_at_same_version() {
+        let conn = advisory_test_db(
+            "('nxv', '0.7.1', 'a', 100, 'b', 200, 'nxv', NULL),
+             ('zeronet', '0.7.1', 'c', 100, 'd', 200, 'zeronet',
+              '[\"Unmaintained. Probable XSS/code injection vulnerability.\"]')",
+        );
+
+        let history = get_version_history(&conn, "nxv").unwrap();
+        assert_eq!(history.len(), 1);
+        assert!(
+            !history[0].is_insecure(),
+            "nxv 0.7.1 must not inherit zeronet's advisory"
+        );
+        assert_eq!(history[0].vulnerabilities, None);
+
+        // ...and the package that really is insecure keeps saying so.
+        let history = get_version_history(&conn, "zeronet").unwrap();
+        assert!(history[0].is_insecure());
+    }
+
+    /// The signal the fix must NOT lose. `known_vulnerabilities` follows the
+    /// newest observation of each (attribute_path, version) row and is never
+    /// backfilled, so `emacs` 28.2 retired in 2023 holding NULL while `emacs28`
+    /// 28.2 shipped the same build until 2025 and picked up the CVEs. Scoping by
+    /// name recovers it; scoping by attribute_path would not.
+    #[test]
+    fn test_version_history_inherits_advisory_from_sibling_attribute() {
+        let conn = advisory_test_db(
+            "('emacs', '28.2', 'a', 100, 'b', 200, 'emacs', NULL),
+             ('emacs', '28.2', 'c', 100, 'd', 300, 'emacs28',
+              '[\"CVE-2024-53920\"]')",
+        );
+
+        let history = get_version_history(&conn, "emacs").unwrap();
+        assert_eq!(history.len(), 1);
+        assert!(
+            history[0].is_insecure(),
+            "emacs 28.2 is the same build as emacs28 28.2"
+        );
+        assert_eq!(
+            history[0].vulnerability_list(),
+            vec!["CVE-2024-53920".to_string()],
+            "the advisory text travels with the flag"
+        );
+    }
+
+    /// A row's own advisory wins over a sibling's, and the empty spellings of
+    /// "no advisory" (NULL, '', '[]', 'null') all read as clean.
+    #[test]
+    fn test_version_history_prefers_own_advisory_and_ignores_empty_spellings() {
+        let conn = advisory_test_db(
+            "('pkg', '1.0', 'a', 100, 'b', 200, 'pkg', '[\"OWN-CVE\"]'),
+             ('pkg', '1.0', 'c', 100, 'd', 300, 'pkg-alias', '[\"SIBLING-CVE\"]'),
+             ('clean', '2.0', 'e', 100, 'f', 200, 'clean-empty', ''),
+             ('clean', '2.0', 'g', 100, 'h', 200, 'clean-array', '[]'),
+             ('clean', '2.0', 'i', 100, 'j', 200, 'clean-null', 'null')",
+        );
+
+        let history = get_version_history(&conn, "pkg").unwrap();
+        assert_eq!(
+            history[0].vulnerability_list(),
+            vec!["OWN-CVE".to_string()],
+            "the row's own advisory takes precedence over a newer sibling's"
+        );
+
+        for attr in ["clean-empty", "clean-array", "clean-null"] {
+            let history = get_version_history(&conn, attr).unwrap();
+            assert!(!history[0].is_insecure(), "{attr} should read as clean");
+        }
+    }
+
+    /// Same two cases against the pre-v4 grouped query, which aggregates several
+    /// rows per (attribute_path, version).
+    #[test]
+    fn test_legacy_version_history_scopes_advisories_by_name() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO meta (key, value) VALUES ('schema_version', '3');
+            CREATE TABLE package_versions (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL,
+                first_commit_hash TEXT NOT NULL,
+                first_commit_date INTEGER NOT NULL,
+                last_commit_hash TEXT NOT NULL,
+                last_commit_date INTEGER NOT NULL,
+                attribute_path TEXT NOT NULL,
+                description TEXT,
+                license TEXT,
+                homepage TEXT,
+                maintainers TEXT,
+                platforms TEXT,
+                source_path TEXT,
+                known_vulnerabilities TEXT
+            );
+            INSERT INTO package_versions
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path,
+                 known_vulnerabilities)
+            VALUES
+                ('nxv', '0.7.1', 'a', 100, 'b', 200, 'nxv', NULL),
+                ('nxv', '0.7.1', 'a2', 50, 'b2', 250, 'nxv', NULL),
+                ('zeronet', '0.7.1', 'c', 100, 'd', 200, 'zeronet', '["XSS"]'),
+                ('emacs', '28.2', 'e', 100, 'f', 200, 'emacs', NULL),
+                ('emacs', '28.2', 'g', 100, 'h', 300, 'emacs28', '["CVE-2024-53920"]');
+            "#,
+        )
+        .unwrap();
+
+        let history = get_version_history(&conn, "nxv").unwrap();
+        assert_eq!(history.len(), 1, "grouped query still collapses rows");
+        assert!(!history[0].is_insecure());
+
+        let history = get_version_history(&conn, "emacs").unwrap();
+        assert!(history[0].is_insecure());
+        assert_eq!(
+            history[0].vulnerability_list(),
+            vec!["CVE-2024-53920".to_string()]
+        );
     }
 
     #[test]
@@ -1844,9 +2068,9 @@ mod tests {
 
         let history = get_version_history(&conn, "python").unwrap();
         assert_eq!(history.len(), 1);
-        assert_eq!(history[0].0, "3.11.0");
-        assert_eq!(history[0].1, Utc.timestamp_opt(50, 0).unwrap());
-        assert_eq!(history[0].2, Utc.timestamp_opt(300, 0).unwrap());
+        assert_eq!(history[0].version, "3.11.0");
+        assert_eq!(history[0].first_seen, Utc.timestamp_opt(50, 0).unwrap());
+        assert_eq!(history[0].last_seen, Utc.timestamp_opt(300, 0).unwrap());
     }
 
     #[test]
@@ -1884,10 +2108,10 @@ mod tests {
 
         let history = get_version_history(&conn, "python").unwrap();
         assert_eq!(history.len(), 1);
-        assert_eq!(history[0].0, "3.11.0");
-        assert_eq!(history[0].1, Utc.timestamp_opt(50, 0).unwrap());
-        assert_eq!(history[0].2, Utc.timestamp_opt(300, 0).unwrap());
-        assert!(!history[0].3);
+        assert_eq!(history[0].version, "3.11.0");
+        assert_eq!(history[0].first_seen, Utc.timestamp_opt(50, 0).unwrap());
+        assert_eq!(history[0].last_seen, Utc.timestamp_opt(300, 0).unwrap());
+        assert!(!history[0].is_insecure());
     }
 
     #[test]

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -323,11 +323,13 @@ pub struct ChannelCoverageStat {
     pub channel: String,
     pub releases_ingested: i64,
     pub releases_pending: i64,
-    /// Of `releases_pending`, those from the pre-2020 nix-env era. Ordinary
-    /// runs never retry these — they are only ingested under
-    /// `nxv index --backfill-evals`, which needs `nix` on the machine.
+    /// Unsettled releases (pending or failed) from the pre-2020 nix-env era.
+    /// Ordinary runs never reach these — they are only ingested under
+    /// `nxv index --backfill-evals`, which needs `nix` on the machine. Counted
+    /// across both statuses because a `failed` nix-env row is just as stuck as
+    /// a `pending` one, and its retry ladder will never run again.
     #[serde(default)]
-    pub releases_pending_eval_era: i64,
+    pub releases_needing_eval: i64,
     pub releases_failed: i64,
     pub releases_skipped: i64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1199,7 +1201,7 @@ fn get_channel_coverage(conn: &rusqlite::Connection) -> Result<Vec<ChannelCovera
         SELECT r.channel,
                SUM(r.status = 'ingested'),
                SUM(r.status = 'pending'),
-               SUM(r.status = 'pending' AND r.source = 'nix_env'
+               SUM(r.status IN ('pending', 'failed') AND r.source = 'nix_env'
                    AND r.release_date < ?1),
                SUM(r.status = 'failed'),
                SUM(r.status = 'skipped'),
@@ -1217,7 +1219,7 @@ fn get_channel_coverage(conn: &rusqlite::Connection) -> Result<Vec<ChannelCovera
             channel: row.get(0)?,
             releases_ingested: row.get::<_, Option<i64>>(1)?.unwrap_or(0),
             releases_pending: row.get::<_, Option<i64>>(2)?.unwrap_or(0),
-            releases_pending_eval_era: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
+            releases_needing_eval: row.get::<_, Option<i64>>(3)?.unwrap_or(0),
             releases_failed: row.get::<_, Option<i64>>(4)?.unwrap_or(0),
             releases_skipped: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
             newest_release: row.get(6)?,

--- a/src/db/releases.rs
+++ b/src/db/releases.rs
@@ -12,6 +12,23 @@ use super::Database;
 use crate::error::Result;
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::Row;
+use serde::{Deserialize, Serialize};
+
+/// Earliest date a `packages.json.br` exists anywhere in the release bucket
+/// (nixpkgs-20.09pre218523.4a3f9aced7f, 2020-03-27).
+///
+/// Releases older than this can only be ingested by evaluating them with
+/// `nix-env`, i.e. under `nxv index --backfill-evals`. That makes it the line
+/// between "unsettled and awaiting retry" and "unsettled and out of reach of
+/// every scheduled run", which both the run report and `nxv stats` distinguish.
+pub const PACKAGES_JSON_FIRST_ARTIFACT: &str = "2020-03-27T00:00:00Z";
+
+/// [`PACKAGES_JSON_FIRST_ARTIFACT`] parsed, for use in queries.
+pub fn eval_era_before() -> DateTime<Utc> {
+    PACKAGES_JSON_FIRST_ARTIFACT
+        .parse()
+        .expect("PACKAGES_JSON_FIRST_ARTIFACT is a valid RFC 3339 timestamp")
+}
 
 /// Maximum automatic retry attempts before a release is parked as `skipped`.
 pub const MAX_ATTEMPTS: i64 = 5;
@@ -359,18 +376,52 @@ impl Database {
         Ok(out)
     }
 
-    /// Count of releases dated at or before `watermark_date` that are
-    /// neither `ingested` nor `skipped` — holes that retries still need to
-    /// fill. Surfaced in the run report and `nxv stats`.
+    /// Releases dated at or before `watermark_date` that are neither `ingested`
+    /// nor `skipped`. Surfaced in the run report and `nxv stats`.
+    ///
+    /// Split by whether an ordinary run can still reach them. Rows from the
+    /// pre-artifact nix-env era are only ever ingested under `--backfill-evals`,
+    /// so a scheduled run will never retry them however many times it runs —
+    /// reporting them as holes awaiting retry is simply false.
     #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
-    pub fn unsettled_release_count_before(&self, watermark_date: DateTime<Utc>) -> Result<i64> {
-        let unsettled: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM releases \
-             WHERE release_date <= ? AND status NOT IN ('ingested', 'skipped')",
-            rusqlite::params![watermark_date.timestamp()],
-            |row| row.get(0),
-        )?;
-        Ok(unsettled)
+    pub fn unsettled_releases_before(
+        &self,
+        watermark_date: DateTime<Utc>,
+        eval_era_before: DateTime<Utc>,
+    ) -> Result<UnsettledReleases> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*), \
+                        COALESCE(SUM(source = 'nix_env' AND release_date < ?2), 0) \
+                 FROM releases \
+                 WHERE release_date <= ?1 AND status NOT IN ('ingested', 'skipped')",
+                rusqlite::params![watermark_date.timestamp(), eval_era_before.timestamp()],
+                |row| {
+                    Ok(UnsettledReleases {
+                        total: row.get(0)?,
+                        needs_eval: row.get(1)?,
+                    })
+                },
+            )
+            .map_err(Into::into)
+    }
+}
+
+/// Breakdown of releases before the watermark that never settled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnsettledReleases {
+    /// All unsettled releases before the watermark.
+    pub total: i64,
+    /// Those only reachable with `--backfill-evals`, and so not retried by
+    /// scheduled runs.
+    pub needs_eval: i64,
+}
+
+impl UnsettledReleases {
+    /// Unsettled releases an ordinary run will pick up again.
+    #[cfg_attr(not(feature = "indexer"), allow(dead_code))]
+    pub fn retryable(&self) -> i64 {
+        self.total - self.needs_eval
     }
 }
 
@@ -572,11 +623,12 @@ mod tests {
         assert_eq!(coverage.len(), 1);
         assert_eq!(coverage[0].ingested, 1);
 
-        assert_eq!(db.unsettled_release_count_before(date(2_000)).unwrap(), 0);
+        let unsettled = db.unsettled_releases_before(date(2_000), date(0)).unwrap();
+        assert_eq!(unsettled, UnsettledReleases::default());
     }
 
     #[test]
-    fn test_unsettled_release_count_before() {
+    fn test_unsettled_releases_before() {
         let (_dir, db) = open_test_db();
         db.insert_release_pending(
             "nixpkgs-unstable",
@@ -587,8 +639,43 @@ mod tests {
             ReleaseSource::PackagesJson,
         )
         .unwrap();
-        assert_eq!(db.unsettled_release_count_before(date(2_000)).unwrap(), 1);
-        assert_eq!(db.unsettled_release_count_before(date(500)).unwrap(), 0);
+
+        let unsettled = db
+            .unsettled_releases_before(date(2_000), date(500))
+            .unwrap();
+        assert_eq!(unsettled.total, 1);
+        assert_eq!(unsettled.needs_eval, 0);
+        assert_eq!(unsettled.retryable(), 1);
+
+        assert_eq!(
+            db.unsettled_releases_before(date(500), date(500)).unwrap(),
+            UnsettledReleases::default(),
+            "the watermark bounds the count"
+        );
+    }
+
+    /// Pre-artifact nix-env rows are counted apart: no scheduled run retries
+    /// them, so reporting them as pending retry would be false.
+    #[test]
+    fn test_unsettled_releases_separates_eval_era() {
+        let (_dir, db) = open_test_db();
+        for (name, when, source) in [
+            ("old-eval", date(100), ReleaseSource::NixEnv),
+            ("probe-era", date(800), ReleaseSource::NixEnv),
+            ("modern", date(1_000), ReleaseSource::PackagesJson),
+        ] {
+            db.insert_release_pending("nixpkgs-unstable", name, "a", None, when, source)
+                .unwrap();
+        }
+
+        // Anything dated before the first artifact needs an evaluation; the
+        // nix_env row after it is only a plan-time guess the probe can correct.
+        let unsettled = db
+            .unsettled_releases_before(date(2_000), date(500))
+            .unwrap();
+        assert_eq!(unsettled.total, 3);
+        assert_eq!(unsettled.needs_eval, 1);
+        assert_eq!(unsettled.retryable(), 2);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,18 @@ pub enum NxvError {
     #[cfg(feature = "indexer")]
     #[error("Configuration error: {0}")]
     Config(String),
+
+    /// A release has no `packages.json.br` and the run may not evaluate.
+    ///
+    /// Distinct from a failure: retrying cannot change the answer, since only
+    /// `--backfill-evals` can ingest it. The coordinator parks such a release
+    /// as `skipped` immediately rather than burning the retry ladder and
+    /// reporting five red runs over two days for a permanent condition.
+    #[cfg(feature = "indexer")]
+    #[error(
+        "{0} has no packages.json.br; ingest it with `nxv index --retry-failed --backfill-evals`"
+    )]
+    NeedsEval(String),
 }
 
 /// Result type alias for nxv operations.

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -152,7 +152,7 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
             (_, Some(u)) if r.release_date > u => false,
             _ => true,
         })
-        .filter(|r| args.backfill_evals || r.source != ReleaseSource::NixEnv)
+        .filter(|r| args.backfill_evals || !needs_eval(r))
         .collect();
     if let Some(max) = args.max_releases {
         worklist.truncate(max);
@@ -215,6 +215,7 @@ pub fn run_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
             &channel_prefixes,
             worklist,
             jobs,
+            args.backfill_evals,
             &shutdown,
             &mut report,
             &progress,
@@ -390,17 +391,37 @@ impl Aggregator {
     }
 }
 
+/// Whether a planned release can only be ingested by evaluating it with `nix`.
+///
+/// The plan-time source is a guess from the release date, and the fetch-time
+/// probe is what settles it (DESIGN §2: probe, never date-classify) — but the
+/// probe lives downstream of the work-list filter, so anything excluded here is
+/// never probed at all. A `NixEnv` guess dated on or after the first known
+/// `packages.json.br` is therefore admitted: worst case it 404s and is recorded
+/// as needing `--backfill-evals`, best case it ingests with no evaluation.
+fn needs_eval(release: &ReleaseRecord) -> bool {
+    if release.source != ReleaseSource::NixEnv {
+        return false;
+    }
+    release.release_date < crate::db::releases::eval_era_before()
+}
+
 /// Fetch + parse one release (worker side; no DB access).
 ///
 /// The plan-time source is a guess from the release date; the truth is
 /// per-release (DESIGN §2: probe, never date-classify). So nix-env-era
-/// releases first probe packages.json.br — the ~60 releases between the
-/// first artifact (2020-03-27) and the safe-after line get the zero-eval
-/// path, and the probe is one cheap 404 for genuinely pre-artifact releases.
+/// releases first probe packages.json.br — the releases between the first
+/// artifact (2020-03-27) and the safe-after line get the zero-eval path.
+///
+/// `allow_eval` mirrors `--backfill-evals`. Without it a probe miss is an
+/// error rather than a silent fallback to `nix-env`: the scheduled publish runs
+/// have no `nix` and must not start evaluating a decade of history because one
+/// artifact was missing.
 fn fetch_release(
     s3: &S3Client,
     prefix: &str,
     release: &ReleaseRecord,
+    allow_eval: bool,
 ) -> Result<(Vec<SnapshotEntry>, ReleaseSource)> {
     match release.source {
         ReleaseSource::PackagesJson => s3
@@ -409,6 +430,12 @@ fn fetch_release(
         ReleaseSource::NixEnv => match s3.fetch_packages_json(prefix, &release.release_name) {
             Ok(entries) => Ok((entries, ReleaseSource::PackagesJson)),
             Err(NxvError::NetworkMessage(msg)) if msg.contains("HTTP 404") => {
+                if !allow_eval {
+                    return Err(NxvError::Config(format!(
+                        "{} has no packages.json.br; re-run with --backfill-evals to evaluate it",
+                        release.release_name
+                    )));
+                }
                 eval::ingest_nix_env_release(s3, prefix, &release.release_name)
                     .map(|entries| (entries, ReleaseSource::NixEnv))
             }
@@ -428,6 +455,7 @@ fn ingest_worklist(
     channel_prefixes: &HashMap<String, String>,
     worklist: Vec<ReleaseRecord>,
     jobs: usize,
+    allow_eval: bool,
     shutdown: &Arc<AtomicBool>,
     report: &mut RunReport,
     progress: &dyn Fn(&str),
@@ -480,7 +508,7 @@ fn ingest_worklist(
                     continue;
                 };
                 let prefix = prefixes.get(&release.channel).cloned().unwrap_or_default();
-                let result = fetch_release(&s3, &prefix, &release);
+                let result = fetch_release(&s3, &prefix, &release, allow_eval);
                 if tx.send((seq, result)).is_err() {
                     break;
                 }
@@ -722,6 +750,55 @@ mod tests {
     use super::*;
     use chrono::TimeZone;
     use tempfile::tempdir;
+
+    fn planned_release(release_date: DateTime<Utc>, source: ReleaseSource) -> ReleaseRecord {
+        ReleaseRecord {
+            id: 1,
+            channel: "nixos-unstable-small".to_string(),
+            release_name: "nixos-20.09pre218523.4a3f9aced7f".to_string(),
+            commit_hash: "a".repeat(40),
+            commit_count: None,
+            release_date,
+            source,
+            status: crate::db::releases::ReleaseStatus::Pending,
+            attempts: 0,
+            last_attempt_at: None,
+            attr_count: None,
+            error: None,
+            ingested_at: None,
+        }
+    }
+
+    /// The work-list filter runs before the fetch-time probe, so a `NixEnv`
+    /// guess inside the mixed window must survive it — otherwise the probe that
+    /// would reclassify it never runs. ~200 nixos-unstable-small snapshots sat
+    /// permanently pending for exactly this reason.
+    #[test]
+    fn test_needs_eval_admits_releases_after_the_first_artifact() {
+        let day = |s: &str| s.parse::<DateTime<Utc>>().unwrap();
+
+        assert!(
+            needs_eval(&planned_release(
+                day("2019-01-01T00:00:00Z"),
+                ReleaseSource::NixEnv
+            )),
+            "genuinely pre-artifact releases still require --backfill-evals"
+        );
+        assert!(
+            !needs_eval(&planned_release(
+                day("2020-04-15T00:00:00Z"),
+                ReleaseSource::NixEnv
+            )),
+            "a date-guessed NixEnv release inside the mixed window must be probed"
+        );
+        assert!(
+            !needs_eval(&planned_release(
+                day("2019-01-01T00:00:00Z"),
+                ReleaseSource::PackagesJson
+            )),
+            "an artifact-backed release never needs an evaluation"
+        );
+    }
 
     fn test_package(attr: &str, version: &str) -> PackageVersion {
         PackageVersion {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -413,10 +413,11 @@ fn needs_eval(release: &ReleaseRecord) -> bool {
 /// releases first probe packages.json.br — the releases between the first
 /// artifact (2020-03-27) and the safe-after line get the zero-eval path.
 ///
-/// `allow_eval` mirrors `--backfill-evals`. Without it a probe miss is an
-/// error rather than a silent fallback to `nix-env`: the scheduled publish runs
-/// have no `nix` and must not start evaluating a decade of history because one
-/// artifact was missing.
+/// `allow_eval` mirrors `--backfill-evals`. Without it a probe miss is a
+/// [`NxvError::NeedsEval`] rather than a silent fallback to `nix-env`: a run
+/// that did not opt into evaluation must not spend hours on one because a
+/// single artifact was missing. The release is parked as `skipped`, since no
+/// amount of retrying will produce an artifact that does not exist.
 fn fetch_release(
     s3: &S3Client,
     prefix: &str,
@@ -431,10 +432,7 @@ fn fetch_release(
             Ok(entries) => Ok((entries, ReleaseSource::PackagesJson)),
             Err(NxvError::NetworkMessage(msg)) if msg.contains("HTTP 404") => {
                 if !allow_eval {
-                    return Err(NxvError::Config(format!(
-                        "{} has no packages.json.br; re-run with --backfill-evals to evaluate it",
-                        release.release_name
-                    )));
+                    return Err(NxvError::NeedsEval(release.release_name.clone()));
                 }
                 eval::ingest_nix_env_release(s3, prefix, &release.release_name)
                     .map(|entries| (entries, ReleaseSource::NixEnv))
@@ -524,7 +522,8 @@ fn ingest_worklist(
         std::result::Result<(Vec<SnapshotEntry>, ReleaseSource), NxvError>,
     > = BTreeMap::new();
     let mut next_seq = 0usize;
-    let mut prev_attrs: HashMap<String, (HashSet<String>, ReleaseSource)> = HashMap::new();
+    let mut prev_attrs: HashMap<String, (HashSet<String>, ReleaseSource, DateTime<Utc>)> =
+        HashMap::new();
     let mut aggregator = Aggregator::default();
     let mut hard_error: Option<NxvError> = None;
 
@@ -556,7 +555,7 @@ fn ingest_worklist(
                         &entries,
                         prev_attrs
                             .get(&release.channel)
-                            .map(|(attrs, source)| (attrs, *source)),
+                            .map(|(attrs, source, date)| (attrs, *source, *date)),
                         &sentinels,
                     )?;
 
@@ -584,6 +583,7 @@ fn ingest_worklist(
                         (
                             entries.iter().map(|e| e.attribute_path.clone()).collect(),
                             release.source,
+                            release.release_date,
                         ),
                     );
 
@@ -599,6 +599,19 @@ fn ingest_worklist(
                     if aggregator.should_flush() {
                         aggregator.flush(db)?;
                     }
+                }
+                // A release that needs an evaluation this run may not do is
+                // parked terminally, not failed: retrying cannot change the
+                // answer, and counting it as a failure reddens CI on a
+                // permanent condition. `--retry-failed --backfill-evals`
+                // resurrects it.
+                Err(NxvError::NeedsEval(name)) => {
+                    progress(&format!("  skipping {name}: no packages.json.br"));
+                    db.mark_release_skipped(
+                        release.id,
+                        "no packages.json.br; needs --backfill-evals",
+                    )?;
+                    report.skipped += 1;
                 }
                 Err(e) => {
                     progress(&format!("  FAILED {}: {e}", release.release_name));

--- a/src/index/monitor.rs
+++ b/src/index/monitor.rs
@@ -34,6 +34,13 @@ const BASELINE_HARD_FRACTION: f64 = 0.70;
 /// advisory (mass renames are legitimate, e.g. python3xPackages flips).
 const DEATHS_WARN_FRACTION: f64 = 0.05;
 
+/// Births/deaths are only meaningful between snapshots that are actually
+/// adjacent. Channel advances land hours apart; anything beyond this is a
+/// coverage gap (a backfilled window meeting the present, a stalled channel),
+/// where "attrs disappeared in one advance" would measure years of ordinary
+/// churn rather than a single bad snapshot.
+const MAX_ADVANCE_GAP_DAYS: i64 = 30;
+
 /// `--strict` head-lag threshold: newest observation older than this fails CI.
 pub const HEAD_LAG_STRICT_HOURS: i64 = 72;
 
@@ -188,7 +195,7 @@ pub fn evaluate_release_gate(
     db: &Database,
     release: &ReleaseRecord,
     entries: &[SnapshotEntry],
-    prev_attrs: Option<(&HashSet<String>, ReleaseSource)>,
+    prev_attrs: Option<(&HashSet<String>, ReleaseSource, DateTime<Utc>)>,
     sentinels: &[Sentinel],
 ) -> Result<GateResult> {
     let mut result = GateResult {
@@ -263,9 +270,13 @@ pub fn evaluate_release_gate(
 
     // 4. Births/deaths vs the previous snapshot in this run. Skipped across
     // era boundaries (the one-time +33k birth event at 2020-03-27 is
-    // expected, not an anomaly).
-    if let Some((prev, prev_source)) = prev_attrs
+    // expected, not an anomaly) and across long gaps: a run that ingests a
+    // backfilled 2020 window followed by today's release would otherwise
+    // compare snapshots six years apart and report every retired attribute as
+    // a mass death. Consecutive snapshots are hours apart, never weeks.
+    if let Some((prev, prev_source, prev_date)) = prev_attrs
         && prev_source == release.source
+        && (release.release_date - prev_date).num_days() <= MAX_ADVANCE_GAP_DAYS
     {
         let births = attrs.iter().filter(|a| !prev.contains(**a)).count();
         let deaths = prev.iter().filter(|a| !attrs.contains(a.as_str())).count();
@@ -694,7 +705,11 @@ mod tests {
             &db,
             &rel,
             &entries,
-            Some((&prev, ReleaseSource::PackagesJson)),
+            Some((
+                &prev,
+                ReleaseSource::PackagesJson,
+                Utc.timestamp_opt(T_2026 - 86_400, 0).unwrap(),
+            )),
             &builtin_sentinels(&[]),
         )
         .unwrap();
@@ -720,12 +735,63 @@ mod tests {
             &db,
             &rel,
             &entries,
-            Some((&prev, ReleaseSource::NixEnv)),
+            Some((
+                &prev,
+                ReleaseSource::NixEnv,
+                Utc.timestamp_opt(1_585_267_200 - 86_400, 0).unwrap(),
+            )),
             &builtin_sentinels(&[]),
         )
         .unwrap();
         assert!(gate.passed());
         assert_eq!(gate.births, None, "era boundary must skip births/deaths");
         assert!(gate.warnings.is_empty());
+    }
+
+    /// A run that ingests a backfilled 2020 window and then today's release
+    /// compares snapshots six years apart. Every attribute retired since is
+    /// not a mass death in "one advance", and under --strict the bogus warning
+    /// would fail the run.
+    #[test]
+    fn test_births_deaths_skipped_across_long_gap() {
+        let dir = tempdir().unwrap();
+        let db = Database::open(dir.path().join("t.db")).unwrap();
+        let rel = release("nixos-unstable-small", ReleaseSource::PackagesJson, T_2026);
+
+        let entries = base_entries(140_000);
+        // The 2020 snapshot: 61k attrs, almost none of them today's.
+        let prev: HashSet<String> = (0..61_000).map(|i| format!("attr2020_{i}")).collect();
+        let six_years_earlier = Utc.timestamp_opt(T_2026 - 6 * 365 * 86_400, 0).unwrap();
+
+        let gate = evaluate_release_gate(
+            &db,
+            &rel,
+            &entries,
+            Some((&prev, ReleaseSource::PackagesJson, six_years_earlier)),
+            &builtin_sentinels(&[]),
+        )
+        .unwrap();
+        assert!(gate.passed());
+        assert_eq!(
+            gate.deaths, None,
+            "snapshots years apart are not consecutive advances"
+        );
+        assert!(gate.warnings.is_empty());
+
+        // A normal same-day advance is still measured.
+        let gate = evaluate_release_gate(
+            &db,
+            &rel,
+            &entries,
+            Some((
+                &prev,
+                ReleaseSource::PackagesJson,
+                Utc.timestamp_opt(T_2026 - 86_400, 0).unwrap(),
+            )),
+            &builtin_sentinels(&[]),
+        )
+        .unwrap();
+        assert_eq!(gate.deaths, Some(61_000));
+        assert!(!gate.warnings.is_empty());
     }
 }

--- a/src/index/monitor.rs
+++ b/src/index/monitor.rs
@@ -8,7 +8,7 @@
 //! ANALYSIS.md); this one refuses the snapshot and pages the operator.
 
 use crate::db::Database;
-use crate::db::releases::{ReleaseRecord, ReleaseSource};
+use crate::db::releases::{ReleaseRecord, ReleaseSource, UnsettledReleases, eval_era_before};
 use crate::error::Result;
 use crate::index::snapshot::SnapshotEntry;
 use chrono::{DateTime, Datelike, Utc};
@@ -308,11 +308,12 @@ pub struct RunReport {
     /// Hours between now and the newest observation across channels.
     pub head_lag_hours: Option<i64>,
     /// Releases dated at or before the newest ingested observation that are
-    /// neither ingested nor skipped — holes that retries still need to fill.
-    /// Publishing ingested progress is safe regardless (gate-failed
-    /// snapshots never write rows), but a persistently nonzero value means
-    /// some window's versions stay missing until its release succeeds.
-    pub unsettled_before_watermark: Option<i64>,
+    /// neither ingested nor skipped, split by whether an ordinary run can still
+    /// reach them. Publishing ingested progress is safe regardless (gate-failed
+    /// snapshots never write rows), but a persistently nonzero `retryable`
+    /// count means some window's versions stay missing until its release
+    /// succeeds, while `needs_eval` will not move without `--backfill-evals`.
+    pub unsettled_before_watermark: Option<UnsettledReleases>,
     /// Total distinct attribute paths in the index after the run.
     pub total_attrs: Option<i64>,
     /// Total (attr, version) rows after the run.
@@ -355,7 +356,7 @@ impl RunReport {
         if let Some(newest) = db.newest_ingested_release(None)? {
             self.head_lag_hours = Some((Utc::now() - newest.release_date).num_hours());
             self.unsettled_before_watermark =
-                Some(db.unsettled_release_count_before(newest.release_date)?);
+                Some(db.unsettled_releases_before(newest.release_date, eval_era_before())?);
         }
 
         let conn = db.connection();
@@ -414,9 +415,22 @@ impl RunReport {
             eprintln!("  index: {attrs} distinct attrs, {rows} (attr, version) rows");
         }
         if let Some(unsettled) = self.unsettled_before_watermark
-            && unsettled > 0
+            && unsettled.total > 0
         {
-            eprintln!("  unsettled releases before watermark: {unsettled} (holes pending retry)");
+            eprint!("  unsettled releases before watermark: {}", unsettled.total);
+            if unsettled.needs_eval > 0 {
+                eprint!(
+                    " ({} pre-2020 nix-env era, unreachable without --backfill-evals",
+                    unsettled.needs_eval
+                );
+                if unsettled.retryable() > 0 {
+                    eprint!("; {} pending retry", unsettled.retryable());
+                }
+                eprint!(")");
+            } else {
+                eprint!(" (holes pending retry)");
+            }
+            eprintln!();
         }
         if let Some(lag) = self.head_lag_hours {
             eprintln!(

--- a/src/index/releases.rs
+++ b/src/index/releases.rs
@@ -33,6 +33,14 @@ pub const DEFAULT_BASE_URL: &str = "https://nix-releases.s3.amazonaws.com";
 /// before mid-2020 that 404 get reclassified to the nix-env era.
 pub const PACKAGES_JSON_SAFE_AFTER: &str = "2020-06-01T00:00:00Z";
 
+// The date of that first artifact — `db::releases::PACKAGES_JSON_FIRST_ARTIFACT`,
+// which lives there so `nxv stats` can report the same era boundary without the
+// indexer feature. Between it and PACKAGES_JSON_SAFE_AFTER the bucket is mixed,
+// so plan-time date classification guesses NixEnv and the fetch-time probe
+// corrects it. Runs without --backfill-evals still admit that window: those
+// releases cost one GET and no evaluation, and excluding them stranded ~200
+// nixos-unstable-small snapshots that had artifacts all along.
+
 /// A channel we ingest, mapped to its S3 prefix.
 #[derive(Debug, Clone)]
 pub struct ChannelSpec {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1020,19 +1020,6 @@ fn cmd_stats(cli: &Cli) -> Result<()> {
             print!("{}: {} ingested", ch.channel, ch.releases_ingested);
             if ch.releases_pending > 0 {
                 print!(", {} pending", ch.releases_pending);
-                // A bare count reads as a backlog the next run will work off.
-                // Pre-2020 releases are not that: nothing but an explicit
-                // `nxv index --backfill-evals` will ever pick them up.
-                if ch.releases_pending_eval_era > 0 {
-                    if ch.releases_pending_eval_era == ch.releases_pending {
-                        print!(" (pre-2020, needs --backfill-evals)");
-                    } else {
-                        print!(
-                            " ({} pre-2020, needs --backfill-evals)",
-                            ch.releases_pending_eval_era
-                        );
-                    }
-                }
             }
             if ch.releases_failed > 0 {
                 print!(", {} failed", ch.releases_failed);
@@ -1046,6 +1033,16 @@ fn cmd_stats(cli: &Cli) -> Result<()> {
                     print!(", {}", date.format("%Y-%m-%d"));
                 }
                 print!(")");
+            }
+            // Bare pending/failed counts read as work the next run will get to.
+            // Pre-2020 nix-env releases are not that: no scheduled run includes
+            // them and the retry ladder will never run again, so say so instead
+            // of leaving a number that looks like a backlog.
+            if ch.releases_needing_eval > 0 {
+                print!(
+                    "; {} pre-2020, needs --backfill-evals",
+                    ch.releases_needing_eval
+                );
             }
             println!();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1020,6 +1020,19 @@ fn cmd_stats(cli: &Cli) -> Result<()> {
             print!("{}: {} ingested", ch.channel, ch.releases_ingested);
             if ch.releases_pending > 0 {
                 print!(", {} pending", ch.releases_pending);
+                // A bare count reads as a backlog the next run will work off.
+                // Pre-2020 releases are not that: nothing but an explicit
+                // `nxv index --backfill-evals` will ever pick them up.
+                if ch.releases_pending_eval_era > 0 {
+                    if ch.releases_pending_eval_era == ch.releases_pending {
+                        print!(" (pre-2020, needs --backfill-evals)");
+                    } else {
+                        print!(
+                            " ({} pre-2020, needs --backfill-evals)",
+                            ch.releases_pending_eval_era
+                        );
+                    }
+                }
             }
             if ch.releases_failed > 0 {
                 print!(", {} failed", ch.releases_failed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1348,7 +1348,13 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
                             "first_seen": entry.first_seen.to_rfc3339(),
                             "last_seen": entry.last_seen.to_rfc3339(),
                             "is_insecure": entry.is_insecure(),
-                            "known_vulnerabilities": entry.vulnerabilities,
+                            // An array, matching `nxv history <pkg> <version>`
+                            // and every other JSON surface — never the stored
+                            // JSON-array string.
+                            "known_vulnerabilities": entry
+                                .vulnerabilities
+                                .as_ref()
+                                .map(|v| db::json_array::parse(v)),
                         })
                     })
                     .collect();
@@ -1383,8 +1389,12 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
                 let mut advisories = Vec::new();
                 for entry in history {
                     let insecure = entry.is_insecure();
-                    if insecure {
-                        advisories.push((entry.version.clone(), entry.vulnerability_list()));
+                    // Only versions with actual text to show. A remote server
+                    // predating the advisory field sends the flag alone, which
+                    // would otherwise print a heading with nothing under it.
+                    let vulns = entry.vulnerability_list();
+                    if !vulns.is_empty() {
+                        advisories.push((entry.version.clone(), vulns));
                     }
                     let version_display = if insecure {
                         format!("{} ⚠", entry.version)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1329,12 +1329,13 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
             cli::OutputFormatArg::Json => {
                 let json_history: Vec<_> = history
                     .iter()
-                    .map(|(v, first, last, is_insecure)| {
+                    .map(|entry| {
                         serde_json::json!({
-                            "version": v,
-                            "first_seen": first.to_rfc3339(),
-                            "last_seen": last.to_rfc3339(),
-                            "is_insecure": is_insecure,
+                            "version": entry.version,
+                            "first_seen": entry.first_seen.to_rfc3339(),
+                            "last_seen": entry.last_seen.to_rfc3339(),
+                            "is_insecure": entry.is_insecure(),
+                            "known_vulnerabilities": entry.vulnerabilities,
                         })
                     })
                     .collect();
@@ -1342,13 +1343,13 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
             }
             cli::OutputFormatArg::Plain => {
                 println!("VERSION\tFIRST_SEEN\tLAST_SEEN\tINSECURE");
-                for (version, first, last, is_insecure) in history {
+                for entry in history {
                     println!(
                         "{}\t{}\t{}\t{}",
-                        version,
-                        first.format("%Y-%m-%d"),
-                        last.format("%Y-%m-%d"),
-                        if is_insecure { "yes" } else { "no" }
+                        entry.version,
+                        entry.first_seen.format("%Y-%m-%d"),
+                        entry.last_seen.format("%Y-%m-%d"),
+                        if entry.is_insecure() { "yes" } else { "no" }
                     );
                 }
             }
@@ -1366,25 +1367,37 @@ fn cmd_history(cli: &Cli, args: &cli::HistoryArgs) -> Result<()> {
                     .set_content_arrangement(ContentArrangement::Dynamic)
                     .set_header(vec!["Version", "First Seen", "Last Seen"]);
 
-                for (version, first, last, is_insecure) in history {
-                    let version_display = if is_insecure {
-                        format!("{} ⚠", version)
+                let mut advisories = Vec::new();
+                for entry in history {
+                    let insecure = entry.is_insecure();
+                    if insecure {
+                        advisories.push((entry.version.clone(), entry.vulnerability_list()));
+                    }
+                    let version_display = if insecure {
+                        format!("{} ⚠", entry.version)
                     } else {
-                        version
+                        entry.version
                     };
-                    let version_color = if is_insecure {
-                        Color::Red
-                    } else {
-                        Color::Green
-                    };
+                    let version_color = if insecure { Color::Red } else { Color::Green };
                     table.add_row(vec![
                         Cell::new(&version_display).fg(version_color),
-                        Cell::new(first.format("%Y-%m-%d").to_string()).fg(Color::White),
-                        Cell::new(last.format("%Y-%m-%d").to_string()).fg(Color::White),
+                        Cell::new(entry.first_seen.format("%Y-%m-%d").to_string()).fg(Color::White),
+                        Cell::new(entry.last_seen.format("%Y-%m-%d").to_string()).fg(Color::White),
                     ]);
                 }
 
                 println!("{table}");
+
+                if !advisories.is_empty() {
+                    use owo_colors::OwoColorize;
+                    println!();
+                    println!("{}", "Known vulnerabilities".bold().underline().red());
+                    for (version, vulns) in &advisories {
+                        for vuln in vulns {
+                            println!("  {} {} {}", "•".red(), version.red().bold(), vuln);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -363,11 +363,12 @@ pub async fn get_version_history(
 
     let entries: Vec<_> = history
         .into_iter()
-        .map(|(version, first, last, is_insecure)| VersionHistorySchema {
-            version,
-            first_seen: first,
-            last_seen: last,
-            is_insecure,
+        .map(|entry| VersionHistorySchema {
+            version: entry.version,
+            first_seen: entry.first_seen,
+            last_seen: entry.last_seen,
+            is_insecure: entry.insecure,
+            vulnerabilities: entry.vulnerabilities,
         })
         .collect();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1010,6 +1010,54 @@ mod tests {
         assert!(data[0]["version"].is_string());
         assert!(data[0]["first_seen"].is_string());
         assert!(data[0]["last_seen"].is_string());
+        assert_eq!(data[0]["is_insecure"], false);
+        assert!(
+            data[0].get("vulnerabilities").is_none(),
+            "clean versions omit the advisory field"
+        );
+    }
+
+    /// The history endpoint reports advisories per software version, so an
+    /// unrelated package sharing a version string is not flagged (issue #80),
+    /// and a sibling attribute packaging the same build is.
+    #[tokio::test]
+    async fn test_get_version_history_advisory_scope() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        create_test_db(&db_path);
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            INSERT INTO package_versions
+                (name, version, first_commit_hash, first_commit_date,
+                 last_commit_hash, last_commit_date, attribute_path,
+                 known_vulnerabilities)
+            VALUES
+                ('emacs', '28.2', 'i111', 1700000000, 'i222', 1700100000, 'emacs', NULL),
+                ('emacs', '28.2', 'i333', 1700000000, 'i444', 1700900000, 'emacs28',
+                 '["CVE-2024-53920"]'),
+                ('unrelated', '28.2', 'i555', 1700000000, 'i666', 1700100000, 'unrelated', NULL);
+            "#,
+        )
+        .unwrap();
+        drop(conn);
+
+        let state = Arc::new(AppState::new(db_path));
+        let app = build_router(state, None, None);
+
+        let (status, json) = get_json(&app, "/api/v1/packages/emacs/history").await;
+        assert_eq!(status, StatusCode::OK);
+        let entry = &json["data"].as_array().unwrap()[0];
+        assert_eq!(entry["is_insecure"], true);
+        assert_eq!(entry["vulnerabilities"], "[\"CVE-2024-53920\"]");
+
+        let (_, json) = get_json(&app, "/api/v1/packages/unrelated/history").await;
+        let entry = &json["data"].as_array().unwrap()[0];
+        assert_eq!(
+            entry["is_insecure"], false,
+            "a shared version string is not a shared package"
+        );
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1050,7 +1050,11 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         let entry = &json["data"].as_array().unwrap()[0];
         assert_eq!(entry["is_insecure"], true);
-        assert_eq!(entry["vulnerabilities"], "[\"CVE-2024-53920\"]");
+        assert_eq!(
+            entry["vulnerabilities"],
+            serde_json::json!(["CVE-2024-53920"]),
+            "the advisory ships as a real array, not the stored JSON string"
+        );
 
         let (_, json) = get_json(&app, "/api/v1/packages/unrelated/history").await;
         let entry = &json["data"].as_array().unwrap()[0];

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -289,6 +289,7 @@ pub struct VersionHistorySchema {
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::db::json_array::serialize_opt"
     )]
+    #[schema(value_type = Option<Vec<String>>)]
     pub vulnerabilities: Option<String>,
 }
 
@@ -375,9 +376,10 @@ pub struct ChannelCoverageSchema {
     pub channel: String,
     pub releases_ingested: i64,
     pub releases_pending: i64,
-    /// Of `releases_pending`, the pre-2020 nix-env-era releases. Scheduled runs
-    /// never retry these; only `nxv index --backfill-evals` ingests them.
-    pub releases_pending_eval_era: i64,
+    /// Unsettled releases (pending or failed) from the pre-2020 nix-env era.
+    /// Scheduled runs never reach these; only `nxv index --backfill-evals`
+    /// ingests them.
+    pub releases_needing_eval: i64,
     pub releases_failed: i64,
     pub releases_skipped: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -424,7 +426,7 @@ impl From<IndexStats> for IndexStatsSchema {
                     channel: c.channel,
                     releases_ingested: c.releases_ingested,
                     releases_pending: c.releases_pending,
-                    releases_pending_eval_era: c.releases_pending_eval_era,
+                    releases_needing_eval: c.releases_needing_eval,
                     releases_failed: c.releases_failed,
                     releases_skipped: c.releases_skipped,
                     newest_release: c.newest_release,

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -273,8 +273,17 @@ pub struct VersionHistorySchema {
     pub first_seen: DateTime<Utc>,
     /// Last time this version was seen.
     pub last_seen: DateTime<Utc>,
-    /// Whether this version has known vulnerabilities.
+    /// Whether nixpkgs reports a known advisory for this software version.
+    ///
+    /// Scoped by package name and version, so every attribute packaging the same
+    /// build agrees (`emacs` and `emacs28` at 28.2 are both flagged). This is not
+    /// the same question as "will nix refuse to build this attribute at this
+    /// revision" — for that, read `known_vulnerabilities` off the version itself
+    /// via `/packages/{attr}/versions/{version}/first`.
     pub is_insecure: bool,
+    /// The advisory text as a JSON array, omitted when the version is clean.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vulnerabilities: Option<String>,
 }
 
 /// Package version info (re-export with ToSchema).

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -369,6 +369,9 @@ pub struct ChannelCoverageSchema {
     pub channel: String,
     pub releases_ingested: i64,
     pub releases_pending: i64,
+    /// Of `releases_pending`, the pre-2020 nix-env-era releases. Scheduled runs
+    /// never retry these; only `nxv index --backfill-evals` ingests them.
+    pub releases_pending_eval_era: i64,
     pub releases_failed: i64,
     pub releases_skipped: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -415,6 +418,7 @@ impl From<IndexStats> for IndexStatsSchema {
                     channel: c.channel,
                     releases_ingested: c.releases_ingested,
                     releases_pending: c.releases_pending,
+                    releases_pending_eval_era: c.releases_pending_eval_era,
                     releases_failed: c.releases_failed,
                     releases_skipped: c.releases_skipped,
                     newest_release: c.newest_release,

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -282,7 +282,13 @@ pub struct VersionHistorySchema {
     /// via `/packages/{attr}/versions/{version}/first`.
     pub is_insecure: bool,
     /// The advisory text as a JSON array, omitted when the version is clean.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    ///
+    /// Stored as a JSON-array string; serialized as a real array, matching
+    /// `known_vulnerabilities` on the package endpoints.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::db::json_array::serialize_opt"
+    )]
     pub vulnerabilities: Option<String>,
 }
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -195,9 +195,17 @@ nxv history python311 --format json
   "version": "3.11.4",
   "first_seen": "2023-06-15T00:00:00+00:00",
   "last_seen": "2023-12-01T00:00:00+00:00",
-  "is_insecure": false
+  "is_insecure": false,
+  "known_vulnerabilities": null
 }
 ```
+
+`is_insecure` means nixpkgs reports a known advisory for that software version,
+resolved by package **name** so every attribute packaging the same build agrees
+(`emacs` and `emacs28` at 28.2 are both flagged). It does not tell you whether
+nix will refuse to build a specific attribute at a specific revision — for that,
+name the version (`nxv history <pkg> <version>`) and read its own
+`known_vulnerabilities`.
 
 Note the field names differ from search (`first_seen`/`last_seen`, not `first_commit_date`/`last_commit_date`), and there are no commit hashes. Adding `--full`, or naming a version (`nxv history python311 3.11.4`), switches the output to the full search row shape documented above — use one of those when you need a commit hash to feed to `nix shell`. Like the compact timeline, bare `--full` resolves the package by its exact installable `attribute_path`.
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4641,3 +4641,80 @@ fn test_checked_in_skill_copies_match_template() {
         );
     }
 }
+
+/// Regression: the history endpoint serializes the advisory as a JSON array,
+/// and the CLI's mirror struct must decode that. When it declared a bare
+/// `Option<String>`, `nxv history` against a remote failed outright for every
+/// package carrying an advisory — while clean packages kept working, which made
+/// it look intermittent.
+#[test]
+fn test_remote_history_decodes_advisory_array() {
+    let mut server = mockito::Server::new();
+
+    let response = serde_json::json!({
+        "data": [
+            {
+                "version": "28.2",
+                "first_seen": "2022-09-14T04:24:08Z",
+                "last_seen": "2023-12-11T23:24:52Z",
+                "is_insecure": true,
+                "vulnerabilities": ["CVE-2024-53920", "CVE-2025-1244"]
+            },
+            {
+                "version": "30.2",
+                "first_seen": "2025-08-15T12:53:23Z",
+                "last_seen": "2026-08-10T14:30:10Z",
+                "is_insecure": false
+            }
+        ]
+    });
+
+    let _mock = server
+        .mock("GET", "/api/v1/packages/emacs/history")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(response.to_string())
+        .create();
+
+    nxv()
+        .args(["history", "emacs", "--format", "plain"])
+        .env("NXV_API_URL", server.url())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "28.2\t2022-09-14\t2023-12-11\tyes",
+        ))
+        .stdout(predicate::str::contains("30.2\t2025-08-15\t2026-08-10\tno"));
+}
+
+/// A server predating the advisory field sends `is_insecure` with no text. The
+/// flag must survive, and the table must not print an advisory heading with
+/// nothing under it.
+#[test]
+fn test_remote_history_accepts_flag_without_advisory_text() {
+    let mut server = mockito::Server::new();
+
+    let response = serde_json::json!({
+        "data": [{
+            "version": "1.0.0",
+            "first_seen": "2024-01-01T00:00:00Z",
+            "last_seen": "2024-06-01T00:00:00Z",
+            "is_insecure": true
+        }]
+    });
+
+    let _mock = server
+        .mock("GET", "/api/v1/packages/legacy-pkg/history")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(response.to_string())
+        .create();
+
+    nxv()
+        .args(["history", "legacy-pkg"])
+        .env("NXV_API_URL", server.url())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1.0.0 ⚠"))
+        .stdout(predicate::str::contains("Known vulnerabilities").not());
+}

--- a/website/advanced/indexer-cli.md
+++ b/website/advanced/indexer-cli.md
@@ -38,7 +38,7 @@ before the subcommand.
 | `--strict`             | `false`     | Treat monitor warnings (count floors, sentinels, head lag) as fatal             |
 | `--report <PATH>`      | -           | Write the end-of-run coverage report as JSON to this path                       |
 | `--retry-failed`       | `false`     | Retry releases that were parked as failed/skipped                               |
-| `--backfill-evals`     | `false`     | Also ingest the pre-2020 era via `nix-env` over `nixexprs.tar.xz` (needs `nix`) |
+| `--backfill-evals`     | `false`     | Also ingest the pre-2020-03-27 era via `nix-env` over `nixexprs.tar.xz`, and allow a `nix-env` fallback for any later release missing `packages.json.br` (needs `nix`) |
 | `--head-eval`          | `false`     | Evaluate nixpkgs master HEAD when channel observations lag (needs `nix`)        |
 | `--full`               | `false`     | Re-queue every known release instead of only new ones                           |
 | `--max-releases <N>`   | -           | Limit the number of releases ingested this run (for testing)                    |

--- a/website/advanced/indexer.md
+++ b/website/advanced/indexer.md
@@ -23,9 +23,13 @@ nixpkgs checkout. It ingests channel-release snapshots from releases.nixos.org:
   decompressed) that enumerates all ~144k attributes — including nested package
   sets (`python3Packages.*`, `haskellPackages.*`, `nodePackages.*`, ...) — with
   versions and metadata. No Nix evaluation is needed for this era.
-- **2016-09 → 2020-06**: releases predate `packages.json`. Opt in with
-  `--backfill-evals` to evaluate each release's `nixexprs.tar.xz` with `nix-env`
-  (the only path that requires `nix`).
+- **2020-03-27 → 2020-06**: a mixed window. `packages.json.br` first appears on
+  2020-03-27, but not every release in that window has one, so the source is
+  settled by probing each release rather than by its date. Ordinary runs cover
+  this window — a probe costs one request and no evaluation.
+- **2016-09 → 2020-03-27**: releases predate `packages.json` entirely. Opt in
+  with `--backfill-evals` to evaluate each release's `nixexprs.tar.xz` with
+  `nix-env` (the only path that requires `nix`).
 
 Every stored commit is a real Hydra-built channel commit: the
 `(attribute, version)` pair was verifiably present at both ends of its range.
@@ -85,6 +89,21 @@ nxv index --backfill-evals
 
 Interrupting with Ctrl+C is safe: each release commits atomically together with
 its row in the `releases` ledger, so unfinished releases simply stay `pending`.
+
+### Reading the Pending Count
+
+`nxv stats` and the end-of-run report split `pending` releases into the ones a
+run will pick up and the ones it structurally cannot:
+
+```
+nixos-unstable-small: 4017 ingested, 3099 pending (2902 pre-2020, needs --backfill-evals)
+```
+
+The pre-2020 portion is not a backlog and will not shrink on its own — no
+scheduled run includes it, and `--retry-failed` does not reach it either. It is
+a standing choice to trade a decade of coarse historical coverage against hours
+of `nix-env` evaluation. Everything outside that portion is genuine queued work
+the next run will attempt.
 
 ### Resuming and Incremental Updates
 

--- a/website/advanced/indexer.md
+++ b/website/advanced/indexer.md
@@ -290,7 +290,26 @@ the index or refuses to emit a slow artifact.
 
 `is_insecure` is not stored as a column — it's derived at query time from
 `known_vulnerabilities` (a non-empty JSON array means the package is flagged
-insecure). The HTTP API's version-history endpoint surfaces this as a boolean.
+insecure). The HTTP API's version-history endpoint surfaces this as a boolean
+alongside the advisory text in `vulnerabilities`.
+
+Version history resolves the advisory by **package name and version**, not by
+attribute path and not by version string alone:
+
+- Version string alone would be wrong in the obvious direction — `nxv` 0.7.1 has
+  nothing to do with `zeronet` 0.7.1.
+- Attribute path alone would be wrong in the subtle direction. Each
+  `(attribute_path, version)` row keeps the `known_vulnerabilities` of its newest
+  observation and is never backfilled, so an advisory added after an attribute
+  stopped shipping a version never reaches that row. `emacs` 28.2 retired in
+  2023 holding no advisory while `emacs28` 28.2 carried the identical build until
+  2025 and picked up CVE-2024-53920.
+
+Name scoping answers "does this software version have a known advisory". That is
+a broader question than "will nix refuse to build this attribute at this
+revision" — for the latter, read `known_vulnerabilities` off the version itself
+(`/packages/{attr}/versions/{version}/first`), which is what the copy-to-clipboard
+commands use to decide on `NIXPKGS_ALLOW_INSECURE`.
 
 ## Troubleshooting
 

--- a/website/advanced/indexer.md
+++ b/website/advanced/indexer.md
@@ -23,9 +23,9 @@ nixpkgs checkout. It ingests channel-release snapshots from releases.nixos.org:
   decompressed) that enumerates all ~144k attributes — including nested package
   sets (`python3Packages.*`, `haskellPackages.*`, `nodePackages.*`, ...) — with
   versions and metadata. No Nix evaluation is needed for this era.
-- **2020-03-27 → 2020-06**: a mixed window. `packages.json.br` first appears on
-  2020-03-27, but not every release in that window has one, so the source is
-  settled by probing each release rather than by its date. Ordinary runs cover
+- **2020-03-27 → 2020-06**: `packages.json.br` first appears on 2020-03-27, but
+  the boundary falls mid-release-name (`20.09pre`), so the source is settled by
+  probing each release rather than inferred from its date. Ordinary runs cover
   this window — a probe costs one request and no evaluation.
 - **2016-09 → 2020-03-27**: releases predate `packages.json` entirely. Opt in
   with `--backfill-evals` to evaluate each release's `nixexprs.tar.xz` with
@@ -96,14 +96,16 @@ its row in the `releases` ledger, so unfinished releases simply stay `pending`.
 run will pick up and the ones it structurally cannot:
 
 ```
-nixos-unstable-small: 4017 ingested, 3099 pending (2902 pre-2020, needs --backfill-evals)
+nixos-unstable-small: 4017 ingested, 3099 pending, 1 skipped (newest: …); 2902 pre-2020, needs --backfill-evals
+nixpkgs-unstable: 4191 ingested, 22 failed, 1 skipped (newest: …); 22 pre-2020, needs --backfill-evals
 ```
 
-The pre-2020 portion is not a backlog and will not shrink on its own — no
-scheduled run includes it, and `--retry-failed` does not reach it either. It is
-a standing choice to trade a decade of coarse historical coverage against hours
-of `nix-env` evaluation. Everything outside that portion is genuine queued work
-the next run will attempt.
+The trailing clause counts pending **and** failed releases from the nix-env era.
+Neither is a backlog and neither shrinks on its own — no scheduled run includes
+them, and `--retry-failed` alone does not reach them (it takes
+`--retry-failed --backfill-evals`). It is a standing choice to trade a decade of
+coarse historical coverage against hours of `nix-env` evaluation. Everything
+outside that clause is genuine queued work the next run will attempt.
 
 ### Resuming and Incremental Updates
 

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -210,11 +210,19 @@ curl "http://localhost:8080/api/v1/packages/python311/history"
       "version": "3.11.3",
       "first_seen": "2023-04-05T00:00:00Z",
       "last_seen": "2023-06-14T00:00:00Z",
-      "is_insecure": false
+      "is_insecure": true,
+      "vulnerabilities": "[\"CVE-2023-24329\"]"
     }
   ]
 }
 ```
+
+`is_insecure` means nixpkgs reports a known advisory for that **software
+version**, resolved by package name so every attribute packaging the same build
+agrees. `vulnerabilities` carries the advisory text and is omitted when the
+version is clean. Neither field tells you whether nix will refuse to build a
+given attribute at a given revision — for that, read `known_vulnerabilities` from
+`/packages/{attr}/versions/{version}/first`.
 
 ### Index Statistics
 


### PR DESCRIPTION
## The bug

The version-history drawer rendered a red **insecure** badge on `nxv` 0.7.1. `nxv` carries no advisory on any version — all six rows have `known_vulnerabilities = NULL`. The badge came from `zeronet` 0.7.1, an unrelated package that happens to share the version string.

`get_version_history` computed `is_insecure` with an `EXISTS` subquery joined **only** on the version string, with no attribute or name constraint:

```sql
EXISTS (SELECT 1 FROM package_versions iv
        WHERE iv.version = pv.version          -- no attribute_path, no name
          AND iv.known_vulnerabilities IS NOT NULL ...)
```

On the live index that falsely flagged **125,618 of 1,788,120 rows (7%)** across 72,667 attribute paths, while only 527 attribute paths are genuinely insecure anywhere. The pre-v4 grouped path had the same defect via a global `insecure_versions` CTE.

Only version history was affected. Search results and `nxv history nxv 0.7.1` read the row's own column and were correct — so the same package showed clean in one view and red in another. The frontend also fabricated `insecure: ['insecure']` from the bad flag, injecting `NIXPKGS_ALLOW_INSECURE=1 --impure` into the copied flake command for 125k clean packages.

## Why not just read the row's own column

That looks correct — `UNIQUE(attribute_path, version)` guarantees one row per pair — but it **silently drops 99 genuine advisories** across 83 attribute paths. `known_vulnerabilities` follows the newest observation of each row and is never backfilled, so an advisory added after an attribute stopped shipping a version never lands:

```
emacs      28.2  NULL   (last seen 2023-12-11)
emacs28    28.2  ["CVE-2024-53920 CVE-2025-1244, please use newer versions such as emacs30"]
```

184 of the 189 signal-loss pairs have exactly that shape. All 99 recovered rows were checked by hand — every one is the same upstream software at the same version (`docker`/`docker_24`, `electron`/`electron_18`, `netbox`/`netbox_4_4`, `pnpm`/`pnpm_10`, `libressl`/`netcat`, the `python*Packages` fan-out). Zero name-collision false positives.

So the lookup is **scoped to `(name, version)`**: keeps all 99, removes 125,519 of 125,618 false positives, uses the existing `idx_packages_name_version`, and needs no schema change or reindex.

## Changes

- **`src/db/queries.rs`** — advisory scoped by `(name, version)` in both query paths; the query returns the advisory text, so `VersionHistoryEntry` is a struct with `is_insecure()` derived and one predicate shared with `PackageVersion::is_insecure`.
- **`src/server/`** — additive `vulnerabilities` field on the history response; `is_insecure` unchanged for older clients.
- **`frontend/app.js`** — badge carries the real advisory as a tooltip; the copy command reads the version's own `known_vulnerabilities` (and its `last_commit_hash`, per #21) instead of the fabricated flag.
- **`src/index/`** — the work-list filter excluded every date-guessed `nix_env` release, upstream of the fetch-time probe that would reclassify it, stranding 197 releases that have `packages.json.br` upstream. It now excludes only pre-2020-03-27 releases. A probe miss without `--backfill-evals` parks the release as `skipped` rather than burning the 5-attempt ladder over two days for a permanent condition.
- **`nxv stats` / run report** — the pending count is split by reachability instead of a bare number that reads as a backlog:

  ```
  nixos-unstable-small: 4017 ingested, 3099 pending, 1 skipped (newest: …); 2902 pre-2020, needs --backfill-evals
  nixpkgs-unstable: 4191 ingested, 22 failed, 1 skipped (newest: …); 22 pre-2020, needs --backfill-evals
  ```

## Verification

`nix flake check` passes (7/7). 429 unit + 115 integration tests, clippy clean with and without `--features indexer`.

Against the live 2.1 GB index and a running server:

| Check | Result |
|---|---|
| `nxv history nxv` | 0.7.1 insecure: **no** |
| `nxv history emacs` | 28.2 insecure: **yes**, with CVE text |
| `nxv history zeronet` | 0.7.1 insecure: **yes** |
| Drawer, `nxv` | 0 danger chips |
| Drawer, `emacs` | 28.2 badged, tooltip shows the CVEs |
| Copy, `emacs` 28.2 | `nix shell nixpkgs/e97b3e41…#emacs` — no prefix, matches what nix does at that rev |
| Copy, `zeronet` 0.7.1 | `NIXPKGS_ALLOW_INSECURE=1 nix shell --impure …` |

New regression tests cover the reported bug (`nxv`/`zeronet`), the signal that must survive (`emacs`/`emacs28`), empty-advisory spellings, the pre-v4 path, the API scope, the remote round-trip, and the `needs_eval` boundaries.

## Review

Two independent agent reviews found 11 issues, all fixed in `c15981c` and `4034c07` and re-verified:

- **A `nxv history` outage against any `nxv serve`** — serializing `vulnerabilities` as an array broke the CLI's mirror struct, which still declared `Option<String>`. Every package with an advisory failed to decode; clean packages kept working, so it looked intermittent. There was no test on the remote history path at all; there are two now.
- **A 19s-per-call regression** on the pre-v4 grouped path (measured on the live index) — the rewritten CTE lost the partial vulnerability index. Restricting it to the requested attribute's names brings it to 29ms.
- Plus: an empty red "Known vulnerabilities" heading, `vulnerabilities` emitting a JSON string where every sibling field emits an array (`jq '.known_vulnerabilities[]'` failed on one form and worked on the other), a `first_commit_hash` flake ref, non-deterministic tie-breaking, a `'None'` sentinel disagreement between the server and the frontend, a guaranteed spurious mass-death warning when backfilled 2020 snapshots meet today's, `nxv stats` mislabeling 22 permanently-stuck rows, and four inaccurate doc claims.

## ⚠️ Deploy note

The first `publish-index.yml` run after this merges sees a **~199-release work list** instead of the usual ~2. That crosses `FTS_BULK_THRESHOLD` (`src/index/mod.rs:180`), so the run drops and rebuilds the FTS index **and** the covering search index on the 2.1 GB / 1.79M-row production index — a path the publish job has never exercised. A timeout or OOM there publishes nothing that window and makes the next run pay a recovery rebuild.

Recommend draining it out-of-band first, so that rebuild stays off the scheduled job:

```bash
nxv index --channel nixos-unstable-small --until 2020-06-01
```

If you throttle with `--max-releases` instead, note `worklist.truncate` runs *after* the filter, so the budget goes to 2020 releases before today's.

Fixes the badge reported on nxv 0.7.1.
